### PR TITLE
Add user time zone to contact us form.

### DIFF
--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,33 +1,16 @@
 /**
- * Fetch the user's timezone (expressed in UTC) and write it to the contact us form submission. This is useful because
- * we'll use the user's timezone to assign inbound leads.
+ * Fetch the user's timezone offset relative to UTC and write it to the contact us form submission. This is useful because
+ * we'll use an Assignment Rule in Salesforce.com to automatically assign leads based on the offset value.
  */
 
 (function () {
-
-  // Given an offset in mins, return a well-formatted time zone string.
-  //
-  // Example:
-  //   formatOffset(420)
-  //   returns "UTC+7"
-  function getUtcTimezone(offsetMins) {
-    var offsetHrs = offsetMins / 60;
-
-    if (offsetHrs > 0) {
-      return "UTC+" + offsetHrs;
-    } else if (offsetHrs == 0) {
-      return "UTC(0)";
-    } else {
-      return "UTC" + offsetHrs;
-    }
-  }
 
   // Per https://stackoverflow.com/a/34602679, the main limitation of using Javascript's builtin getTimezoneOffset() to
   // calculate Timezone is that daylight saving rules may change on several occasions during a year. But this doesn't
   // matter for our purposes, where we only need to know the approximate time zone to assign the lead to the right person.
   var offsetMins = new Date().getTimezoneOffset();
-  var utcTimeZone = getUtcTimezone(offsetMins);
+  var offsetHrs = offsetMins / 60;
 
-  $('input#user-timezone').val(utcTimeZone);
+  $('input#user-utc-timezone-offset').val(offsetHrs);
 
 }());

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,37 +1,33 @@
 /**
- * Fetch the user's locale and write it to the contact us form submission. This is useful because we'll use the
- * user's locale to assign inbound leads.
+ * Fetch the user's timezone (expressed in UTC) and write it to the contact us form submission. This is useful because
+ * we'll use the user's timezone to assign inbound leads.
  */
