### PR TITLE
Update careers page

### DIFF
--- a/pages/careers/_human-friendly.html
+++ b/pages/careers/_human-friendly.html
@@ -12,7 +12,9 @@
     <p>In short, <strong>we want to work on interesting problems, with interesting people, while leading interesting lives.</strong></p>
     <h3>How We Work</h3>
     Check out <a href="https://blog.gruntwork.io/how-we-built-a-distributed-self-funded-family-friendly-profitable-startup-93635feb5ace" target="_blank">How
-    we built a distributed, self-funded, family-friendly, profitable startup</a> for all the details on what we do,
+    we built a distributed, self-funded, family-friendly, profitable startup</a> and
+    <a href="https://blog.gruntwork.io/how-we-got-to-1-million-in-annual-recurring-revenue-with-0-in-fundraising-340ed2b4e158" target="_blank">How
+    we got to $1 million in annual recurring revenue with $0 in fundraising</a> for all the details on what we do,
     how we fund it, how we hire, and how we work.
   </div>
 </div>

--- a/pages/careers/_mission.html
+++ b/pages/careers/_mission.html
@@ -2,11 +2,9 @@
   <div class="col-xs-12">
     <h2>Focused on improving humanity's most important invention: Software.</h2>
     <p>
-      See our <a href="/about#our-mission">mission and vision</a> for an overview of what we work on and check out
-      <a href="https://blog.gruntwork.io/how-we-built-a-distributed-self-funded-family-friendly-profitable-startup-93635feb5ace" target="_blank">How
-      we built a distributed, self-funded, family-friendly, profitable startup</a> for a detailed look at how we work.
-      If you're passionate about making software 10x better and believe you can make a significant impact, we'd love to
-      hear from you.
+      Our mission is to make it 10x easier to understand, build, and deploy software (see our
+      <a href="/about#our-mission">mission and vision page</a> for more details). If you're passionate about making
+      software 10x better and believe you can make a significant impact, we'd love to hear from you.
     </p>
   </div>
 </div>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -6,10 +6,12 @@
       supports it, so timing matters. If you're inspired by what you've seen and believe in a little serendipity,
       we would love to hear from you. Here are the positions we're currently looking for:</p>
     <h3>Software Engineer</h3>
-    <h4>What You'll Work On</h4>
+    <h5>What You'll Work On</h5>
     <ul>
       <li>
-        <a href="/houston">Gruntwork Houston</a>: build a fundamentally better DevOps experience.
+        <a href="/houston">Gruntwork Houston</a>: build a fundamentally better DevOps experience. Houston consists of
+        a REST API (Node.js, TypeScript, Lambda, API Gateway), a web-based single-page app (Angular, TypeScript,
+        SASS), and a CLI tool (Go).
       </li>
       <li>
         <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a>: create reusable infrastructure
@@ -25,34 +27,27 @@
         <a href="https://github.com/gruntwork-io/cloud-nuke" target="_blank">cloud-nuke</a>,
         <a href="https://github.com/gruntwork-io/bash-commons" target="_blank">bash-commons</a>, and more.
       </li>
-    </ul>
-    <h4>What You'll Do</h4>
-    <ul>
       <li>
-        <strong>Work on just about every aspect of the Gruntwork stack.</strong> Write Go-based CLI tools, work on
-        Serverless apps in Node.js, write Terraform modules, write Python scripts and Bash scripts, do frontend
-        development, learn the newest tech from AWS, GCP, and Azure, invent new ways of managing infrastructure.
-        We're looking for full-stack engineers who can go deep in any area. We're less concerned with prior experience
-        than we are with curiosity about all areas of the stack and demonstrated ability to learn quickly and go deep
-        when necessary.
-      </li>
-      <li>
-        <strong>Wear many hats.</strong> Gruntwork is a
+        <strong>A little bit of everything.</strong> Gruntwork is a
         <a href="https://blog.gruntwork.io/how-we-built-a-distributed-self-funded-family-friendly-profitable-startup-93635feb5ace" target="_blank">small,
-        distributed, self-funded, profitable startup</a>, so things are changing all the time and we all take on many
-        roles. You should expect to write plenty of code, but, depending on your interests, there will also be ample
+        distributed, self-funded, profitable startup</a>, so things are changing all the time, and we all wear many hats.
+        You should expect to write plenty of code, but, depending on your interests, there will also be ample
         opportunity to write blog posts, give talks, contribute to open source, go to conferences, talk with customers,
         do sales calls, think through financial questions, interview candidates, mentor new hires, design products,
-        come up with marketing ideas, discuss strategy, consider legal questions, get swag for the company, and all the
-        other tasks that are part of working at a small company.
+        come up with marketing ideas, discuss strategy, consider legal questions, and all the other tasks that are
+        part of working at a small company.
       </li>
     </ul>
-    <h4>Your Ideal Background</h4>
+    <h5>Your Ideal Background</h5>
     <ul>
       <li>You know how to write code across the stack ("Dev").</li>
       <li>You have experience running production software ("Ops").</li>
       <li>You have a strong background in software engineering (or are working hard on it!).</li>
       <li>Bonus points for a sense of humor, empathy, and curiosity.</li>
