### PR TITLE
Fix links on guides

### DIFF
--- a/_posts/2019-05-08-Deploying-a-Dockerized-app-on-GCP-GKE.md
+++ b/_posts/2019-05-08-Deploying-a-Dockerized-app-on-GCP-GKE.md
@@ -6,7 +6,7 @@ image: /assets/img/guides/kubernetics_image.png
 excerpt: Before we can deploy a dockerized app, we need to first create one. For the purposes of this guide we will create a basic Node.js app that responds to requests on port 8080.
 tags: ["gcp", "gke", "docker"]
 date: 2019-05-08
-categories: Kubernetics
+categories: Kubernetes
 cloud: gcp
 toc: true
 ---

--- a/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
+++ b/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
@@ -1,5 +1,5 @@
 ---
-categories: Docker
+categories: Foundations
 image: /assets/img/guides/aws-account/aws-logo.png
 excerpt: Learn about why you need multiple AWS accounts, AWS Organizations, IAM Users, IAM Roles, IAM Policies, CloudTrail, and more.
 tags: [aws, terraform]

--- a/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
+++ b/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
@@ -52,7 +52,8 @@ This guide consists of four main sections:
 
 <<production_grade_design>>::
   An overview of how to configure a secure, scalable, highly available AWS account structure that you can rely on in
-  production. To get a sense of what production-grade means, check out <<production_grade_infra_checklist>>.
+  production. To get a sense of what production-grade means, check out
+  link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#production_grade_infra_checklist[The production-grade infrastructure checklist].
 
 <<deployment_walkthrough>>::
   A step-by-step guide to configuring a production-grade AWS account structure using code from the Gruntwork Service
@@ -643,7 +644,7 @@ No MFA::
   services. For example, if you have Jenkins running on an EC2 instance, and you give that EC2 instance access to an
   IAM role so it can deploy your apps, you should do your best to minimize the permissions that IAM role has (e.g.,
   to just `ecs` permissions if deploying to ECS) and you should ensure that your Jenkins instance runs in private
-  subnets so that it is NOT accessible from the public Internet (see <<production_grade_vpc_aws>>).
+  subnets so that it is NOT accessible from the public Internet (see link:/guides/networking/how-to-deploy-production-grade-vpc-aws[How to deploy a production-grade VPC on AWS]).
 
 Use the right Principal::
   The trust policy in service IAM roles will need to specify the appropriate `Principal` to allow an AWS service to
@@ -769,13 +770,13 @@ Gruntwork Service Catalog::
 +
 IMPORTANT: You must be a https://gruntwork.io/[Gruntwork subscriber] to access this code.
 +
-Make sure to read <<how_to_use_gruntwork_service_catalog>>.
+Make sure to read link:/guides/gruntwork/how-to-use-gruntwork-service-catalog[How to use the Gruntwork Service Catalog].
 
 Terraform::
   This guide uses https://www.terraform.io/[Terraform] to define and manage all the infrastructure as code. If you're
   not familiar with Terraform, check out https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca[A
   Comprehensive Guide to Terraform], https://training.gruntwork.io/p/terraform[A Crash Course on Terraform], and
-  <<how_to_use_gruntwork_service_catalog>>.
+  link:/guides/gruntwork/how-to-use-gruntwork-service-catalog[How to use the Gruntwork Service Catalog].
 
 Keybase (optional)::
   As part of this guide, you will create IAM users, including, optionally, credentials for those IAM users. If you
@@ -809,8 +810,9 @@ IMPORTANT: You must be a https://gruntwork.io/[Gruntwork subscriber] to access `
 
 NOTE: This guide will use https://github.com/gruntwork-io/terragrunt[Terragrunt] and its associated file and folder
 structure to deploy Terraform modules. Please note that *Terragrunt is NOT required for using Terraform modules from
-the Gruntwork Service Catalog.* Check out <<how_to_use_gruntwork_service_catalog>> for instructions on alternative
-options, such as how to <<deploy_using_plain_terraform>>.
+the Gruntwork Service Catalog.* Check out link:/guides/gruntwork/how-to-use-gruntwork-service-catalog[How to use the Gruntwork Service Catalog]
+for instructions on alternative options, such as how to
+link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#deploy_using_plain_terraform[deploying how to use plain terraform].
 
 First, create a _wrapper module_ called `iam` in your `infrastructure-modules` repo:
 
