### PR TITLE
Add mention of extensive contract review fee.

### DIFF
--- a/pages/pricing/_other-services.html
+++ b/pages/pricing/_other-services.html
@@ -13,5 +13,12 @@
         </tr>
       </tbody>
     </table>
+
+    <h3>Miscellaneous Fees</h3>
+    <p><strong>Gruntwork has no hidden fees.</strong> The one fee we apply is a one-time charge of $4,000 for any significant requested
+    changes on our contract to cover the cost we pay to our lawyers to review this. Minor contract change requests are
+    done inhouse and cost nothing.</p>
   </div>
 </div>
+
+

--- a/pages/pricing/_other-services.html
+++ b/pages/pricing/_other-services.html
@@ -14,10 +14,9 @@
       </tbody>
     </table>
 
-    <h3>Miscellaneous Fees</h3>
-    <p><strong>Gruntwork has no hidden fees.</strong> The one fee we apply is a one-time charge of $4,000 for any significant requested
-    changes on our contract to cover the cost we pay to our lawyers to review this. Minor contract change requests are
-    done inhouse and cost nothing.</p>
+    <h2 style="padding-top: 27px;">Legal Fee</h2>
+    <p>The pricing on this page comes with our standard contract. If you request significant changes on that contract, we
+      add a fee of $5,000 to pay our lawyers. Minor contract changes are included at no additional cost.</p>
   </div>
 </div>
 

--- a/pages/pricing/_other-services.html
+++ b/pages/pricing/_other-services.html
@@ -15,8 +15,11 @@
     </table>
 
     <h2 style="padding-top: 27px;">Legal Fee</h2>
-    <p>The pricing on this page comes with our standard contract. If you request significant changes on that contract, we
-      add a fee of $5,000 to pay our lawyers. Minor contract changes are included at no additional cost.</p>
+    <p>The pricing on this page comes with our standard contract. We have made every effort to write a fair contract that
+      includes reasonable warranties, indemnities by Gruntwork, clear provisions around intellectual property, and more.
+      If you request significant changes on that contract, we unfortunately must add a fee of $5,000 to cover the cost
+      of our lawyers.</p>
+    <p>Minor contract changes are included at no additional cost.</p>
   </div>
 </div>
 


### PR DESCRIPTION
Here's how this renders on the [pricing page](https://gruntwork.io/pricing/):

<img width="935" alt="image" src="https://user-images.githubusercontent.com/4295964/41794559-9da58ff4-7614-11e8-9c64-5b0ffd47159e.png">
