### PR TITLE
ssh-iam => ssh-grunt

### DIFF
--- a/_data/library-tools.yml
+++ b/_data/library-tools.yml
@@ -24,7 +24,7 @@
   description: |
     A command-line tool that makes it easy to encrypt and decrypt data using Amazon Key Management Service (KMS).
 
-- name: "ssh-iam"
+- name: "ssh-grunt"
   tags:
     - AWS
   icons:
@@ -32,8 +32,8 @@
       image: icon-terraform.png
     - title: Go
       image: icon-go.png
-  docs_url: "https://github.com/gruntwork-io/module-security-public/tree/master/modules/ssh-iam"
-  full_url: "https://github.com/gruntwork-io/module-security/tree/master/modules/ssh-iam"
+  docs_url: "https://github.com/gruntwork-io/module-security-public/tree/master/modules/ssh-grunt"
+  full_url: "https://github.com/gruntwork-io/module-security/tree/master/modules/ssh-grunt"
   description: |
     A tool that allows you to manage SSH access to EC2 Instances using AWS IAM. Developers can use their personal SSH
     keys to log in.


### PR DESCRIPTION
I noticed that we had `ssh-iam` instead of `ssh-grunt`, so updated it.