-$(function () {
 
-  // Inspired by https://stackoverflow.com/a/31135571
-  function getUserLocale()
-  {
-    if (navigator.languages !== undefined)
-      return navigator.languages[0];
-    else
-      return navigator.language;
-  }
+(function () {
 
-  // In Safari on macOS and iOS prior to 10.2, the country code returned is lowercase: "en-us", "fr-fr" etc.
-  // This function will take a locale and normalize its country code to "en-US", "fr-FR", etc.
-  function normalizeLocale(localeRaw) {
-    var localeTokens = localeRaw.split("-");
+  // Given an offset in mins, return a well-formatted time zone string.
+  //
+  // Example:
+  //   formatOffset(420)
+  //   returns "UTC+7"
+  function getUtcTimezone(offsetMins) {
+    var offsetHrs = offsetMins / 60;
 
-    var countryCodeRaw = "";
-    var countryCodeNormalized = countryCodeRaw;
-
-    if (localeTokens.length > 1) {
-       countryCodeRaw = localeTokens[1];
-       countryCodeNormalized = countryCodeRaw.toUpperCase();
-       localeTokens[1] = countryCodeNormalized;
+    if (offsetHrs > 0) {
+      return "UTC+" + offsetHrs;
+    } else if (offsetHrs == 0) {
+      return "UTC(0)";
+    } else {
+      return "UTC" + offsetHrs;
     }
-
-    return localeTokens.join("-");
   }
 
-  var localeRaw = getUserLocale();
-  var localeNormalized = normalizeLocale(localeRaw);
+  // Per https://stackoverflow.com/a/34602679, the main limitation of using Javascript's builtin getTimezoneOffset() to
+  // calculate Timezone is that daylight saving rules may change on several occasions during a year. But this doesn't
+  // matter for our purposes, where we only need to know the approximate time zone to assign the lead to the right person.
+  var offsetMins = new Date().getTimezoneOffset();
+  var utcTimeZone = getUtcTimezone(offsetMins);
 
-  $('input#user-locale').val(localeNormalized);
-});
+  $('input#user-timezone').val(utcTimeZone);
+
+}());

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,0 +1,37 @@
+/**
+ * Fetch the user's locale and write it to the contact us form submission. This is useful because we'll use the
+ * user's locale to assign inbound leads.
+ */
+$(function () {
+
+  // Inspired by https://stackoverflow.com/a/31135571
+  function getUserLocale()
+  {
+    if (navigator.languages !== undefined)
+      return navigator.languages[0];
+    else
+      return navigator.language;
+  }
+
+  // In Safari on macOS and iOS prior to 10.2, the country code returned is lowercase: "en-us", "fr-fr" etc.
+  // This function will take a locale and normalize its country code to "en-US", "fr-FR", etc.
+  function normalizeLocale(localeRaw) {
+    var localeTokens = localeRaw.split("-");
+
+    var countryCodeRaw = "";
+    var countryCodeNormalized = countryCodeRaw;
+
+    if (localeTokens.length > 1) {
+       countryCodeRaw = localeTokens[1];
+       countryCodeNormalized = countryCodeRaw.toUpperCase();
+       localeTokens[1] = countryCodeNormalized;
+    }
+
+    return localeTokens.join("-");
+  }
+
+  var localeRaw = getUserLocale();
+  var localeNormalized = normalizeLocale(localeRaw);
+
+  $('input#user-locale').val(localeNormalized);
+});

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -9,7 +9,12 @@
   // calculate Timezone is that daylight saving rules may change on several occasions during a year. But this doesn't
   // matter for our purposes, where we only need to know the approximate time zone to assign the lead to the right person.
   var offsetMins = new Date().getTimezoneOffset();
-  var offsetHrs = offsetMins / 60;
+
+  // Why multiply by -1? Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset#Description:
+  // The time-zone offset is the difference, in minutes, from local time to UTC. Note that this means that the offset is
+  // positive if the // local timezone is behind UTC and negative if it is ahead. For example, for time zone UTC+10:00
+  // (Australian Eastern Standard Time, Vladivostok Time, Chamorro Standard Time), -600 will be returned.
+  var offsetHrs = (offsetMins / 60) * -1;
 
   $('input#user-utc-timezone-offset').val(offsetHrs);
 

--- a/pages/contact/_form.html
+++ b/pages/contact/_form.html
@@ -18,7 +18,7 @@
         {% include_relative _input-check.html id="interested-ref-arch" label="Reference Architecture" %}
         {% include_relative _input-check.html id="interested-devops-bootcamp" label="DevOps Bootcamp" %}
         {% include_relative _input-check.html id="interested-custom-module-development" label="Custom Module Development" %}
-        {% include_relative _input-hidden.html id="user-locale" %}
+        {% include_relative _input-hidden.html id="user-timezone" %}
       </div>
     </div>
   </div>

--- a/pages/contact/_form.html
+++ b/pages/contact/_form.html
@@ -18,7 +18,7 @@
         {% include_relative _input-check.html id="interested-ref-arch" label="Reference Architecture" %}
         {% include_relative _input-check.html id="interested-devops-bootcamp" label="DevOps Bootcamp" %}
         {% include_relative _input-check.html id="interested-custom-module-development" label="Custom Module Development" %}
-        {% include_relative _input-hidden.html id="user-timezone" %}
+        {% include_relative _input-hidden.html id="user-utc-timezone-offset" %}
       </div>
     </div>
   </div>

--- a/pages/contact/_form.html
+++ b/pages/contact/_form.html
@@ -18,6 +18,7 @@
         {% include_relative _input-check.html id="interested-ref-arch" label="Reference Architecture" %}
         {% include_relative _input-check.html id="interested-devops-bootcamp" label="DevOps Bootcamp" %}
         {% include_relative _input-check.html id="interested-custom-module-development" label="Custom Module Development" %}
+        {% include_relative _input-hidden.html id="user-locale" %}
       </div>
     </div>
   </div>

--- a/pages/contact/_input-hidden.html
+++ b/pages/contact/_input-hidden.html
@@ -1,0 +1,5 @@
+<div class="form-group">
+  <div class="row">
+      <input id="{{ include.id }}" name="{{ include.id }}" type="hidden" class="form-control">
+  </div>
+</div>

--- a/pages/contact/_input-hidden.html
+++ b/pages/contact/_input-hidden.html
@@ -1,5 +1,1 @@
-<div class="form-group">
-  <div class="row">
-      <input id="{{ include.id }}" name="{{ include.id }}" type="hidden" class="form-control">
-  </div>
-</div>
+<input id="{{ include.id }}" name="{{ include.id }}" type="hidden" class="form-control">

--- a/pages/contact/index.html
+++ b/pages/contact/index.html
@@ -3,6 +3,8 @@ layout: default
 title: Contact Us
 permalink: /contact/
 slug: contact
+custom_js:
+- contact
 ---
 
 <div class="main">


### PR DESCRIPTION
The overall goal here is to allow Salesforce.com to automatically assign leads to either Rob or Josh based on the timezone the user submits their inquiry from. I originally thought locale was the way to do this, and then I realized that Javascript directly exposes the user's timezone offset, so I went that route.

Now when the contact us form is submitted, it will include a field "User UTC Timezone Offset." That field has also been added to Salesforce, and I've created a [lead assignment rule](https://help.salesforce.com/articleView?id=customize_leadrules.htm&type=5) to automatically assign leads as follows:

- If the user's timezone is > UTC-1 and < UTC+11, it will be assigned to Rob.
- If the user's timezone is > UTC+11 or < UTC-1, it will be assigned to josh

UTC timezones worldwide range from UTC+12 to UTC-12, with the USA ranging from UTC-11 to UTC-4. See https://www.worldtimezone.com/ for a visual map of them. This assignment system should be active within the hour.