### PR TITLE
Update Ref Arch to say encryption instead of TLS

### DIFF
--- a/pages/pricing/_reference-architecture.html
+++ b/pages/pricing/_reference-architecture.html
@@ -39,7 +39,7 @@
         <td class="text-right">+$2,500</td>
       </tr>
       <tr>
-        <th>End-to-end TLS Setup</th>
+        <th>End-to-end encryption setup</th>
         <td class="text-right">+$2,000</td>
       </tr>
       <tr>


### PR DESCRIPTION
End-to-end encryption applies to data in transit and at rest, so it’s not just TLS.