### PR TITLE
Add link to refarch blog post

### DIFF
--- a/pages/reference-architecture/_sub-hero.html
+++ b/pages/reference-architecture/_sub-hero.html
@@ -7,6 +7,8 @@
       includes just about everything you need: server cluster, load balancer, database, cache, network topology,
       monitoring, alerting, CI/CD, secrets management, VPN, and more (check out the
       <a href="/devops-checklist/">Production Readiness Checklist</a> to see what it takes to go to prod).
+      Learn more about what is included in the Reference Architecture in our blog post
+      <a href="https://blog.gruntwork.io/how-to-build-an-end-to-end-production-grade-architecture-on-aws-part-1-eae8eeb41fec">How to Build an End to End Production-Grade Architecture on AWS</a>.
     </p>
     <p>
       We customize the Reference Architecture to your needs, deploy into your AWS or GCP accounts, and give you 100% of

--- a/pages/reference-architecture/_whats-included.html
+++ b/pages/reference-architecture/_whats-included.html
@@ -8,5 +8,8 @@
       {% include_relative _panel.html id="security" title="Security" features=site.data.reference-architecture.security expanded="false" %}
       {% include_relative _panel.html id="design" title="Design" features=site.data.reference-architecture.design expanded="false" %}
     </div>
+    <p class="text-muted"><em>
+       Read our blog post <a href="https://blog.gruntwork.io/how-to-build-an-end-to-end-production-grade-architecture-on-aws-part-1-eae8eeb41fec">How to Build an End to End Production-Grade Architecture on AWS</a> for an overview of what is included.
+    </em></p>
   </div>
 </div>


### PR DESCRIPTION
This adds a link to the new ref arch blog post in our ref arch product page. Let me know if you imagined the link should live somewhere else!