@@ -1187,8 +1189,10 @@ output "user_passwords" {
 }
 ----
 
-At this point, you'll want to test your code. See <<manual_tests_terraform>> and <<automated_tests_terraform>> for
-instructions.
+At this point, you'll want to test your code. See
+link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#manual_tests_terraform[Manual tests for Terraform code] and
+link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#automated_tests_terraform[Automated tests for Terraform code]
+for instructions.
 
 Once your code is tested and working, commit and release your changes:
 
@@ -1526,8 +1530,10 @@ variable "force_destroy" {
 }
 ----
 
-At this point, you'll want to test your code. See <<manual_tests_terraform>> and <<automated_tests_terraform>> for
-instructions.
+At this point, you'll want to test your code. See
+link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#manual_tests_terraform[Manual tests for Terraform code] and
+link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#automated_tests_terraform[Automated tests for Terraform code]
+for instructions.
 
 Once tests are passing, commit and release your changes:
 
@@ -1740,8 +1746,10 @@ output "organizations_account_access_role_name" {
 }
 ----
 
-At this point, you'll want to test your code. See <<manual_tests_terraform>> and <<automated_tests_terraform>> for
-instructions.
+At this point, you'll want to test your code. See
+link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#manual_tests_terraform[Manual tests for Terraform code] and
+link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#automated_tests_terraform[Automated tests for Terraform code]
+for instructions.
 
 When you're done testing, commit and release your changes:
 
@@ -2312,4 +2320,4 @@ Remember to repeat this process in the other child accounts too!
 
 Now that you have your basic AWS account structure set up, the next step is to start deploying infrastructure in those
 accounts! Usually, the best starting point is to configure your network topology, as described in
-<<production_grade_vpc_aws>>.
+link:/guides/networking/how-to-deploy-production-grade-vpc-aws[How to deploy a production-grade VPC on AWS].

--- a/_posts/2019-08-13-how-to-deploy-production-grade-vpc-aws.adoc
+++ b/_posts/2019-08-13-how-to-deploy-production-grade-vpc-aws.adoc
@@ -48,7 +48,7 @@ This guide consists of four main sections:
 
 <<production_grade_design>>::
   An overview of how to configure a secure, scalable, highly available VPC that you can rely on in production. To get a
-  sense of what production-grade means, check out <<production_grade_infra_checklist>>.
+  sense of what production-grade means, check out link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#production_grade_infra_checklist[The production-grade infrastructure checklist].
 
 <<deployment_walkthrough>>::
   A step-by-step guide to deploying a production-grade VPC in AWS using code from the Gruntwork Service Catalog.
@@ -438,7 +438,7 @@ change something in prod rather than pre-prod).
 
 Therefore, your best bet is to put pre-production environments and production environments in completely separate AWS
 accounts. This makes it easy to, for example, grant relatively lax permissions in pre-prod environments, but very
-strict permissions in production. Check out the  link:../foundations/how-to-configure-production-grade-aws-account-structure[Production Grade AWS Account Structure]
+strict permissions in production. Check out the  link:/guides/foundations/how-to-configure-production-grade-aws-account-structure[Production Grade AWS Account Structure]
 guide for instructions.
 
 [[multiple_vpcs]]
@@ -605,17 +605,17 @@ Gruntwork Service Catalog::
 +
 IMPORTANT: You must be a https://gruntwork.io/[Gruntwork subscriber] to access this code.
 +
-Make sure to read link:../gruntwork/how-to-use-gruntwork-service-catalog[How to Use the Gruntwork Service Catalog].
+Make sure to read link:/guides/gruntwork/how-to-use-gruntwork-service-catalog[How to Use the Gruntwork Service Catalog].
 
 Terraform::
   This guide uses https://www.terraform.io/[Terraform] to define and manage all the infrastructure as code. If you're
   not familiar with Terraform, check out https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca[A
   Comprehensive Guide to Terraform], https://training.gruntwork.io/p/terraform[A Crash Course on Terraform], and
