### PR TITLE
Remove third-party calls to ipinfo.io & re-add missing cookie modal styles

### DIFF
--- a/_data/devops-bootcamp.yml
+++ b/_data/devops-bootcamp.yml
@@ -35,7 +35,7 @@ day_three:
     description: A Gruntwork engineer goes through a checklist of questions with your team to see what work you need to do to be ready for prod.
 
   - title: Architecture deployment
-    description: Deploy your customized <a href="/reference-architecture">Reference Architecture</a> in AWS.
+    description: Deploy your customized <a href="/reference-architecture/">Reference Architecture</a> in AWS.
 
   - title: Architecture walkthrough
     description: Overview of how the architecture works and how to use it.

--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -66,8 +66,8 @@
         <p>
           At Gruntwork, we've already created all the infrastructure you need. In fact, if you hired a team of
           DevOps experts and had them do nothing but work on your infrastructure for several years, you'd most likely
-          end up with code that looks almost exactly like the <a href="/infrastructure-as-code-library">Infrastructure
-          as Code Library</a> and <a href="/reference-architecture">Reference Architecture</a>. But why waste all that
+          end up with code that looks almost exactly like the <a href="/infrastructure-as-code-library/">Infrastructure
+          as Code Library</a> and <a href="/reference-architecture/">Reference Architecture</a>. But why waste all that
           time reinventing the wheel? For a fraction of the cost of a single full-time developer, you can get access to
           a library of proven, battle-tested code, as well as support, updates, and maintenance. You focus on your
           product; let us take care of the grunt work.
@@ -84,7 +84,7 @@
         </p>
         <p>
           At Gruntwork, our focus is on creating reusable, high quality infrastructure code, such as the
-          <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a> and <a href="/reference-architecture">Reference Architecture</a>.
+          <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a> and <a href="/reference-architecture/">Reference Architecture</a>.
           Because all the code is <i>already written</i>, we can get you up and running 10-100x faster than a
           consulting company (typically in just a single day!) on top of code that is thoroughly documented, tested,
           and has been proven in production at dozens of other customer deployments. We do all of this for a price
@@ -111,9 +111,9 @@
         </p>
         <p>
           Our goal at Gruntwork is to allow you to take advantage of the full control and power of an IaaS while still
-          having the ease-of-use of a PaaS. By using the <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a>, you get a
+          having the ease-of-use of a PaaS. By using the <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a>, you get a
           simple API for complicated infrastructure; for example, you can deploy a Kafka cluster or configure CI/CD
-          or even deploy your entire <a href="/reference-architecture">Architecture</a> in just a few lines of code.
+          or even deploy your entire <a href="/reference-architecture/">Architecture</a> in just a few lines of code.
           And since all of this infrastructure is backed by code, you can easily debug, scale, and customize things
           as much as you want.
         </p>
@@ -123,7 +123,7 @@
         <p>
           You can find open source infrastructure code in registries such as Ansible Galaxy, Terraform Module Registry,
           Puppet Forge, and Chef Marketplace. So why use a paid, commercial product such as the
-          <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a> instead of this open source code?
+          <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a> instead of this open source code?
         </p>
         <p>
           First, we love open source at Gruntwork, and parts of our Infrastructure as Code Library actually are open source (e.g.,
@@ -156,7 +156,7 @@
               <th style="width: 20%">Integration</th>
               <td>
                 The modules in the Infrastructure as Code Library are all designed to be highly configurable, composable, and to
-                work together. In fact, we even offer the <a href="/reference-architecture">Reference Architecture</a>,
+                work together. In fact, we even offer the <a href="/reference-architecture/">Reference Architecture</a>,
                 which is a battle-tested, end-to-end tech stack for AWS that we can customize to your needs and deploy
                 into your AWS accounts in about one day. With open source code, all the integration work is up to you,
                 and you'll find many of the modules are too inflexible to fit your needs or incompatible with other modules.
@@ -165,7 +165,7 @@
             <tr>
               <th style="width: 20%">Support</th>
               <td>
-                With <a href="/support">Gruntwork Support</a>, you get commercial support for all the
+                With <a href="/support/">Gruntwork Support</a>, you get commercial support for all the
                 code in the Infrastructure as Code Library. We're there to help you via email, chat, and phone/video call any time
                 you need a bug fixed, or help with troubleshooting, or a code or design review. With open source code,
                 if something goes wrong, you're typically on your own.
@@ -181,9 +181,9 @@
     - question: What's included with each Gruntwork user license?
       answer: |
         <p>
-          When you become a <a href="/pricing">Gruntwork Subscriber</a>, each user license will allow one human or
-          machine user to access our <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a>,
-          <a href="/training">DevOps Training Library</a>, <a href="/houston">Gruntwork Houston</a>, and our paid support
+          When you become a <a href="/pricing/">Gruntwork Subscriber</a>, each user license will allow one human or
+          machine user to access our <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a>,
+          <a href="/training/">DevOps Training Library</a>, <a href="/houston/">Gruntwork Houston</a>, and our paid support
           services. In addition, a user license allows a user to fork and modify the code and create derivative works as
           much as you want.
         </p>
@@ -202,7 +202,7 @@
         <p>
           The Gruntwork Subscription is valid for <i>one</i> company to use to manage its own infrastructure. If you
           are an agency or reseller that manages infrastructure for other companies, please
-          <a href="/contact">contact us</a> to discuss licensing options.
+          <a href="/contact/">contact us</a> to discuss licensing options.
         </p>
 
     - question: How can I modify your Terms of Service?
@@ -264,6 +264,6 @@
           custom, one-off project completely unique to your company), we'd be happy to build it, add it to the
           Infrastructure as Code Library, and provide support, maintenance, and updates for it long-term! For example, we're
           currently looking into adding ElasticSearch, Kubernetes, and DataDog to our Library and are looking for
-          companies willing to fund those projects. See <a href="/custom-module-development">Custom Module Development</a>
+          companies willing to fund those projects. See <a href="/custom-module-development/">Custom Module Development</a>
           for more info.
         </p>

--- a/_data/houston-videos.yml
+++ b/_data/houston-videos.yml
@@ -22,7 +22,7 @@
 - id: vpn-access
   title: SSO for VPN access
   caption: |
-    Finally, self-service VPN certificates! If you use <a href="/infrastructure-as-code-library">Gruntwork's IaC Library</a>
+    Finally, self-service VPN certificates! If you use <a href="/infrastructure-as-code-library/">Gruntwork's IaC Library</a>
     to deploy an OpenVPN server, your team members will be able to request their own VPN certificates through the
     Houston UI.
   url: "/assets/img/houston/gruntwork-houston-vpn.mp4"
@@ -30,7 +30,7 @@
 - id: ssh-access
   title: SSO for SSH access
   caption: |
-    If you run <code>ssh-grunt</code> from <a href="/infrastructure-as-code-library">Gruntwork's IaC Library</a> on your
+    If you run <code>ssh-grunt</code> from <a href="/infrastructure-as-code-library/">Gruntwork's IaC Library</a> on your
     EC2 Instances, your team members will be able to upload their public SSH keys to Houston and then SSH to those EC2
     Instances using their own usernames and keys.
   url: "/assets/img/houston/gruntwork-houston-ssh.mp4"

