### PR TITLE
Update support page to reflect previous update to Terms of Service

### DIFF
--- a/_data/support-benefits.yml
+++ b/_data/support-benefits.yml
@@ -25,11 +25,6 @@
   description: |
     <p>Send us questions via email and track them through our support portal.</p>
 
-- title: Chat with us live in phone/video calls
-  description: |
-    <p>When we both agree that we can't resolve an issue via email, Slack, or schedule a support call
-    with us to discuss your issue real-time.</p>
-
 - title: Get access to the Gruntwork Community Slack channel
   description: |
     <p>Subscribers get access to the Gruntwork Community Slack channel where you can talk with the other Gruntwork customers and occasionally Gruntwork engineers. Since you are all using the same infrastructure, this is a great place to ask questions, discuss design decisions, and work together as a community to improve infrastructure and DevOps practices.</p>

--- a/pages/support/_enterprise-support.html
+++ b/pages/support/_enterprise-support.html
@@ -2,8 +2,15 @@
   <div class="col-xs-12">
     <h2>Enterprise Support</h2>
     <p>
-      Gruntwork also offers an enterprise support plan that includes design reviews, code reviews, prioritized bug fixes
-      and same-day response times. For more information, please <a href="/contact">contact us</a>.
+      Gruntwork also offers an enterprise support plan that includes:
+      <ul>
+        <li>Live chat in phone/video calls</li>
+        <li>Design reviews</li>
+        <li>Code reviews</li>
+        <li>Prioritized bug fixes</li>
+        <li>Guaranteed same-day response times</li>
+      </ul>
+      For more information, please <a href="/contact">contact us</a>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
- Removed live/video chat, which should only be available with enterprise plans
- Light update to enterprise support formatting