### PR TITLE
Refactor docker-compose to make it much faster

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,23 @@
-web:
-  build: .
-  volumes:
-    - .:/src
-  ports:
-    - "4000:4000"
-  environment:
-    - JEKYLL_ENV=development
-    # Pass your AWS credentials as env vars through to the Docker container for uploading the website to S3
-    - AWS_ACCESS_KEY_ID
-    - AWS_SECRET_ACCESS_KEY
-    - AWS_SESSION_TOKEN
+version: '3'
+
+services:
+  web:
+    build: .
+    volumes:
+      # Bind mount the working dir so the app reloads automatically every time you make a change
+      # Note that we use 'delegated' to improve perf on OSX: https://docs.docker.com/docker-for-mac/osxfs-caching/     
+      - .:/src:delegated
+      # Bind a Docker-only volume to the generated _site folder to make it clear we don't need to sync that folder
+      # back to the host OS. That makes Jekyll in Docker work much faster. 
+      - generated_site:/src/_site
+    ports:
+      - "4000:4000"
+    environment:
+      - JEKYLL_ENV=development
+      # Pass your AWS credentials as env vars through to the Docker container for uploading the website to S3
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+
+volumes:
+  generated_site:


### PR DESCRIPTION
@oredavids Brought up that using Jekyll + Docker was running very slowly for him: https://github.com/gruntwork-io/gruntwork-io.github.io/pull/132#discussion_r309643279

In local experiments, I was able to speed up my local dev speed by 5-10x: 14 second boot -> 2 second boot, 3 second hot reload -> 0.7 second hot reload.

1. Install the latest version of Docker: 2.1.0.0. This seemed to shave a couple seconds off Jekyll boot time.
1. Add `:delegated` to the bind mount. This also shaved a few seconds off boot time.
1. Use a docker-only volume for the generated `_site` folder. This shaved a few more seconds off the time.