--- a/_data/initial-setup-how-it-works.yml
+++ b/_data/initial-setup-how-it-works.yml
@@ -17,7 +17,7 @@
       <li>Kakfa, ZooKeeper, ELK, MongoDB, and many other options</li>
     </ul>
 
-    <p class="text-muted"><em>Are we missing something you want? Pay us a one-time fee to <a href="/custom-module-development">build it for you</a>.</em></p>
+    <p class="text-muted"><em>Are we missing something you want? Pay us a one-time fee to <a href="/custom-module-development/">build it for you</a>.</em></p>
 
 - title: We build your architecture
   description: |
@@ -29,7 +29,7 @@
 - title: Learn how to use it
   description: |
     <p>
-      Use our <a href="training">DevOps Training Library</a> to learn how to use your new architecture with a series of
+      Use our <a href="/training/">DevOps Training Library</a> to learn how to use your new architecture with a series of
       micro-videos that do an in-depth walkthrough of all the most common uses cases. Need to learn Terraform, Docker,
       or Packer? We have courses on those, too!
     </p>
@@ -38,7 +38,7 @@
   description: |
     <p>
       If you run into a snag, either ask a question on our <a href="https://community.gruntwork.io">Community Forum</a>
-      or sign up for <a href="/support">Dedicated Support</a> to chat directly with Gruntwork engineers via Slack,
+      or sign up for <a href="/support/">Dedicated Support</a> to chat directly with Gruntwork engineers via Slack,
       email, or phone/video, and guarantee a timely response.
     </p>
 

--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -1,68 +1,68 @@
 - title: Products &amp; Services
   links:
     - title: Infrastructure Code Library
-      url: /infrastructure-as-code-library
+      url: /infrastructure-as-code-library/
 
     - title: Reference Architecture
-      url: /reference-architecture
+      url: /reference-architecture/
 
     - title: DevOps Training Library
-      url: /training
+      url: /training/
 
     - title: Gruntwork Houston
-      url: /houston
+      url: /houston/
 
     - title: Support
-      url: /support
+      url: /support/
 
     - title: DevOps Bootcamp
-      url: /devops-bootcamp
+      url: /devops-bootcamp/
 
     - title: Module Development
-      url: /custom-module-development
+      url: /custom-module-development/
 
 - title: Learn
   links:
     - title: How it Works
-      url: /how-it-works
+      url: /how-it-works/
 
     - title: Pricing
-      url: /pricing
+      url: /pricing/
 
     - title: FAQ
-      url: /faq
+      url: /faq/
 
     - title: DevOps Checklist
-      url: /devops-checklist
+      url: /devops-checklist/
 
     - title: DevOps Resources
-      url: /devops-resources
+      url: /devops-resources/
 
     - title: Why prod is down
-      url: /why-prod-is-down
+      url: /why-prod-is-down/
 
 - title: Company
   links:
     - title: About
-      url: /about
+      url: /about/
 
     - title: How we work
       url: "https://blog.gruntwork.io/how-we-built-a-distributed-self-funded-family-friendly-profitable-startup-93635feb5ace"
 
     - title: Customers
-      url: /customers
+      url: /customers/
 
     - title: Careers
-      url: /careers
+      url: /careers/
 
     - title: Terms of Service
-      url: /terms
+      url: /terms/
 
     - title: Privacy Policy
-      url: /privacy-policy
+      url: /privacy-policy/
 
     - title: Cookie Policy
-      url: /cookie-policy
+      url: /cookie-policy/
 
 - title: Connect
   links:
@@ -70,10 +70,10 @@
       url: "https://blog.gruntwork.io"
 
     - title: Contact us
-      url: /contact
+      url: /contact/
 
     - title: Newsletter
-      url: /newsletter
+      url: /newsletter/
 
     - title: Community Forum
       url: "https://community.gruntwork.io/"

--- a/_data/steps.yml
+++ b/_data/steps.yml
@@ -8,18 +8,18 @@
 
 - title: Try out the Infrastructure as Code library
   description: |
-    Fortunately, there's a solution: the Gruntwork <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a>
+    Fortunately, there's a solution: the Gruntwork <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a>
     (IaC Library) is a collection of reusable infrastructure code written in Terraform, Go, Bash, and Python that
     solves these 1,001 problems. Instead of reinventing the wheel, you can leverage 2+ years and 300,000+ lines of
-    battle-tested code that has been proven in production at <a href="/customers">hundreds of companies</a>. To get an idea of
-    how the library works, try out our <a href="/infrastructure-as-code-library#open-source">open source modules</a>
+    battle-tested code that has been proven in production at <a href="/customers/">hundreds of companies</a>. To get an idea of
+    how the library works, try out our <a href="/infrastructure-as-code-library/#open-source">open source modules</a>
     and watch the talk
     <a href="https://blog.gruntwork.io/reusable-composable-battle-tested-terraform-modules-9c2fb53bc034" target="_blank">Reusable, composable, battle-tested Terraform modules</a>.
 
 - title: If you like what you see, become a Gruntwork Subscriber
   description: |
-    To get access to the IaC Library, you must be a <a href="/pricing">Gruntwork Subscriber</a>. The process is simple:
-    you <a href="/contact">contact us via this simple form</a>, we'll follow up to get your payment details, and then we
+    To get access to the IaC Library, you must be a <a href="/pricing/">Gruntwork Subscriber</a>. The process is simple:
+    you <a href="/contact/">contact us via this simple form</a>, we'll follow up to get your payment details, and then we
     grant you access to all the code. You'll be able to use the IaC Library code directly in your own codebase via
     <a href="https://www.terraform.io/docs/modules/sources.html#generic-git-repository" target="_blank">Terraform source URLs</a>
     and the <a href="https://github.com/gruntwork-io/gruntwork-installer" target="_blank">Gruntwork Installer</a>.
@@ -27,7 +27,7 @@
 - title: Deploy an end-to-end architecture in your AWS account
   description: |
     You can assemble all the code from the IaC Library yourself, or you can have the Gruntwork team assemble a
-    <a href="/reference-architecture">Reference Architecture</a> for you. The Reference Architecture is an opinionated,
+    <a href="/reference-architecture/">Reference Architecture</a> for you. The Reference Architecture is an opinionated,
     battle-tested, end-to-end tech stack that includes just about everything you need, including: server cluster, load
     balancer, database, cache, network topology, monitoring, alerting, CI/CD, secrets management, VPN, and more. We
     customize the Reference Architecture to your needs, deploy it into your AWS accounts, and give you 100% of
@@ -35,7 +35,7 @@
 
 - title: Manage everything using Gruntwork Houston
   description: |
