### PR TITLE
IE 10/11 Fix for Flex Columns Direction - Add width 100%

### DIFF
--- a/assets/css/app.less
+++ b/assets/css/app.less
@@ -1818,3 +1818,8 @@ input[type="radio"] .styled:checked + label::after {
     width: 50px;
     padding: 5px;
 }
+
+/* Flex Direction - IE Fix */
+.row-library .row-equalize-col-height > div[class*='col-'] > .panel > .panel-body{
+    width: 100%;
+}


### PR DESCRIPTION
This should fix the overflow issue on IE for panels.