### PR TITLE
Update library links.

### DIFF
--- a/_data/library-infrastructure-packages.yml
+++ b/_data/library-infrastructure-packages.yml
@@ -59,6 +59,7 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
+  full_url: "https://github.com/gruntwork-io/package-lambda"
   description: |
     Deploy and manage Lambda functions with Terraform. Automatically upload source code, configure environment variables,
     create an IAM Role, associate with a VPC. enable versioning/aliasing. Also supports scheduled Lambdas and dead letter
@@ -146,6 +147,7 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
+  full_url: "https://github.com/gruntwork-io/package-static-assets"
   description: |
     Deploy your static content and static websites on S3, optionally with a CloudFront distribution in front of it as a
     CDN. Includes bucket versioning, access logging, cache settings, Route 53 DNS entries, and TLS certs.
@@ -158,6 +160,7 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
+  full_url: "https://github.com/gruntwork-io/package-mongodb"
   description: |
     Deploy a MongoDB cluster, including replica sets, sharding, an automated bootstrapping process, backup, recovery,
     and OS optimizations.
@@ -170,6 +173,7 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
+  full_url: "https://github.com/gruntwork-io/package-kafka"
   description: |
     Deploy a cluster of Apache brokers that can automatically bootstrap themselves. Includes support for automatically
     discovering a ZooKeeper cluster, EBS Volumes for better log performance, automated zero-downtime rolling deployment,
@@ -183,6 +187,7 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
+  full_url: "https://github.com/gruntwork-io/package-zookeeper"
   description: |
     Deploy an Apache ZooKeeper cluster that can automatically bootstrap itself. Includes support for Exhibitor as a
     process supervisor and management UI for ZooKeeper, static IP addresses (ENIs), EBS Volumes for better transaction
@@ -199,6 +204,7 @@
       image: icon-bash.png
     - title: Go
       image: icon-go.png
+  full_url: "https://github.com/gruntwork-io/package-openvpn"
   description: |
     Deploy an OpenVPN server and manage user accounts using IAM groups. Includes automatic install and configuration of
     a high-availability OpenVPN server, public key infrastructure (PKI), data backup, IAM policies, security groups, and
@@ -210,6 +216,7 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
+  full_url: "https://github.com/gruntwork-io/package-messaging"
   description: |
     Create SQS queues with support for FIFO, message retention, message delays, content-based deduplication,
     dead-letter queues, and IP-based access controls. Create SNS topics with configurable IAM and delivery policies.

--- a/_data/library-terraform-modules.yml
+++ b/_data/library-terraform-modules.yml
@@ -8,9 +8,9 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
-  aws_url: github.com/hashicorp/terraform-aws-consul
-  gcp_url: github.com/hashicorp/terraform-google-consul
-  azure_url: github.com/hashicorp/terraform-azurerm-consul
+  aws_url: "https://github.com/hashicorp/terraform-aws-consul"
+  gcp_url: "https://github.com/hashicorp/terraform-google-consul"
+  azure_url: "https://github.com/hashicorp/terraform-azurerm-consul"
   description: |
     Deploy a best-practices HashiCorp Consul cluster. Includes support for automatic bootstrapping, configuring dnsmasq
     to use Consul as a DNS server, access to the Consul UI, and automatic recovery of failed servers.
@@ -25,9 +25,9 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
-  aws_url: github.com/hashicorp/terraform-aws-nomad
-  gcp_url: github.com/hashicorp/terraform-google-nomad
-  azure_url: github.com/hashicorp/terraform-azurerm-nomad
+  aws_url: "https://github.com/hashicorp/terraform-aws-nomad"
+  gcp_url: "https://github.com/hashicorp/terraform-google-nomad"
+  azure_url: "https://github.com/hashicorp/terraform-azurerm-nomad"
   description: |
     Deploy a HashiCorp Nomad cluster. Includes support for automatic bootstrapping and automatic recovery of failed
     servers.
@@ -42,9 +42,9 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
-  aws_url: github.com/hashicorp/terraform-aws-vault
-  gcp_url: github.com/hashicorp/terraform-google-vault
-  azure_url: github.com/hashicorp/terraform-azurerm-vault
+  aws_url: "https://github.com/hashicorp/terraform-aws-vault"
+  gcp_url: "https://github.com/hashicorp/terraform-google-vault"
+  azure_url: "https://github.com/hashicorp/terraform-azurerm-vault"
   description: |
     Deploy a HashiCorp Vault cluster. Includes support for automatically discovering Consul clusters as a high availability
     backend, using S3 as a storage backend, creating self-signed TLS certificates, updating the OS certificate store,

--- a/_data/library-tools.yml
+++ b/_data/library-tools.yml
@@ -4,6 +4,7 @@
   icons:
     - title: Go
       image: icon-go.png
+  full_url: "https://github.com/gruntwork-io/gruntkms"
   description: |
     A command-line tool that makes it easy to encrypt and decrypt data using Amazon Key Management Service (KMS).
 
@@ -15,6 +16,8 @@
       image: icon-terraform.png
     - title: Go
       image: icon-go.png