-    To manage all of your new infrastructure, you get access to <a href="/houston">Gruntwork Houston</a>. On the
+    To manage all of your new infrastructure, you get access to <a href="/houston/">Gruntwork Houston</a>. On the
     surface, Houston is a simple web interface that your Dev team can use to deploy and manage infrastructure. Under
     the hood, the web interface and how it manages infrastructure are completely defined and controlled by your Ops
     team using infrastructure as code. It's the best of both worlds: your Dev team gets an easy-to-use, self-service
@@ -44,15 +44,15 @@
 
 - title: Learn Terraform, Docker, Packer, AWS, and DevOps
   description: |
-    Gruntwork Subscribers also get access to the <a href="/training">DevOps Training Library</a>, which
+    Gruntwork Subscribers also get access to the <a href="/training/">DevOps Training Library</a>, which
     is a collection of video courses that teach you everything you need to know to use the Iac Library and Reference
     Architecture, including Terraform, Docker, Packer, AWS, security, scalability, high availability, and more.
-    If you prefer live, in-person training, we also offer an on-site <a href="/devops-bootcamp">DevOps Bootcamp</a>.
+    If you prefer live, in-person training, we also offer an on-site <a href="/devops-bootcamp/">DevOps Bootcamp</a>.
 
 - title: Get ongoing maintenance and updates
   description: |
     At Gruntwork, we provide ongoing maintenance and updates for all the code in the IaC Library and Reference
-    Architecture. We regularly add new modules (see <a href="/custom-module-development">Custom Module Development</a>)
+    Architecture. We regularly add new modules (see <a href="/custom-module-development/">Custom Module Development</a>)
     and every time Terraform comes out with a new version, AWS releases new services, or a security vulnerability is
     announced, we update our code, release a new version, and announce it in our
     <a href="https://blog.gruntwork.io/tagged/gruntwork-newsletter" target="_blank">newsletter</a>. As a Subscriber,
@@ -67,6 +67,6 @@
 
 - title: Become a DevOps superhero
   description: |
-    At Gruntwork, our goal is to make it 10x easier for you to understand, build, and deploy software. <a href="/contact">
+    At Gruntwork, our goal is to make it 10x easier for you to understand, build, and deploy software. <a href="/contact/">
     Join the Gruntwork community</a> and become your team's hero, using your superpowers to do in hours
     what used to take months. Focus on your product and let us take care of the gruntwork!

--- a/_data/terms-of-service.yml
+++ b/_data/terms-of-service.yml
@@ -4,7 +4,7 @@
   items:
     - title:
       legalese: |
-        <p>These Terms and Conditions (“Terms”) govern access to and use of the Gruntwork (“Gruntwork,” “we” or “us”) products, services and other deliverables (collectively, the “Services”) by individuals or entities who purchase the Services and their Authorized Users (collectively, “Customers”). By using any Services, you as a Customer accept these Terms and the Privacy Policy located at <a href="/privacy-policy" title="Gruntwork Privacy Policy">https://gruntwork.io/privacy-policy/</a> (whether on behalf of yourself or a legal entity you represent). Customers may be referred to in these Terms as “you” and “your” as applicable. You and Gruntwork may be individually referred to in these Terms as a “Party” and collectively as the “Parties.”</p>
+        <p>These Terms and Conditions (“Terms”) govern access to and use of the Gruntwork (“Gruntwork,” “we” or “us”) products, services and other deliverables (collectively, the “Services”) by individuals or entities who purchase the Services and their Authorized Users (collectively, “Customers”). By using any Services, you as a Customer accept these Terms and the Privacy Policy located at <a href="/privacy-policy/" title="Gruntwork Privacy Policy">https://gruntwork.io/privacy-policy/</a> (whether on behalf of yourself or a legal entity you represent). Customers may be referred to in these Terms as “you” and “your” as applicable. You and Gruntwork may be individually referred to in these Terms as a “Party” and collectively as the “Parties.”</p>
         <p>If you are a Customer and you or your organization is bound by a Master Services Agreement with Gruntwork (“MSA”), then these Terms will apply, if at all, only to the use of the Services to the extent such use is not already governed by such an MSA.</p>
         <p>BY ACCESSING, USING, OR COPYING ANY MATERIALS FROM THE SERVICES, YOU AGREE TO FOLLOW AND BE BOUND BY THESE TERMS. IF YOU DO NOT AGREE TO THESE TERMS, YOU ARE NOT AUTHORIZED AND MUST CEASE USING THE SERVICES IMMEDIATELY.</p>
       plain:  |
@@ -42,7 +42,7 @@
         <p><strong>4.1. Pricing.</strong> In consideration for the Services, you will pay Gruntwork as provided in the applicable terms for the specific Services you have chosen to subscribe to. The price you pay for specific Services will be the prices as published on our Website at the time you first register for the Services, which will remain your prices throughout the term of this Agreement (including any renewal periods).  Gruntwork is free to change the pricing of the Services at any time during the term of this Agreement, but the new pricing shall only apply to you for any renewal period if you notify Gruntwork before the beginning of such renewal period of your request for the new pricing.</p>
         <p><strong>4.2. Incidental Expenses.</strong> If performing the Services involves incidental expenses, you will only be responsible for such incidental expenses if you previously approved the expenses in writing (email is sufficient).</p>
       plain:  |
-        All our pricing is published at <a target="_blank" rel="internal" href="/pricing" title="Gruntwork Pricing">https://gruntwork.io/pricing</a>, and we don't charge any hidden fees. We won't change the price you pay for our services unless:<br />(1) we announce new pricing, AND<br  />(2) you ask us to apply the new pricing to your next renewal period.
+        All our pricing is published at <a target="_blank" rel="internal" href="/pricing/" title="Gruntwork Pricing">https://gruntwork.io/pricing</a>, and we don't charge any hidden fees. We won't change the price you pay for our services unless:<br />(1) we announce new pricing, AND<br  />(2) you ask us to apply the new pricing to your next renewal period.
 
     - title:
       legalese: |
@@ -249,21 +249,21 @@
 
     - title: 2. Payment Terms
       legalese: |
-        <p>In consideration for the Gruntwork Subscription, you shall pay Gruntwork the rate specified at <a target="_blank" rel="internal" href="/pricing" title="Gruntwork Pricing">https://gruntwork.io/pricing</a> for the number of Authorized Users selected during registration on a monthly basis, in accordance with the payment terms set forth in the Terms, and subject to <a href="#1-term-and-termination">section 1</a> of these Gruntwork Subscription Terms.</p>
+        <p>In consideration for the Gruntwork Subscription, you shall pay Gruntwork the rate specified at <a target="_blank" rel="internal" href="/pricing/" title="Gruntwork Pricing">https://gruntwork.io/pricing</a> for the number of Authorized Users selected during registration on a monthly basis, in accordance with the payment terms set forth in the Terms, and subject to <a href="#1-term-and-termination">section 1</a> of these Gruntwork Subscription Terms.</p>
       plain: |
         Although this is a 12-month contract, we'll bill you by credit card on a monthly basis.
 
     - title: 3. Included Features
       legalese: |