-  link:../gruntwork/how-to-use-gruntwork-service-catalog[How to Use the Gruntwork Service Catalog]
+  link:/guides/gruntwork/how-to-use-gruntwork-service-catalog[How to Use the Gruntwork Service Catalog]
 
 AWS accounts::
   This guide deploys infrastructure into one or more AWS accounts. Check out the
-  link:../foundations/how-to-configure-production-grade-aws-account-structure[Production Grade AWS Account Structure] guide for instructions.
+  link:/guides/foundations/how-to-configure-production-grade-aws-account-structure[Production Grade AWS Account Structure] guide for instructions.
   You will also need to be able to authenticate to these accounts on the CLI: check out
   https://blog.gruntwork.io/a-comprehensive-guide-to-authenticating-to-aws-on-the-command-line-63656a686799[A Comprehensive Guide to Authenticating to AWS on the Command Line]
   for instructions.
@@ -642,9 +642,9 @@ IMPORTANT: You must be a https://gruntwork.io/[Gruntwork subscriber] to access `
 
 NOTE: This guide will use https://github.com/gruntwork-io/terragrunt[Terragrunt] and its associated file and folder
 structure to deploy Terraform modules. Please note that *Terragrunt is NOT required for using Terraform modules from
-the Gruntwork Service Catalog.* Check out link:../gruntwork/how-to-use-gruntwork-service-catalog[How to Use the Gruntwork Service Catalog]
+the Gruntwork Service Catalog.* Check out link:/guides/gruntwork/how-to-use-gruntwork-service-catalog[How to Use the Gruntwork Service Catalog]
 for instructions on alternative options, such as how to
-link:../gruntwork/how-to-use-gruntwork-service-catalog#deploy_using_plain_terraform[deploy using plain terraform].
+link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#deploy_using_plain_terraform[deploy using plain terraform].
 
 To deploy the `vpc-mgmt` module, create a _wrapper module_ called `vpc-mgmt` in your `infrastructure-modules` repo:
 
@@ -735,8 +735,8 @@ file for reference.
 [[test_wrapper_module]]
 ==== Test your wrapper module
 
-At this point, you'll want to test your code. See link:../gruntwork/how-to-use-gruntwork-service-catalog#manual_tests_terraform[Manual tests for Terraform code]
-and link:../gruntwork/how-to-use-gruntwork-service-catalog#automated_tests_terraform[Automated tests for Terraform code]
+At this point, you'll want to test your code. See link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#manual_tests_terraform[Manual tests for Terraform code]
+and link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#automated_tests_terraform[Automated tests for Terraform code]
 for instructions.
 
 [[merge_release_wrapper_module]]
@@ -1020,8 +1020,8 @@ file for reference.
 [[test_wrapper_module_app]]
 ==== Test your wrapper module
 
-At this point, you'll want to test your code. See link:../gruntwork/how-to-use-gruntwork-service-catalog#manual_tests_terraform[Manual tests for Terraform code]
-and link:../gruntwork/how-to-use-gruntwork-service-catalog#automated_tests_terraform[Automated tests for Terraform code]
+At this point, you'll want to test your code. See link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#manual_tests_terraform[Manual tests for Terraform code]
+and link:/guides/gruntwork/how-to-use-gruntwork-service-catalog#automated_tests_terraform[Automated tests for Terraform code]
 for instructions.
 
 [[merge_release_wrapper_module_app]]
@@ -1126,7 +1126,7 @@ Now that you have your management and application VPCs deployed, you can start b
 on top of them! Typically, the best next step is to deploy a cluster of servers for running your applications by using
 one of the following guides:
 
-. link:../docker/how-to-deploy-production-grade-kubernetes-cluster-aws[How to deploy a production-grade Kubernetes cluster on AWS]
+. link:/guides/docker/how-to-deploy-production-grade-kubernetes-cluster-aws[How to deploy a production-grade Kubernetes cluster on AWS]
 . `How to deploy a production grade ECS cluster on AWS` _(coming soon!)_
 . `How to deploy a production grade Nomad cluster on AWS` _(coming soon!)_
 . `How to deploy a production grade Auto Scaling Group on AWS` _(coming soon!)_

