### PR TITLE
Move helm-kubernetes-services to open source module

### DIFF
--- a/_data/library-infrastructure-packages.yml
+++ b/_data/library-infrastructure-packages.yml
@@ -67,16 +67,6 @@
     Deploy a best-practices Tiller (Helm Server) to your Kubernetes cluster. Supports namespaces, service accounts,
     least privilege RBAC roles, and automated TLS management.
 
-- name: "Kubernetes Services"
-  tags:
-    - K8S
-  private_beta: true
-  full_url: "https://github.com/gruntwork-io/helm-kubernetes-services"
-  description: |
-    Package services into a best-practices deployment for Kubernetes. Supports zero-downtime, rolling deployment, RBAC
-    roles and groups, auto scaling, secrets management, and centralized logging. Includes support for web services,
-    daemon sets, and tasks / jobs.
-
 - name: "Auto Scaling Group"
   tags:
     - AWS

--- a/_data/library-infrastructure-packages.yml
+++ b/_data/library-infrastructure-packages.yml
@@ -61,7 +61,6 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
-  private_beta: true
   full_url: "https://github.com/gruntwork-io/terraform-kubernetes-helm"
   description: |
     Deploy a best-practices Tiller (Helm Server) to your Kubernetes cluster. Supports namespaces, service accounts,

--- a/_data/library-terraform-modules.yml
+++ b/_data/library-terraform-modules.yml
@@ -1,3 +1,12 @@
+- name: "Kubernetes Services"
+  tags:
+    - K8S
+  k8s_url: "https://github.com/gruntwork-io/helm-kubernetes-services"
+  description: |
+    Package services into a best-practices deployment for Kubernetes. Supports zero-downtime, rolling deployment, RBAC
+    roles and groups, auto scaling, secrets management, and centralized logging. Includes support for web services,
+    daemon sets, and tasks / jobs.
+
 - name: "Consul"
   tags:
     - AWS

--- a/pages/infrastructure-as-code-library/_library.html
+++ b/pages/infrastructure-as-code-library/_library.html
@@ -56,6 +56,7 @@
             View Repo: {% if package.aws_url %}<a href="{{ package.aws_url }}">AWS</a>{% endif %}
             {% if package.gcp_url %} | <a href="{{ package.gcp_url }}">GCP</a>{% endif %}
             {% if package.azure_url %} | <a href="{{ package.azure_url }}">Azure</a>{% endif %}
+            {% if package.k8s_url %} <a href="{{ package.k8s_url }}">K8S</a>{% endif %}
           </p>
         </div>
         <div class="row">


### PR DESCRIPTION
I just realized `helm-kubernetes-services` is still labeled as a private beta repo, which is no longer true. So I moved it to the open source section.

That said, I am not sure if this is the best way to do this, since now it is not together with the EKS and Helm stuff. Let me know if you think this should be handled differently.