-        <p><strong>3.1. Infrastructure as Code Library.</strong> Each Authorized User will receive access to the private source code repositories (“Library Repos”), which contain a collection of infrastructure code created by Gruntwork (the “Infrastructure as Code Library”). Client can find a list of the code in the Infrastructure as Code Library at <a target="_blank" rel="internal" href="/infrastructure-as-code-library" title="Gruntwork's Infrastructure as code library">https://gruntwork.io/infrastructure-as-code-library</a>, or any other URL to which the prior URL redirects. From time to time, Gruntwork will release new features, bug fixes, security patches, automated tests, documentation, and other improvements to existing code, as well as create completely new code (collectively, “Updates”). Authorized Users will have access to all Updates and will be able to make use of the Updates by modifying their own source code to use a newer version of the Library Repos.</p>
+        <p><strong>3.1. Infrastructure as Code Library.</strong> Each Authorized User will receive access to the private source code repositories (“Library Repos”), which contain a collection of infrastructure code created by Gruntwork (the “Infrastructure as Code Library”). Client can find a list of the code in the Infrastructure as Code Library at <a target="_blank" rel="internal" href="/infrastructure-as-code-library/" title="Gruntwork's Infrastructure as code library">https://gruntwork.io/infrastructure-as-code-library</a>, or any other URL to which the prior URL redirects. From time to time, Gruntwork will release new features, bug fixes, security patches, automated tests, documentation, and other improvements to existing code, as well as create completely new code (collectively, “Updates”). Authorized Users will have access to all Updates and will be able to make use of the Updates by modifying their own source code to use a newer version of the Library Repos.</p>
       plain:  |
-        See <a target="_blank" rel="internal" href="/infrastructure-as-code-library">https://gruntwork.io/infrastructure-as-code-library</a> for additional details.
+        See <a target="_blank" rel="internal" href="/infrastructure-as-code-library/">https://gruntwork.io/infrastructure-as-code-library</a> for additional details.
 
     - title:
       legalese: |
         <p><strong>3.2. DevOps Training Library.</strong> Each Authorized User will receive access to a set of pre-recorded training courses (the “Courses”), including courses on Terraform, Packer/Docker/ECS, and the Gruntwork Reference Architecture. From time to time, Gruntwork will update the Courses to reflect the latest industry updates.</p>
       plain:  |
-        See <a target="_blank" rel="internal" href="/training">https://gruntwork.io/training</a> for additional details.
+        See <a target="_blank" rel="internal" href="/training/">https://gruntwork.io/training</a> for additional details.
 
     - title:
       legalese: |
@@ -297,7 +297,7 @@
 
     - title: 2. Payment Terms
       legalese: |
-        <p>In consideration for the Dedicated Support, you shall pay Gruntwork the rate specified at <a target="_blank" rel="internal" href="/pricing" title="Gruntwork Pricing">https://gruntwork.io/pricing</a> for the number of Authorized Users selected during registration on a monthly basis, in accordance with the payment terms set forth in the Terms, and subject to <a href="#1-term-and-termination-1">section 1</a> of these Dedicated Support Terms.</p>
+        <p>In consideration for the Dedicated Support, you shall pay Gruntwork the rate specified at <a target="_blank" rel="internal" href="/pricing/" title="Gruntwork Pricing">https://gruntwork.io/pricing</a> for the number of Authorized Users selected during registration on a monthly basis, in accordance with the payment terms set forth in the Terms, and subject to <a href="#1-term-and-termination-1">section 1</a> of these Dedicated Support Terms.</p>
       plain: |
         We will bill you by credit card on a monthly basis.
 
@@ -305,7 +305,7 @@
       legalese: |
         <p><strong>3.1. Supported Requests.</strong> Any Authorized User may submit a support request (“Support Request”) to Gruntwork. Support Requests may involve questions, troubleshooting, code reviews, design reviews, and bug fixes. All Support Requests must be reasonably related to the infrastructure set up by Gruntwork on your behalf. Gruntwork shall not be obligated to provide custom development in response to a Support Request; however, Gruntwork, at its discretion, may offer to perform custom development for free (e.g., for bug fixes) or as part of a separate statement of work (e.g., for developing new modules).</p>
       plain:  |
-        This section lists what's included with Dedicated Support. For more information, see <a target="_blank" rel="internal" href="/support" title="Dedicated Support">https://gruntwork.io/support</a>.
+        This section lists what's included with Dedicated Support. For more information, see <a target="_blank" rel="internal" href="/support/" title="Dedicated Support">https://gruntwork.io/support</a>.
 
     - title:
       legalese: |
@@ -348,7 +348,7 @@
 
     - title: 2. Payment Terms
       legalese: |
-        <p>In consideration for the Reference Architecture, you shall pay Gruntwork the rate specified at <a target="_blank" rel="internal" href="/pricing" title="Gruntwork Pricing">https://gruntwork.io/pricing</a> before we begin your Reference Architecture implementation (as described in section 3) and in accordance with the payment terms set forth in the Terms, and subject to section 1 of these Reference Architecture Terms.</p>
+        <p>In consideration for the Reference Architecture, you shall pay Gruntwork the rate specified at <a target="_blank" rel="internal" href="/pricing/" title="Gruntwork Pricing">https://gruntwork.io/pricing</a> before we begin your Reference Architecture implementation (as described in section 3) and in accordance with the payment terms set forth in the Terms, and subject to section 1 of these Reference Architecture Terms.</p>
       plain:  |
         We'll charge you upfront for the Reference Architecture.
 
@@ -394,7 +394,7 @@
       legalese: |
         <p><strong>3.1. About Gruntwork Houston.</strong> Houston is a web-based service that provides a central place where your development and operations teams can manage your infrastructure. Houston runs directly in your AWS account, and includes a command line tool to allow interacting with Houston from the terminal. Houston is a standalone product and not part of the Infrastructure as Code Library. Each Authorized User will have access to the Houston services and Houston downloadable tools, but not to the Houston source code repository, which shall remain private to Gruntwork.</p>
       plain: |
-        To learn more about Houston, see <a href="https://gruntwork.io/houston" title="Learn more about Gruntwork Houston">https://gruntwork.io/houston</a>
+        To learn more about Houston, see <a href="https://gruntwork.io/houston/" title="Learn more about Gruntwork Houston">https://gruntwork.io/houston</a>
     - title:
       legalese: |
         <p><strong>3.2. Authentication to Amazon Web Services.</strong> Houston enables you to authenticate to one or more of your AWS accounts using any Identity Provider that is compatible with Houston and which you configure for use with Houston. An “Identity Provider” is a system entity that creates, maintains, and manages identity information for principals while providing authentication services to relying party applications within a federation or distributed network.</p>

--- a/_data/training-resources.yml
+++ b/_data/training-resources.yml
@@ -46,7 +46,7 @@
   bg_color: purple
 
 - title: The Production Readiness Checklist for AWS
-  url: "/devops-checklist"
+  url: "/devops-checklist/"
   image: /assets/img/training-resources/devops-checklist.png
   description: |
     This checklist is your guide to the best practices for deploying secure, scalable, and highly available

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
       <div class="row row-call-to-action">
         <div class="col-xs-12 text-center">
           <h2 class="h1 no-anchor">{{ page.footer_heading }}</h2>