+      <li>
+        Note that we're less concerned with prior experience than we are with curiosity about all areas of the stack
+        and demonstrated ability to learn quickly and go deep when necessary.
+      </li>
     </ul>
     <p>If the above describes you, email us at <a href="mailto:careers@gruntwork.io">careers@gruntwork.io</a>.</p>
   </div>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -1,24 +1,59 @@
 <div class="row row-page-header">
   <div class="col-xs-12">
     <h2>Open Positions</h2>
-    <p>We are always ready to add the next Grunt, but as a 100% bootstrapped company, we only hire when our revenue supports it, so timing matters. If you're inspired by what you've seen and believe in a little serendipity, we would love to hear from you. Here are the positions we're currently looking for:</p>
-    <h3>Senior Full-Stack Engineer</h3>
+    <p>
+      We are always ready to add the next Grunt, but as a 100% bootstrapped company, we only hire when our revenue
+      supports it, so timing matters. If you're inspired by what you've seen and believe in a little serendipity,
+      we would love to hear from you. Here are the positions we're currently looking for:</p>
+    <h3>Software Engineer</h3>
     <h4>What You'll Work On</h4>
     <ul>
-      <li>Engineering a fundamentally better DevOps experience.</li>
+      <li>
+        <a href="/houston">Gruntwork Houston</a>: build a fundamentally better DevOps experience.
+      </li>
+      <li>
+        <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a>: create reusable infrastructure
+        modules for a variety of infrastructure (e.g., Kubernetes, ELK, Consul, Vault, Kafka, MongoDB, InfluxDB,
+        Jenkins, etc), using a variety of tools (e.g., Terraform, Go, Python, Bash, Docker, Packer, etc), across many
+        clouds (e.g., AWS, GCP, and Azure).
+      </li>
+      <li>
+        <a href="https://github.com/gruntwork-io/" target="_blank">Open Source</a>: contribute to our open source
+        projects, including our <a href="/infrastructure-as-code-library/#open-source">open source modules</a>,
+        <a href="https://github.com/gruntwork-io/terragrunt" target="_blank">Terragrunt</a>,
+        <a href="https://github.com/gruntwork-io/terratest" target="_blank">Terratest</a>,
+        <a href="https://github.com/gruntwork-io/cloud-nuke" target="_blank">cloud-nuke</a>,
+        <a href="https://github.com/gruntwork-io/bash-commons" target="_blank">bash-commons</a>, and more.
+      </li>
     </ul>
     <h4>What You'll Do</h4>
     <ul>
-      <li><strong>Work on just about every aspect of the Gruntwork stack.</strong> Write Go-based CLI tools, work on Serverless apps in Node, write Terraform modules, write Python scripts and Bash scripts, do frontend development, learn the newest tech from AWS, invent new ways of managing infrastructure. We're looking for true full-stack engineers who can go deep in any area. We're less concerned with prior experience than we are with demonstrated ability to go deep when necessary.</li>
+      <li>
+        <strong>Work on just about every aspect of the Gruntwork stack.</strong> Write Go-based CLI tools, work on
+        Serverless apps in Node.js, write Terraform modules, write Python scripts and Bash scripts, do frontend
+        development, learn the newest tech from AWS, GCP, and Azure, invent new ways of managing infrastructure.
+        We're looking for full-stack engineers who can go deep in any area. We're less concerned with prior experience
+        than we are with curiosity about all areas of the stack and demonstrated ability to learn quickly and go deep
+        when necessary.
+      </li>
+      <li>
+        <strong>Wear many hats.</strong> Gruntwork is a
+        <a href="https://blog.gruntwork.io/how-we-built-a-distributed-self-funded-family-friendly-profitable-startup-93635feb5ace" target="_blank">small,
+        distributed, self-funded, profitable startup</a>, so things are changing all the time and we all take on many
+        roles. You should expect to write plenty of code, but, depending on your interests, there will also be ample
+        opportunity to write blog posts, give talks, contribute to open source, go to conferences, talk with customers,
+        do sales calls, think through financial questions, interview candidates, mentor new hires, design products,
+        come up with marketing ideas, discuss strategy, consider legal questions, get swag for the company, and all the
+        other tasks that are part of working at a small company.
+      </li>
     </ul>
     <h4>Your Ideal Background</h4>
     <ul>
       <li>You know how to write code across the stack ("Dev").</li>
       <li>You have experience running production software ("Ops").</li>
       <li>You have a strong background in software engineering (or are working hard on it!).</li>
-      <li>Bonus points for a sense of humor, empathy and curiosity.</li>
+      <li>Bonus points for a sense of humor, empathy, and curiosity.</li>
     </ul>
     <p>If the above describes you, email us at <a href="mailto:careers@gruntwork.io">careers@gruntwork.io</a>.</p>
-    <p>For more info, see the blog post we wrote when we were looking for employee #1: <a href="https://blog.gruntwork.io/gruntwork-is-hiring-devops-engineers-c268513a0b5a" target="_blank">Gruntwork is hiring DevOps Engineers</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
1. Update the job title from "Senior Full Stack Engineer," which is both confusing (is "full stack" just Angular + Node.js?), and somewhat discouraging of women, who typically underestimate their skill level and may avoid applying for a "senior" job that they'd actually be qualified for. [See here for context](https://twitter.com/gitbisect/status/1065274662417063941?s=21), and thanks to @Etiene for bringing this up.

1. Update the job description, flushing out more details about what we do and what kind of company we are. 

1. Minor clean up for the rest of the page to reduce duplication.