--- a/_posts/2019-08-13-how-to-deploy-production-grade-vpc-aws.adoc
+++ b/_posts/2019-08-13-how-to-deploy-production-grade-vpc-aws.adoc
@@ -438,7 +438,8 @@ change something in prod rather than pre-prod).
 
 Therefore, your best bet is to put pre-production environments and production environments in completely separate AWS
 accounts. This makes it easy to, for example, grant relatively lax permissions in pre-prod environments, but very
-strict permissions in production. Check out the <<production_grade_aws_account_structure>> guide for instructions.
+strict permissions in production. Check out the  link:../foundations/how-to-configure-production-grade-aws-account-structure[Production Grade AWS Account Structure]
+guide for instructions.
 
 [[multiple_vpcs]]
 === Multiple VPCs
@@ -604,18 +605,18 @@ Gruntwork Service Catalog::
 +
 IMPORTANT: You must be a https://gruntwork.io/[Gruntwork subscriber] to access this code.
 +
-Make sure to read <<how_to_use_gruntwork_service_catalog>>.
+Make sure to read link:../gruntwork/how-to-use-gruntwork-service-catalog[How to Use the Gruntwork Service Catalog].
 
 Terraform::
   This guide uses https://www.terraform.io/[Terraform] to define and manage all the infrastructure as code. If you're
   not familiar with Terraform, check out https://blog.gruntwork.io/a-comprehensive-guide-to-terraform-b3d32832baca[A
   Comprehensive Guide to Terraform], https://training.gruntwork.io/p/terraform[A Crash Course on Terraform], and
-  <<how_to_use_gruntwork_service_catalog>>.
+  link:../gruntwork/how-to-use-gruntwork-service-catalog[How to Use the Gruntwork Service Catalog]
 
 AWS accounts::
   This guide deploys infrastructure into one or more AWS accounts. Check out the
-  <<production_grade_aws_account_structure>> guide for instructions. You will also need to be able to authenticate to
-  these accounts on the CLI: check out
+  link:../foundations/how-to-configure-production-grade-aws-account-structure[Production Grade AWS Account Structure] guide for instructions.
+  You will also need to be able to authenticate to these accounts on the CLI: check out
   https://blog.gruntwork.io/a-comprehensive-guide-to-authenticating-to-aws-on-the-command-line-63656a686799[A Comprehensive Guide to Authenticating to AWS on the Command Line]
   for instructions.
 
@@ -641,8 +642,9 @@ IMPORTANT: You must be a https://gruntwork.io/[Gruntwork subscriber] to access `
 
 NOTE: This guide will use https://github.com/gruntwork-io/terragrunt[Terragrunt] and its associated file and folder
 structure to deploy Terraform modules. Please note that *Terragrunt is NOT required for using Terraform modules from
-the Gruntwork Service Catalog.* Check out <<how_to_use_gruntwork_service_catalog>> for instructions on alternative
-options, such as how to <<deploy_using_plain_terraform>>.
+the Gruntwork Service Catalog.* Check out link:../gruntwork/how-to-use-gruntwork-service-catalog[How to Use the Gruntwork Service Catalog]
+for instructions on alternative options, such as how to
+link:../gruntwork/how-to-use-gruntwork-service-catalog#deploy_using_plain_terraform[deploy using plain terraform].
 
 To deploy the `vpc-mgmt` module, create a _wrapper module_ called `vpc-mgmt` in your `infrastructure-modules` repo:
 
@@ -733,8 +735,9 @@ file for reference.
 [[test_wrapper_module]]
 ==== Test your wrapper module
 
-At this point, you'll want to test your code. See <<manual_tests_terraform>> and <<automated_tests_terraform>> for
-instructions.
+At this point, you'll want to test your code. See link:../gruntwork/how-to-use-gruntwork-service-catalog#manual_tests_terraform[Manual tests for Terraform code]
+and link:../gruntwork/how-to-use-gruntwork-service-catalog#automated_tests_terraform[Automated tests for Terraform code]
+for instructions.
 
 [[merge_release_wrapper_module]]
 ==== Merge and release your wrapper module
@@ -1017,8 +1020,9 @@ file for reference.
 [[test_wrapper_module_app]]
 ==== Test your wrapper module
 