-          <p><a href="/checkout" class="btn btn-info" role="button" ga-on="click" ga-event-category="footer-{{ page.path | slugify }}" ga-event-action="get-started">Get Started</a></p>
+          <p><a href="/checkout/" class="btn btn-info" role="button" ga-on="click" ga-event-category="footer-{{ page.path | slugify }}" ga-event-action="get-started">Get Started</a></p>
         </div>
       </div>
       {% endif %}

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -12,26 +12,26 @@
       </div>
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
         <ul class="nav navbar-nav navbar-right">
-          <li><a href="/how-it-works" ga-on="click" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="how-it-works">How it Works</a></li>
+          <li><a href="/how-it-works/" ga-on="click" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="how-it-works">How it Works</a></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Products <i class="fa fa-caret-down" aria-hidden="true"></i></a>
             <ul class="dropdown-menu dropdown-menu-left" role="menu">
-              <li><a href="/infrastructure-as-code-library" ga-on="click" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="infrastructure-as-code-library">Infrastructure as Code Library</a></li>
-              <li><a href="/training" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="training-library">DevOps Training Library</a></li>
-              <li><a href="/reference-architecture" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="reference-architecture">Reference Architecture</a></li>
-              <li><a href="/houston" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="reference-architecture">Gruntwork Houston</a></li>
+              <li><a href="/infrastructure-as-code-library/" ga-on="click" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="infrastructure-as-code-library">Infrastructure as Code Library</a></li>
+              <li><a href="/training/" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="training-library">DevOps Training Library</a></li>
+              <li><a href="/reference-architecture/" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="reference-architecture">Reference Architecture</a></li>
+              <li><a href="/houston/" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="reference-architecture">Gruntwork Houston</a></li>
             </ul>
           </li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Services <i class="fa fa-caret-down" aria-hidden="true"></i></a>
             <ul class="dropdown-menu dropdown-menu-left" role="menu">
-              <li><a href="/support" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="support">Support</a></li>
-              <li><a href="/devops-bootcamp" ga-on="click" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="devops-bootcamp">DevOps Bootcamp</a></li>
-              <li><a href="/custom-module-development" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="custom-module-dev">Custom Module Development</a></li>
+              <li><a href="/support/" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="support">Support</a></li>
+              <li><a href="/devops-bootcamp/" ga-on="click" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="devops-bootcamp">DevOps Bootcamp</a></li>
+              <li><a href="/custom-module-development/" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="custom-module-dev">Custom Module Development</a></li>
             </ul>
           </li>
-          <li><a href="/pricing" ga-on="click" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="pricing">Pricing</a></li>
-          <li><a href="/checkout" class="btn btn-info" role="button" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="get-started">Get Started</a></li>
+          <li><a href="/pricing/" ga-on="click" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="pricing">Pricing</a></li>
+          <li><a href="/checkout/" class="btn btn-info" role="button" ga-event-category="nav-{{ page.path | slugify }}" ga-event-action="get-started">Get Started</a></li>
         </ul>
       </div>
     </div>

--- a/assets/css/app.less
+++ b/assets/css/app.less
@@ -2136,3 +2136,87 @@ input[type="radio"] .styled:checked + label::after {
     background-image: linear-gradient(to bottom, #ff5c3b, #ff2b67);
     border: 2px solid #1d252e;
 }
+
+/* Elmo - The Grunty Cookie Policy Gatekeeper */
+
+#gruntyCookie{
+    background: rgba(255,255,255,0.85);
+    display: block;
+    color:#333333;
+    position:fixed;
+    bottom: 8px;
+    left:50%;
+    transform: translateX(-50%);
+    margin: 0 auto;
+    width:502px;
+    max-width: 80vw;
+    padding: 4px 19px;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    z-index:1112;
+    box-shadow: 0 8px 16px 0 rgba(34,50,84,.06);
+    border-radius: 8px;
+    text-align: center;
+    p {
+        margin: 0;
+        float: left;
+        padding: 15px 0 10px;
+        font-size: 18px;
+        line-height: 22px;
+        a {
+            &:link, &:visited, &:hover, &:active {
+                color: @color-blue;
+            }
+        }
+    }
+
+    #cookieModalClose{
+        float:right;
+        margin-left:10px;
+    }
+    @media (max-width: @screen-xs-max) {
+        width: 100%;
+        max-width: none;
+        border-radius: 0;
+        bottom: 0;
+        padding: 4px 10px;
+        p{
+            width: 78%;
+            display: inline-block;
+            text-align: left;
+        }
+        #cookieModalClose{
+            width: 20%;
+            display: inline-block;
+            float: none;
+            margin: 18px 0 10px;
+        }
+    }
+}
+.cookieModalCBeginAnimate{
+    -webkit-animation: gruntyCookieModal 0.5s;
+    animation: gruntyCookieModal 0.5s;
+}
+/* Chrome, Safari, Opera */
+@-webkit-keyframes gruntyCookieModal {
+    from {
+        opacity: 0;
+        transform:  translate(0px,40px);
+    }
+    to {
+        opacity: 1;
+        transform:  translate(0px,0px)
+    }
+}
+/* Standard syntax */
+@keyframes gruntyCookieModal {
+    from {
+        opacity: 0;
+        transform:  translate(-50%,40px);
+    }
+    to {
+        opacity: 1;
+        transform:  translate(-50%,0px);
+    }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -402,21 +402,9 @@ $(function() {
       setCookie("GruntyCookie", "1", 365);
       cookieModal.style.display = "none";
   }
-  /* Get Country Code from USER IP */
-  var country_code = null;
-  $euList = [
-      "BE", "BG", "CZ", "DK", "DE", "EE", "IE", "EL", "ES", "FR", "HR", "IT", "CY",
-      "LV", "LT", "LU", "HU", "MT", "NL", "AT", "PL", "PT", "RO", "SI", "SK", "FI",
-      "SE", "UK", "IS", "NO", "LI"
-  ];
-  $.getJSON('http://ipinfo.io/', function(data){
-    country_code = data.country;
-    if($euList.includes(country_code)){
-      cookieModal.style.display = "block";
-      cookieModal.classList.add("cookieModalCBeginAnimate");
-      cookieModalCloseBtn.addEventListener("click", cookieModalClose, false);
-    }
-  });
+  cookieModal.style.display = "block";
+  cookieModal.classList.add("cookieModalCBeginAnimate");
+  cookieModalCloseBtn.addEventListener("click", cookieModalClose, false);
 })();
 
 // If Panel with fa-caret is clicked, turn the caret down, and turn it back up on others

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -9,12 +9,12 @@
     <h4>What You'll Work On</h4>
     <ul>
       <li>
-        <strong><a href="/houston">Gruntwork Houston</a></strong>: build a fundamentally better DevOps experience.
+        <strong><a href="/houston/">Gruntwork Houston</a></strong>: build a fundamentally better DevOps experience.
         Houston consists of a serverless REST API (Node.js, TypeScript, Lambda, API Gateway), a web-based single-page
         app (Angular, TypeScript, SASS), and a CLI tool (Go).
       </li>
       <li>