+  docs_url: "https://github.com/gruntwork-io/module-security-public/tree/master/modules/ssh-iam"
+  full_url: "https://github.com/gruntwork-io/module-security/tree/master/modules/ssh-iam"
   description: |
     A tool that allows you to manage SSH access to EC2 Instances using AWS IAM. Developers can use their personal SSH
     keys to log in.
@@ -25,6 +28,8 @@
   icons:
     - title: Bash
       image: icon-bash.png
+  docs_url: "https://github.com/gruntwork-io/module-security-public/tree/master/modules/aws-auth"
+  full_url: "https://github.com/gruntwork-io/module-security/tree/master/modules/aws-auth"
   description: |
     A small wrapper script for the AWS CLI that makes it much easier to authenticate to AWS with Multi-factor
     authentication (MFA), or when you want to assume an IAM Role in another AWS account.
@@ -33,5 +38,6 @@
   icons:
     - title: Bash
       image: icon-bash.png
+  public_url: "https://github.com/gruntwork-io/gruntwork-installer"
   description: |
-    A simple, lightweight package manaer for installing Gruntwork modules.
+    A simple, lightweight package manager for installing Gruntwork modules.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -24,6 +24,8 @@ function serialize(a,b){"object"!=typeof b?b={hash:!!b}:void 0===b.hash&&(b.hash
 /* Repo modal link handler */
 $("#modalPublicRepo").on("show.bs.modal",function(r){var e=$(r.relatedTarget).data("public-repo"),a=$(r.relatedTarget).data("private-repo");$(r.currentTarget).find(".public-repo-link").attr("href",e),$(r.currentTarget).find(".private-repo-link").attr("href",a)});
 
+$("#modalPrivateRepo").on("show.bs.modal",function(r){var a=$(r.relatedTarget).data("private-repo");$(r.currentTarget).find(".private-repo-link").attr("href",a)});
+
 /* Dashed lines on homepage */
 var c=document.getElementById("dottedLine");if(c){var ctx=c.getContext("2d");ctx.beginPath(),ctx.setLineDash([10,10]),ctx.moveTo(0,0),ctx.lineTo(0,200),ctx.strokeStyle="#fff",ctx.lineWidth=1.5,ctx.stroke()}
 

--- a/pages/infrastructure-as-code-library/_library.html
+++ b/pages/infrastructure-as-code-library/_library.html
@@ -10,6 +10,8 @@
             <p>
               {% if package.docs_url %}
                 <a href="#" data-toggle="modal" data-target="#modalPublicRepo" data-public-repo="{{ package.docs_url }}" data-private-repo="{{ package.full_url }}">View Public Docs</a>
+              {% elsif package.full_url %}
+                <a href="#" data-toggle="modal" data-target="#modalPrivateRepo" data-private-repo="{{ package.full_url }}">View Full Repo</a> <small style="color: #757575;">(subscribers only)</small>
               {% endif %}
             </p>
           </div>
@@ -51,6 +53,10 @@
           <p>
             {% if package.docs_url %}
             <a href="#" data-toggle="modal" data-target="#modalPublicRepo" data-public-repo="{{ package.docs_url }}" data-private-repo="{{ package.full_url }}">View Public Docs</a>
+            {% elsif package.full_url %}
+            <a href="#" data-toggle="modal" data-target="#modalPrivateRepo" data-private-repo="{{ package.full_url }}">View Tool</a> <small style="color: #757575;">(subscribers only)</small>
+            {% elsif package.public_url %}
+            <a href="{{ package.public_url }}">View Tool</a>
             {% else %}
             <span style="color: #676767;">View Public Docs</span> (coming soon)
             {% endif %}

--- a/pages/infrastructure-as-code-library/_modal.html
+++ b/pages/infrastructure-as-code-library/_modal.html
@@ -21,3 +21,26 @@
     </div>
   </div>
 </div>
+
+<div class="modal fade" id="modalPrivateRepo" tabindex="-1" role="dialog" aria-labelledby="modalPrivateRepoTitle">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header text-center">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><i class="fa fa-fw fa-close"></i></button>
+      </div>
+      <div class="modal-body text-center">
+        <h4 class="h2 modal-title margin-top-none" id="modalPrivateRepoTitle">You're about to view a private repo.</h4>
+        <p>
+          Private repos are available to <a href="/pricing">Gruntwork Library subscribers</a>.
+          <br>
+          We create public docs versions of some of our repos, but not yet for this one.
+          <br>
+          Note that if you're not a subscriber, you'll see a 404 if you proceed.
+        </p>
+        <p>
+          <a class="btn btn-info private-repo-link" href="">I'm a subscriber. Proceed!</a>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This commit:
- Adds links to all infra packages, even ones where we don't have a docs
repo. If no docs repo exists, a new slightly different modal is used,
and a small label is next to the link that says "(subscribers only")
- Fixed links to the open source repos. Previously, these forgot the
"https://"

These changes were motivated by the desire to make it easier for
subscribers to browse everything in the library. In the future, I'd like
to add a small checkbox that allows users to stop the modal on every
click.