### PR TITLE
Fix minor typos

### DIFF
--- a/_data/steps.yml
+++ b/_data/steps.yml
@@ -30,7 +30,7 @@
     <a href="/reference-architecture">Reference Architecture</a> for you. The Reference Architecture is an opinionated,
     battle-tested, end-to-end tech stack that includes just about everything you need, including: server cluster, load
     balancer, database, cache, network topology, monitoring, alerting, CI/CD, secrets management, VPN, and more. We
-    customize the Reference Architecture to your needs, deploy it into into your AWS accounts, and give you 100% of
+    customize the Reference Architecture to your needs, deploy it into your AWS accounts, and give you 100% of
     the code—all in about one day.
 
 - title: Manage everything using Gruntwork Houston
@@ -51,7 +51,7 @@
 
 - title: Get ongoing maintenance and updates
   description: |
-    At Gruntwork, we provide ongoing maintenance and updates for all the code in the IaC Libary and Reference
+    At Gruntwork, we provide ongoing maintenance and updates for all the code in the IaC Library and Reference
     Architecture. We regularly add new modules (see <a href="/custom-module-development">Custom Module Development</a>)
     and every time Terraform comes out with a new version, AWS releases new services, or a security vulnerability is
     announced, we update our code, release a new version, and announce it in our
@@ -70,4 +70,3 @@
     At Gruntwork, our goal is to make it 10x easier for you to understand, build, and deploy software. <a href="/contact">
     Join the Gruntwork community</a> and become your team's hero, using your superpowers to do in hours
     what used to take months. Focus on your product and let us take care of the gruntwork!
-


### PR DESCRIPTION
Remove superfluous "into" and correct spelling of "library".