-        <strong><a href="/infrastructure-as-code-library">Infrastructure as Code Library</a></strong>: create reusable
+        <strong><a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a></strong>: create reusable
         infrastructure modules for a variety of infrastructure (e.g., Kubernetes, ELK, Consul, Vault, Kafka, MongoDB,
         InfluxDB, Jenkins, etc), using a variety of tools (e.g., Terraform, Go, Python, Bash, Docker, Packer, etc),
         across many clouds (e.g., AWS, GCP, and Azure).

--- a/pages/checkout/_subscription.html
+++ b/pages/checkout/_subscription.html
@@ -34,7 +34,7 @@
             <div class="col-sm-7 col-sm-offset-2">
               <div class="visible-xs-block text-left" style="margin-bottom: 16px">
                 <h4 class="h5 text-bold margin-top-none margin-bottom-none">Legal:</h4>
-                View our <a target="_blank" href="/terms">Terms of Service</a>
+                View our <a target="_blank" href="/terms/">Terms of Service</a>
               </div>
               <h4 class="h5 text-bold margin-top-none">Add-ons:</h4>
               <div class="switch-group">
@@ -60,7 +60,7 @@
           <ul class="text-muted smaller">
             <li>An initial deposit of $500 will be charged at the time of checkout. The remaining balance for your monthly payment and any Reference Architecture fees (if you selected it) will be charged when your order is processed.</li>
             <li>We typically process your order within 1 - 2 business days.</li>
-            <li>These <a style="text-decoration: underline;" class="text-muted" href="/terms">Terms of Service</a> license our products FOR YOUR COMPANY'S INTERNAL USE ONLY. If you wish to become a Gruntwork Partner, please <a style="text-decoration: underline;" class="text-muted" href="/contact">contact us</a>.</li>
+            <li>These <a style="text-decoration: underline;" class="text-muted" href="/terms/">Terms of Service</a> license our products FOR YOUR COMPANY'S INTERNAL USE ONLY. If you wish to become a Gruntwork Partner, please <a style="text-decoration: underline;" class="text-muted" href="/contact/">contact us</a>.</li>
           </ul>
         </div>
       </div>

--- a/pages/custom-module-development/_sub-hero.html
+++ b/pages/custom-module-development/_sub-hero.html
@@ -3,7 +3,7 @@
     <h2>The world experts in building reusable infrastructure modules</h2>
     <p>
       Need to deploy infrastructure (e.g., Elasticsearch, Kubernetes, DataDog) that's not already part of
-      the <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a>? Gruntwork can help. We've built dozens of modules
+      the <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a>? Gruntwork can help. We've built dozens of modules
       across multiple clouds that are used in production by hundreds of companies and thousands of engineers. We can develop a new, reusable module for you, complete with documentation, example code, and automated
       tests, and best of all, we'll provide support and maintenance for the module long-term!
     </p>
@@ -18,7 +18,7 @@
     <p>
       Check out the <a href="https://blog.gruntwork.io/reusable-composable-battle-tested-terraform-modules-9c2fb53bc034" target="_blank">Reusable,
       composable, battle-tested Terraform modules</a> talk to learn how we design, build, and test modules. Or better
-      yet, have a look at our <a href="/infrastructure-as-code-library#open-source">open source modules</a>, and try
+      yet, have a look at our <a href="/infrastructure-as-code-library/#open-source">open source modules</a>, and try
       them out yourself!
     </p>
     <h2>Features</h2>
@@ -37,7 +37,7 @@
     </div>
     <h2>Get started</h2>
     <p>
-      <a href="/contact">Contact us</a> to let us know what modules you'd like us to build!
+      <a href="/contact/">Contact us</a> to let us know what modules you'd like us to build!
     </p>
   </div>
 </div>

--- a/pages/devops-bootcamp/_sub-hero.html
+++ b/pages/devops-bootcamp/_sub-hero.html
@@ -21,7 +21,7 @@
     </div>
     <h2>Pricing</h2>
     <p>
-      You can find the pricing for the DevOps Bootcamp on our <a href="/pricing">pricing page</a>.
+      You can find the pricing for the DevOps Bootcamp on our <a href="/pricing/">pricing page</a>.
     </p>
   </div>
 </div>

--- a/pages/devops-checklist/_gruntwork.html
+++ b/pages/devops-checklist/_gruntwork.html
@@ -5,9 +5,9 @@
     <p>
       Creating a production-ready infrastructure is a lot of work. But don't worry, we've got you covered. Just about
       everything in this checklist is already part of the Gruntwork
-      <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a> and can be deployed in your AWS
+      <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a> and can be deployed in your AWS
       account in 1 day as part of the
-      <a href="/reference-architecture">Reference Architecture</a>.
+      <a href="/reference-architecture/">Reference Architecture</a>.
     </p>
   </div>
 </div>

--- a/pages/houston/_beta.html
+++ b/pages/houston/_beta.html
@@ -1,5 +1,5 @@
 <h2>Gruntwork Houston Beta</h2>
 <p>
-  Gruntwork Houston is currently in private beta. If you'd like early access, <a href="/contact">contact us</a> and
+  Gruntwork Houston is currently in private beta. If you'd like early access, <a href="/contact/">contact us</a> and
   we'll add you to the waiting list!
 </p>

--- a/pages/index/_community.html
+++ b/pages/index/_community.html
@@ -11,5 +11,5 @@
       </div>
     {% endfor %}
   </div>
-  <p><a href="/customers" ga-on="click" ga-event-category="home-customers" ga-event-action="see-their-results">See their results <i class="fa fa-fw fa-caret-right"></i></a></p>
+  <p><a href="/customers/" ga-on="click" ga-event-category="home-customers" ga-event-action="see-their-results">See their results <i class="fa fa-fw fa-caret-right"></i></a></p>
 </div>

--- a/pages/index/_learn-more.html
+++ b/pages/index/_learn-more.html
@@ -13,7 +13,7 @@
   <div class="col-xs-12 col-sm-7 col-md-6 col-description">
     <h2>Get access to the Infrastructure as Code Library.</h2>
     <p>Build your infrastructure on top of a collection of over 300,000 lines of reusable, battle-tested infrastructure code written in Terraform, Go, Python, and Bash that has been proven in production at hundreds of companies and is maintained and supported by DevOps experts.</p>
-    <p><a href="/infrastructure-as-code-library" class="btn btn-primary" role="button" ga-on="click" ga-event-category="home-learn-more" ga-event-action="browse-infra-as-code-library">Browse the Library</a></p>
+    <p><a href="/infrastructure-as-code-library/" class="btn btn-primary" role="button" ga-on="click" ga-event-category="home-learn-more" ga-event-action="browse-infra-as-code-library">Browse the Library</a></p>
   </div>
 </div>
 
@@ -23,8 +23,8 @@
   </div>
   <div class="col-xs-12 col-sm-7 col-sm-pull-5 col-md-6 col-md-pull-6 col-description">
     <h2>Deploy your entire tech stack.</h2>