-At this point, you'll want to test your code. See <<manual_tests_terraform>> and <<automated_tests_terraform>> for
-instructions.
+At this point, you'll want to test your code. See link:../gruntwork/how-to-use-gruntwork-service-catalog#manual_tests_terraform[Manual tests for Terraform code]
+and link:../gruntwork/how-to-use-gruntwork-service-catalog#automated_tests_terraform[Automated tests for Terraform code]
+for instructions.
 
 [[merge_release_wrapper_module_app]]
 ==== Merge and release your wrapper module

--- a/_posts/2019-08-26-how-to-use-gruntwork-service-catalog.adoc
+++ b/_posts/2019-08-26-how-to-use-gruntwork-service-catalog.adoc
@@ -585,7 +585,7 @@ we'll deploy the `vpc-app`  Terraform module from https://github.com/gruntwork-i
 IMPORTANT: You must be a https://gruntwork.io/[Gruntwork subscriber] to access `module-vpc`.
 
 You can use this module to deploy a production-grade VPC on AWS. For full background information on VPCs, check
-out link:../networking/how-to-deploy-production-grade-vpc-aws[How to deploy a production-grade VPC on AWS].
+out link:/guides/networking/how-to-deploy-production-grade-vpc-aws[How to deploy a production-grade VPC on AWS].
 
 ==== Create a wrapper module
 
