### PR TITLE
[DO NOT MERGE] Ugly hack to be able to produce ToS in Word Doc format

### DIFF
--- a/_data/terms-of-service.yml
+++ b/_data/terms-of-service.yml
@@ -1,5 +1,5 @@
 - category_name:
-  category_id: general
+  category_id: tos
   category_description:
   items:
     - title:
@@ -10,6 +10,10 @@
       plain:  |
         By using Gruntwork products and services, you agree to these Terms of Service.
 
+- category_name: General Terms
+  category_id: general
+  category_description:
+  items:
     - title: 1. Updates to these Terms
       legalese: |
         <p><strong>1.1. Revisions.</strong> We may revise these Terms or any additional terms and conditions which are relevant to a particular Service from time-to-time. We will post the revised terms to our website (currently <a rel="internal" rel="internal" href="/terms/" title="Grountwork Terms of Service">https://gruntwork.io/terms</a>) (the “Website”) with a “last updated” date, and we will attempt to notify you of any material updates to these Terms via email or through the Services. IF YOU CONTINUE TO USE THE SERVICES AFTER THE REVISIONS TAKE EFFECT, YOU AGREE TO BE BOUND BY THE REVISED TERMS. You agree that we shall not be liable to you or to any third party for any modification of the Terms.</p>

--- a/pages/terms/markdown.html
+++ b/pages/terms/markdown.html
@@ -1,0 +1,42 @@
+---
+layout: null
+title: Gruntwork Terms of Service
+modified_date: July 18, 2018
+permalink: /terms/word
+slug: terms
+---
+
+<html>
+<body>
+<div class="main">
+  <div class="section">
+    <div class="container">
+      <div class="row">
+        <div class="col-xs-12 tos-table">
+          <h1>Gruntwork Terms of Service</h1>
+          {% for category in site.data.terms-of-service %}
+          {% if category.category_name != nil %}
+          <h2 id="{{ category.category_id }}">{{ category.category_name }}</h2>
+          {% endif %}
+          {% if category.category_description != nil %}
+          <p>{{ category.category_description }}</p>
+          {% endif %}
+          {% for step in category.items %}
+          <div class="row terms-row">
+            {% if step.title != nil %}
+            <h3 class="col-md-12 col-md-offset-5 col-print-12">{{ step.title }}</h3>
+            {% endif %}
+            <div class="col-md-12 tos-table__legal col-print-12">
+              {{ step.legalese }}
+            </div>
+          </div>
+          {% endfor %}
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
This PR adds a page that can render our Terms of Service in plain HTML with no extra markup or styling. Combined with Pandoc, I was able to use this to produce a reasonable-looking Word Doc version of our Terms of Service as follows:

```
pandoc -s -r html http://localhost:4000/terms/word -o terms.docx
```

The result in `terms.docx` is passable, though it uses the default Word styling, which is a bit ugly, so I cleaned up the styles manually. If there's a way to clean up the styles automatically, then we can add Pandoc to the Docker image and make it part of the Jekyll build process. 

This PR is not meant to be merged directly, but to be used by @sahilakos as a possible starting point.

@sahilakos See if this helps you at all.