-    <p>We can deploy an end-to-end Reference Architecture built on top of the Infrastructure as Code Library into your AWS account and give you 100% of the code in about one day. You get to customize the tech stack to your needs, choosing from Docker or Packer, MySQL or Postgres, Jenkins or CircleCI, and so on. And you get to manage everything using <a href="/houston">Gruntwork Houston</a>, the Mission Control for your entire infrastructure.</p>
-    <p><a href="/how-it-works" class="btn btn-primary" role="button" ga-on="click" ga-event-category="home-learn-more" ga-event-action="how-it-works">See how it works</a></p>
+    <p>We can deploy an end-to-end Reference Architecture built on top of the Infrastructure as Code Library into your AWS account and give you 100% of the code in about one day. You get to customize the tech stack to your needs, choosing from Docker or Packer, MySQL or Postgres, Jenkins or CircleCI, and so on. And you get to manage everything using <a href="/houston/">Gruntwork Houston</a>, the Mission Control for your entire infrastructure.</p>
+    <p><a href="/how-it-works/" class="btn btn-primary" role="button" ga-on="click" ga-event-category="home-learn-more" ga-event-action="how-it-works">See how it works</a></p>
   </div>
 </div>
 
@@ -35,6 +35,6 @@
   <div class="col-xs-12 col-sm-7 col-md-6 col-description">
     <h2>Get expert support and training.</h2>
     <p>Get support from a team of DevOps experts who can help you with questions, troubleshooting, best practices, and maintenance. Learn DevOps from our DevOps Training Library or DevOps Bootcamps. We wrote <a href="https://www.terraformupandrunning.com" target="_blank">the book on Terraform</a> and <a href="https://www.airpair.com/aws/posts/building-a-scalable-web-app-on-amazon-web-services-p1" target="_blank">the definitive guide to AWS</a>, so you’re in good hands.</p>
-    <p><a href="/training" class="btn btn-primary" role="button" ga-on="click" ga-event-category="home-learn-more" ga-event-action="preview-training">Preview Our Training</a></p>
+    <p><a href="/training/" class="btn btn-primary" role="button" ga-on="click" ga-event-category="home-learn-more" ga-event-action="preview-training">Preview Our Training</a></p>
   </div>
 </div>

--- a/pages/infrastructure-as-code-library/_modal.html
+++ b/pages/infrastructure-as-code-library/_modal.html
@@ -9,7 +9,7 @@
         <p>
           Public docs repos contain all the documentation but none of the code.
           <br>
-          Full repo access is available to <a href="/pricing">Gruntwork subscribers</a>.
+          Full repo access is available to <a href="/pricing/">Gruntwork subscribers</a>.
         </p>
         <p>
           <a class="btn btn-info public-repo-link" href="">I understand, take me to the docs!</a>
@@ -31,7 +31,7 @@
       <div class="modal-body text-center">
         <h4 class="h2 modal-title margin-top-none" id="modalPrivateRepoTitle">You're about to view a private repo.</h4>
         <p>
-          Private repos are available to <a href="/pricing">Gruntwork Subscribers</a>.
+          Private repos are available to <a href="/pricing/">Gruntwork Subscribers</a>.
           <br>
           We create public docs versions of some of our repos, but not yet for this one.
           <br>

--- a/pages/infrastructure-as-code-library/_process.html
+++ b/pages/infrastructure-as-code-library/_process.html
@@ -3,7 +3,7 @@
     <h2>How do I get access to this code?</h2>
     <p>
       To get access to all the code in the Infrastructure as Code Library, you must be a Gruntwork Subscriber.
-      Check out the <a href="/pricing">pricing page</a> for details.
+      Check out the <a href="/pricing/">pricing page</a> for details.
     </p>
   </div>
 </div>

--- a/pages/pricing/_benefits.html
+++ b/pages/pricing/_benefits.html
@@ -1,9 +1,9 @@
 <ul class="check-list">
-  <li><a href="/infrastructure-as-code-library" class="text-white">Infrastructure as Code Library</a>: 300,000+ lines of reusable, battle-tested infrastructure code.</li>
-  <li><a href="/training" class="text-white">DevOps Training Library</a>: A collection of training video courses that teach you DevOps.</li>
-  <li><a href="/houston" class="text-white">Gruntwork Houston</a>: Mission Control for your infrastructure. Currently in private beta.</li>
+  <li><a href="/infrastructure-as-code-library/" class="text-white">Infrastructure as Code Library</a>: 300,000+ lines of reusable, battle-tested infrastructure code.</li>
+  <li><a href="/training/" class="text-white">DevOps Training Library</a>: A collection of training video courses that teach you DevOps.</li>
+  <li><a href="/houston/" class="text-white">Gruntwork Houston</a>: Mission Control for your infrastructure. Currently in private beta.</li>
   {% if include.dedicated_support %}
-    <li><a href="/support" target="_blank" class="text-white">Dedicated Support</a>: Get support via email, chat, and phone/video from Gruntwork. 1 Business Day SLA.</li>
+    <li><a href="/support/" target="_blank" class="text-white">Dedicated Support</a>: Get support via email, chat, and phone/video from Gruntwork. 1 Business Day SLA.</li>
   {% else %}
     <li><a href="https://community.gruntwork.io/" target="_blank" class="text-white">Community Forum</a>: Get support via our public community forum. 2 Business Day SLA.</li>
   {% endif %}

--- a/pages/pricing/_calculator.html
+++ b/pages/pricing/_calculator.html
@@ -25,6 +25,6 @@
     <h5 style="margin-top: 0;"><strong data-pricing-calc="title"></strong></h5>
     <p class="medium-price" style="margin-bottom: 0;"><span>$</span> <span data-pricing-calc="total"></span></p>
     <p class="text-muted small">total per month</p>
-    <p style="margin-bottom: 0;"><a href="/checkout" class="btn btn-info" role="button">Get Started</a></p>
+    <p style="margin-bottom: 0;"><a href="/checkout/" class="btn btn-info" role="button">Get Started</a></p>
   </div>
 </div>

--- a/pages/pricing/_other-services.html
+++ b/pages/pricing/_other-services.html
@@ -4,12 +4,12 @@
     <table class="table table-striped table-border">
       <tbody>
         <tr>
-          <th><a href="/devops-bootcamp">DevOps Bootcamp</a></th>
-          <td class="text-right additional-services-pricing"><span class="text-white">$3,000</span> <small>/ person</small><span class="additional-services-link"><small><a href="/contact" class="underline">Get started</a></small></span></td>
+          <th><a href="/devops-bootcamp/">DevOps Bootcamp</a></th>
+          <td class="text-right additional-services-pricing"><span class="text-white">$3,000</span> <small>/ person</small><span class="additional-services-link"><small><a href="/contact/" class="underline">Get started</a></small></span></td>
         </tr>
         <tr>