@@ -640,7 +640,7 @@ Pin AWS account IDs::
   variable (you'll declare this shortly). This is an extra safety measure to ensure you don't accidentally authenticate
   to the wrong AWS account while deploying this code—e.g., so you don't accidentally deploy changes intended for
   staging to production (for more info on working with multiple AWS accounts, see
-  link:../foundations/how-to-configure-production-grade-aws-account-structure[How to Configure a Production Grade AWS Account Structure].
+  link:/guides/foundations/how-to-configure-production-grade-aws-account-structure[How to Configure a Production Grade AWS Account Structure].
 
 Let's add the corresponding input variables in `variables.tf`:
 
@@ -1188,7 +1188,7 @@ Where:
   balancers, and so on. Each module is configured via a `terragrunt.hcl` file.
 
 For example, if you were using AWS, with separate accounts for staging and production (see
-link:../foundations/how-to-configure-production-grade-aws-account-structure[How to Configure a Production Grade AWS Account Structure]),
+link:/guides/foundations/how-to-configure-production-grade-aws-account-structure[How to Configure a Production Grade AWS Account Structure]),
 and you wanted to deploy the `vpc-app` module in the `us-east-2` region in
 each of these accounts, the folder structure would look like this:
 
@@ -1958,5 +1958,5 @@ Need Windows support?::
 Now that you've learned how to use the Gruntwork Service Catalog, you can start leveraging it to build your
 infrastructure! Here are some good first steps:
 
-. link:../foundations/how-to-configure-production-grade-aws-account-structure[How to Configure a Production Grade AWS Account Structure]
+. link:/guides/foundations/how-to-configure-production-grade-aws-account-structure[How to Configure a Production Grade AWS Account Structure]
 . `How to deploy a production grade Kubernetes (EKS) cluster in AWS` _(coming soon!)_

--- a/_posts/2019-08-26-how-to-use-gruntwork-service-catalog.adoc
+++ b/_posts/2019-08-26-how-to-use-gruntwork-service-catalog.adoc
@@ -1,5 +1,5 @@
 ---
-categories: Docker
+categories: Gruntwork
 image: /assets/img/guides/service-catalog/grunty-blocks.png
 excerpt: Learn about production-grade infrastructure, Terraform, Terragrunt, Packer, Docker, immutable infrastructure, versioning for infrastructure code, automated tests for infrastructure code, and more.
 tags: [aws, gcp, terraform, terragrunt]
@@ -206,8 +206,7 @@ Opinionated code::
   save months on having to wire everything together and deploy it yourself. If the opinionated design is not a good
   fit, then you can use the Gruntwork Service Catalog directly instead.
 
-[[example_ref_arch]]
-See an example Reference Architecture::
+[[example_ref_arch]]See an example Reference Architecture::
   You can find the code for an example Reference Architecture for a fictional Acme corporation in the following repos:
 +
 IMPORTANT: You must be a https://gruntwork.io/[Gruntwork subscriber] to access these example repos.
@@ -571,8 +570,8 @@ The next step is to get access to the Gruntwork Service Catalog.
 The next step is to find the modules you want to use. Head over to the
 https://gruntwork.io/infrastructure-as-code-library/[Gruntwork Service Catalog] and find the repos that you wish to
 use. Browse the `modules` folder each the repo to see what modules are available and the `examples` folders to see the
-various ways to combine those modules. You can also browse the <<example_ref_arch>> to find production-ready sample
-code to use as examples.
+various ways to combine those modules. You can also browse the <<example_ref_arch, example Reference Architecture>>
+to find production-ready sample code to use as examples.
 
 Within the Service Catalog, you'll find two types of modules: (1) Terraform modules and (2) scripts and binaries. The
 next two sections of the guide will walk you through how to use each of these.
@@ -586,7 +585,7 @@ we'll deploy the `vpc-app`  Terraform module from https://github.com/gruntwork-i
 IMPORTANT: You must be a https://gruntwork.io/[Gruntwork subscriber] to access `module-vpc`.
 
 You can use this module to deploy a production-grade VPC on AWS. For full background information on VPCs, check
-out <<production_grade_vpc_aws>>.
+out link:../networking/how-to-deploy-production-grade-vpc-aws[How to deploy a production-grade VPC on AWS].
 
 ==== Create a wrapper module
 
@@ -641,7 +640,7 @@ Pin AWS account IDs::
   variable (you'll declare this shortly). This is an extra safety measure to ensure you don't accidentally authenticate
   to the wrong AWS account while deploying this code—e.g., so you don't accidentally deploy changes intended for
   staging to production (for more info on working with multiple AWS accounts, see
-  <<production_grade_aws_account_structure>>).
+  link:../foundations/how-to-configure-production-grade-aws-account-structure[How to Configure a Production Grade AWS Account Structure].
 
 Let's add the corresponding input variables in `variables.tf`:
 
@@ -1189,7 +1188,8 @@ Where:
   balancers, and so on. Each module is configured via a `terragrunt.hcl` file.
 
 For example, if you were using AWS, with separate accounts for staging and production (see
-<<production_grade_aws_account_structure>>), and you wanted to deploy the `vpc-app` module in the `us-east-2` region in
+link:../foundations/how-to-configure-production-grade-aws-account-structure[How to Configure a Production Grade AWS Account Structure]),
+and you wanted to deploy the `vpc-app` module in the `us-east-2` region in
 each of these accounts, the folder structure would look like this:
 
 ----
@@ -1958,6 +1958,5 @@ Need Windows support?::
 Now that you've learned how to use the Gruntwork Service Catalog, you can start leveraging it to build your
 infrastructure! Here are some good first steps:
 
-. <<production_grade_aws_account_structure>>
+. link:../foundations/how-to-configure-production-grade-aws-account-structure[How to Configure a Production Grade AWS Account Structure]
 . `How to deploy a production grade Kubernetes (EKS) cluster in AWS` _(coming soon!)_
-

--- a/_posts/2019-09-03-how-to-deploy-production-grade-kubernetes-cluster-aws.adoc
+++ b/_posts/2019-09-03-how-to-deploy-production-grade-kubernetes-cluster-aws.adoc
@@ -19,9 +19,8 @@ ifdef::env-github[]
 :important-caption: :heavy_exclamation_mark:
 :caution-caption: :fire:
 :warning-caption: :warning:
-endif::[]
-
 toc::[]
+endif::[]
 
 == Intro
 

--- a/_posts/2019-09-03-how-to-deploy-production-grade-kubernetes-cluster-aws.adoc
+++ b/_posts/2019-09-03-how-to-deploy-production-grade-kubernetes-cluster-aws.adoc
@@ -1,9 +1,14 @@
-[[how_to_deploy_prod_grade_kubernetes_cluster_aws]]
+---
+categories: Kubernetes
+image: /assets/img/guides/eks/amazon-eks-logo.png
+excerpt: Learn about EKS, the Kubernetes control plane, worker nodes, auto scaling, auto healing, TLS certs, VPC tagging, DNS forwarding, RBAC, and more.
+tags: [aws, kubernetes, eks]
+cloud: aws
+---
 = How to deploy a production-grade Kubernetes cluster on AWS
-:type: guide
-:description: Learn about EKS, the Kubernetes control plane, worker nodes, auto scaling, auto healing, TLS certs, VPC tagging, DNS forwarding, RBAC, and more.
-:image: ../assets/img/guides/eks/amazon-eks-logo.png
-:tags: aws, kubernetes, eks
+:page-type: guide
+:page-layout: post
+:page-title: How to deploy a production-grade Kubernetes cluster on AWS
 :toc:
 :toc-placement!:
 
@@ -83,7 +88,7 @@ Feel free to read the guide from start to finish or skip around to whatever part
 === Why Kubernetes
 
 .The popularity of container orchestration tools
-image::../assets/img/guides/eks/docker-orchestration-google-trends.png[]
+image::/assets/img/guides/eks/docker-orchestration-google-trends.png[]
 
 Kubernetes has become the de facto choice for container orchestration. Here's why:
 
@@ -116,7 +121,7 @@ Let's start by looking at Kubernetes from a very high level, and then gradually 
 level, a simple way to think about Kubernetes is as an operating system for your data center.
 
 .Kubernetes is like an operating system for your data center, abstracting away the underlying hardware behind its API
-image::../assets/img/guides/eks/kubernetes-simple.png[]
+image::/assets/img/guides/eks/kubernetes-simple.png[]
 
 Operating system for a single computer::
   On a single computer, the operating system (e.g., Windows, Linux, macOS) abstracts away all the low-level hardware
@@ -144,7 +149,7 @@ of containers up and down with load, and so on.
 If you zoom in a bit further on the Kubernetes architecture, it looks something like this:
 
 .Kubernetes architecture
-image::../assets/img/guides/eks/kubernetes-architecture.png[]
+image::/assets/img/guides/eks/kubernetes-architecture.png[]
 
 Kubernetes consists of two main pieces: the control plane and worker nodes. Each of these will be discussed next.
 
@@ -276,7 +281,7 @@ switch between contexts—and therefore, different clusters and users.
 ==== Web UI (Dashboard)
 
 .The Kubernetes Dashboard
-image::../assets/img/guides/eks/kubernetes-dashboard.png[]
+image::/assets/img/guides/eks/kubernetes-dashboard.png[]
 
 The _https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/[Kubernetes Dashboard]_ is a
 web-based interface you can use to manage your Kubernetes cluster. The dashboard is not enabled by default in most
@@ -507,7 +512,7 @@ With all the core concepts out of the way, let's now discuss how to configure a 
 that looks something like this:
 
 .EKS architecture
-image::../assets/img/guides/eks/eks-architecture.png[]
+image::/assets/img/guides/eks/eks-architecture.png[]
 
 === Use EKS
 
@@ -873,7 +878,7 @@ link:/guides/networking/how-to-configure-production-grade-vpc-aws[How to deploy 
 `module-vpc` to create a VPC setup that looks like this:
 
 .A production-grade VPC setup deployed using module-vpc from the Gruntwork Service Catalog
-image::../assets/img/guides/vpc/vpc-diagram.png[]
+image::/assets/img/guides/vpc/vpc-diagram.png[]
 
 After following this guide, you should have `vpc-app` wrapper module in your `infrastructure-modules` repo:
 


### PR DESCRIPTION
Interdocs link are not support in ascdoc in jekyll (nor on github). Nothing happened when clicking them. This PR fixes these links, along with some other internal anchor links that were also not properly formatted and properly categorizing the current posts. 

***This PR is important if you're writing or importing any guides*** 

### Example of how the fix looks visually
#### before:
<img width="891" alt="Screen Shot 2019-09-09 at 11 44 55" src="https://user-images.githubusercontent.com/1516418/64526563-8fa39f00-d2fb-11e9-8fd1-faaa00ac4fb3.png">

#### after:
<img width="887" alt="Screen Shot 2019-09-09 at 12 11 45" src="https://user-images.githubusercontent.com/1516418/64526564-916d6280-d2fb-11e9-99f5-b31a94a3b51f.png">

### Questions
Should we add quotes around these? 
