### PR TITLE
Clarify that billing frequency is monthly.

### DIFF
--- a/pages/pricing/_infrastructure-as-code-library.html
+++ b/pages/pricing/_infrastructure-as-code-library.html
@@ -39,6 +39,10 @@
           <td>Annual</td>
         </tr>
         <tr>
+          <th>Billing frequency</th>
+          <td>Monthly</td>
+        </tr>
+        <tr>
           <th>Price</th>
           <td><strong>$500 / month</strong></td>
         </tr>

--- a/pages/pricing/_support.html
+++ b/pages/pricing/_support.html
@@ -87,9 +87,15 @@
             {% endfor %}
           </tr>
           <tr>
-            <th><i class="fa fa-info-circle info-icon" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="The minimum sign-up period."></i> Subscription Period</th>
+            <th><i class="fa fa-info-circle info-icon" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="The minimum sign-up period. Note that billing may be done monthly."></i> Subscription Period</th>
             {% for plan in site.data.support-plans %}
             <td>Annual</td>
+            {% endfor %}
+          </tr>
+          <tr>
+            <th><i class="fa fa-info-circle info-icon" aria-hidden="true" data-toggle="tooltip" data-placement="top" title="How often we bill for this service."></i> Billing Frequency</th>
+            {% for plan in site.data.support-plans %}
+            <td>Monthly</td>
             {% endfor %}
           </tr>
           <tr>


### PR DESCRIPTION
In Slack we discussed that:

> We need to clarify that while a customer commits to 12 months we only charge them on a monthly basis. A number of potential customers have emailed and asked if they could pay monthly for the IAC Library and support. This confused us because we already list the price as monthly. But then we noticed something: we say that the "Subscription Period" is "annual."

> We think people interpret it as "you must pay for the whole year up-front." I bet that has scared a number of potential customers off. It's prob a small tweak, but ... we should make it clear we bill monthly, but that the contract is for 1 year.

Rather than engage the design team to tackle this, I made this simple tweak.