-          <th><a href="/custom-module-development">Custom Terraform Module Development</a></th>
-          <td class="text-right"><small><a href="/contact" class="underline">Contact us</a></small></td>
+          <th><a href="/custom-module-development/">Custom Terraform Module Development</a></th>
+          <td class="text-right"><small><a href="/contact/" class="underline">Contact us</a></small></td>
         </tr>
       </tbody>
     </table>

--- a/pages/pricing/_pricing-faqs.html
+++ b/pages/pricing/_pricing-faqs.html
@@ -7,10 +7,10 @@
         {% include_relative _calculator.html %}
         <p style="margin-top: 20px">
           Some perspective: the Gruntwork Subscription gets you access to a library of over 300,000 lines of
-          <a href="/infrastructure-as-code-library" target="_blank">infrastructure code</a> that has been proven
+          <a href="/infrastructure-as-code-library/" target="_blank">infrastructure code</a> that has been proven
           in production at hundreds of companies over the last 2+ years,
           <a href="https://blog.gruntwork.io/tagged/gruntwork-newsletter" target="_blank">ongoing maintenance and
-          updates</a> for that code, a library of <a href="/training" target="_blank">DevOps training videos</a>, and
+          updates</a> for that code, a library of <a href="/training/" target="_blank">DevOps training videos</a>, and
           support from a team of DevOps experts, all starting at just ${{site.data.pricing.tier1.price[0]}} per month.
         </p>
         <p>

--- a/pages/pricing/_subscription-tabs.html
+++ b/pages/pricing/_subscription-tabs.html
@@ -20,7 +20,7 @@
           </div>
         </div>
         <div class="text-white text-center" style="margin-top: 20px;">
-          <p style="margin-bottom: 0;">51+ users? We offer volume discounts for enterprise teams. <a href="/contact">Contact Us</a></p>
+          <p style="margin-bottom: 0;">51+ users? We offer volume discounts for enterprise teams. <a href="/contact/">Contact Us</a></p>
         </div>
         <img class="grunty-confident" src="/assets/img/grunty-pricing.png" width="238" height="288" alt="Grunty confident">
       </div>
@@ -35,7 +35,7 @@
           </div>
         </div>
         <div class="text-white text-center" style="margin-top: 20px;">
-          <p style="margin-bottom: 0;">51+ users? We offer volume discounts for enterprise teams. <a href="/contact">Contact Us</a></p>
+          <p style="margin-bottom: 0;">51+ users? We offer volume discounts for enterprise teams. <a href="/contact/">Contact Us</a></p>
         </div>
         <img class="grunty-support" src="/assets/img/grunty-support.png" width="464" height="293" alt="Grunty support">
       </div>

--- a/pages/pricing/_support.html
+++ b/pages/pricing/_support.html
@@ -2,7 +2,7 @@
   <div class="col-xs-12">
     <h2>Need something else?</h2>
     <p>
-      To discuss volume discounts, or custom support needs, please <a href="/contact">contact us</a>.
+      To discuss volume discounts, or custom support needs, please <a href="/contact/">contact us</a>.
     </p>
   </div>
 </div>

--- a/pages/reference-architecture/_pricing.html
+++ b/pages/reference-architecture/_pricing.html
@@ -2,7 +2,7 @@
   <div class="col-xs-12">
     <h2>Pricing</h2>
     <p>
-      Check out the <a href="/pricing">Pricing page</a> for details. Please note that to use the Reference
+      Check out the <a href="/pricing/">Pricing page</a> for details. Please note that to use the Reference
       Architecture, you must be a Gruntwork Subscriber.
     </p>
   </div>

--- a/pages/reference-architecture/_sub-hero.html
+++ b/pages/reference-architecture/_sub-hero.html
@@ -3,10 +3,10 @@
     <h2>A new standard for architecture on AWS</h2>
     <p>
       The Reference Architecture is an opinionated, battle-tested, best-practices way to assemble the code from the
-      <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a> into an end-to-end tech stack that
+      <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a> into an end-to-end tech stack that
       includes just about everything you need: server cluster, load balancer, database, cache, network topology,
       monitoring, alerting, CI/CD, secrets management, VPN, and more (check out the
-      <a href="/devops-checklist">Production Readiness Checklist</a> to see what it takes to go to prod on AWS).
+      <a href="/devops-checklist/">Production Readiness Checklist</a> to see what it takes to go to prod on AWS).
     </p>
     <p>
       We customize the Reference Architecture to your needs, deploy into into your AWS accounts, and give you 100% of

--- a/pages/signup-complete/index.html
+++ b/pages/signup-complete/index.html
@@ -36,7 +36,7 @@ ol li{
             <li>A Grunt will contact you, process your order, and grant your team access to all the code, training, and support in the next 1-2 business days.</li>
             <li>If you purchased a Reference Architecture, we'll be in touch shortly to schedule a deployment date and let you customize all the details.</li>
           </ol>
-          <p>Finally, if you have any questions or feedback, please <a href="/contact">contact us</a> any time! Continuous improvement is a key part of DevOps and we greatly value your feedback.</p>
+          <p>Finally, if you have any questions or feedback, please <a href="/contact/">contact us</a> any time! Continuous improvement is a key part of DevOps and we greatly value your feedback.</p>
           <p>We'll be in touch shortly,</p>
           <p>The Gruntwork Team </p>
           <p><em>P.S. We just emailed these same instructions to you!</em></p>

--- a/pages/training/_more-info.html
+++ b/pages/training/_more-info.html
@@ -1,14 +1,14 @@
 <h2>How do I get access to the DevOps Training Library?</h2>
 <p>
   Access to the DevOps Training Library, including all current courses as well as future updates and additions, is
-  available as part of the Gruntwork Subscription. Check out the <a href="/pricing">pricing page</a> for details.
+  available as part of the Gruntwork Subscription. Check out the <a href="/pricing/">pricing page</a> for details.
 </p>
 <h2>Looking for live, on-site training?</h2>
 <p>
   For teams that want a personalized, accelerated, hands-on way to learn DevOps best practices, check out our
-  <a href="/devops-bootcamp">DevOps Bootcamps</a>.
+  <a href="/devops-bootcamp/">DevOps Bootcamps</a>.
 </p>
 <h2>Looking for resources to learn DevOps?</h2>
 <p>
-  You can find a collection of blog posts, talks, and books about DevOps on our <a href="/devops-resources">DevOps Resources</a> page.
+  You can find a collection of blog posts, talks, and books about DevOps on our <a href="/devops-resources/">DevOps Resources</a> page.
 </p>

--- a/pages/training/_sub-hero.html
+++ b/pages/training/_sub-hero.html
@@ -7,7 +7,7 @@
       "micro-videos" of 1-10 minutes each that you can watch your own pace as many times as you like.
     </p>
     <p>
-      Just as with our <a href="/infrastructure-as-code-library">Infrastructure as Code Library</a>, we regularly
+      Just as with our <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a>, we regularly
       grow and update the DevOps Training Library so that Gruntwork Subscribers are always learning the latest
       techniques and practices.
     </p>


### PR DESCRIPTION
@josh-padnick This PR should take care of the third party calls, and there were some missing styles for cookie modal in the last merge, so added them back. Let me know if there's any further changes to the modal.