### PR TITLE
Fix callouts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,9 +19,9 @@ custom_js:
         <a href="/guides" ga-event-category="guide-{{ post.title | downcase}}" ga-event-action="deployment-guides">Production Deployment Guides</a> 
         {% for crumb in crumbs offset: 2 %}
           {% if forloop.last %}
-           <a href="#"> / <span> {{ crumb | replace:'-',' ' | capitalize }}</span></a>
+           <a href="#"> / <span> {{ page.title | replace:'-',' ' }}</span></a>
           {% else %}
-            <a href="/guides#{{ crumb }}" >/ <span class="active">{{ crumb | replace:'-',' ' | capitalize }}</span></a>
+            <a href="/guides#{{ crumb }}" >/ <span>{{ crumb | replace:'-',' ' | capitalize }}</span></a>
           {% endif %}
         {% endfor %}      
       </ol>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,17 +14,17 @@ custom_js:
       </div>
     </div>
     <div class="col-md-7 guides-section-white">
-      <ol class="breadcrumb text-center">
-        {% assign crumbs = page.url | split: '/' %}
-        <a href="/guides" ga-event-category="guide-{{ post.title | downcase}}" ga-event-action="deployment-guides">Production Deployment Guides</a> 
-        {% for crumb in crumbs offset: 2 %}
-          {% if forloop.last %}
-           <a href="#"> / <span> {{ page.title | replace:'-',' ' }}</span></a>
-          {% else %}
-            <a href="/guides#{{ crumb }}" >/ <span>{{ crumb | replace:'-',' ' | capitalize }}</span></a>
-          {% endif %}
-        {% endfor %}      
-      </ol>
+        <ol class="breadcrumb text-center">
+          {% assign crumbs = page.url | split: '/' %}
+          <a href="/guides" ga-event-category="guide-{{ post.title | downcase}}" ga-event-action="deployment-guides">Production Deployment Guides</a> 
+          {% for crumb in crumbs offset: 2 %}
+            {% if forloop.last %}
+              <a href="#"> / <span> {{ page.title | replace:'-',' ' }}</span></a>
+            {% else %}
+              <a href="/guides#{{ crumb }}" >/ <span>{{ crumb | replace:'-',' ' | capitalize }}</span></a>
+            {% endif %}
+          {% endfor %}      
+        </ol>
       <div class="post-title text-center">
         <img class="img-center" src="{{ page.image }}" alt="post logo">
         <label>{{ page.title }}</label>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,9 +19,9 @@ custom_js:
         <a href="/guides" ga-event-category="guide-{{ post.title | downcase}}" ga-event-action="deployment-guides">Production Deployment Guides</a> 
         {% for crumb in crumbs offset: 2 %}
           {% if forloop.last %}
-           <a href="#"> / {{ crumb | replace:'-',' ' | capitalize }}</a>
+           <a href="#"> / <span> {{ crumb | replace:'-',' ' | capitalize }}</span></a>
           {% else %}
-            <a href="/guides#{{ crumb }}">/ {{ crumb | replace:'-',' ' | capitalize }}</a>
+            <a href="/guides#{{ crumb }}" >/ <span class="active">{{ crumb | replace:'-',' ' | capitalize }}</span></a>
           {% endif %}
         {% endfor %}      
       </ol>

--- a/assets/css/global.less
+++ b/assets/css/global.less
@@ -1450,7 +1450,6 @@ body .guides .guides-section-white {
       & td, td p {
         text-align: initial;
         font-size: 12px;
-        font-weight: 600;
         line-height: normal;
         letter-spacing: 0.34px;
         color: @guides-font;

--- a/assets/css/global.less
+++ b/assets/css/global.less
@@ -1412,25 +1412,72 @@ body .guides .guides-section-white {
   letter-spacing: 0.34px;
 }
 
-.admonitionblock  {
+.admonitionblock-content  {
+  position: relative;
+  padding: 10px;
   border-top: 9px solid @guides-primary-color;
   background-color: #f5f9fa;
   font-size: 12px;
   text-align: center;
-  padding: 0 0 1px;
   margin: 10px 0;
-  table tbody {
-    opacity: 1 !important;
-    & tr td:nth-child(even) {
-      background-color: #f5f9fa !important;
+  table {
+    text-align:center; 
+    margin-left:auto; 
+    margin-right:auto;
+    & tbody tr {
+      border-bottom: none !important;
+      & td {
+        text-align: initial;
+        code {
+          background: #e5ecee !important;
+          color: black;
+        }
+        & .title {
+          margin-right: 20px;
+          line-height: 0;
+          position: relative;
+          font-size: 0;
+          text-align: center;
+          &:after {
+            display: block;
+            position: absolute;
+            color: #fff;
+            content: "!";
+            border-radius: 50%;
+            // border: 1px solid #06a6fd;
+            width: 21px;
+            height: 21px;
+            line-height: 22px;
+            font-weight: normal;
+            // background-color: #06a6fd;
+            left: 0;
+            font-size: 16px;
+            margin-top: -9px;
+          }
+        }
+        &:nth-child(even) {
+          background-color: inherit !important;
+        }  
+      }
     }
   }
 }
 
-// .admonitionblock .important {
+.admonitionblock.important, .admonitionblock.note{
+  .admonitionblock-content;
+  .title:after {
+    background-color: #06a6fd; 
+    border: 1px solid #06a6fd;
+  }
+}
 
-// }
-
+.admonitionblock.error{
+  .admonitionblock-content;
+  .title:after {
+    background-color: #ef5a73; 
+    border: 1px solid #ef5a73;
+  }
+}
 
 // Sections that have a blue background
 .section-hero-blue {

--- a/assets/css/global.less
+++ b/assets/css/global.less
@@ -1766,13 +1766,21 @@ body .guides .guides-section-white {
   }
   .breadcrumb {
     font-size: 14px;
-    font-weight: bold;
     letter-spacing: -0.2px;
     background-color: white;
     > a {
       color: @guides-primary-color;
-      &:last-child, &:hover {
-        text-decoration: underline;
+      &:last-child span {
+        border-bottom: 1px solid @guides-primary-color;
+        text-shadow: 0.5px 0 0;
+      }
+      &:last-child span:hover,
+      &:first-child:hover,
+      &:first-child:active, 
+      & span:hover,
+      & span:active {
+        border-bottom: 2px solid @guides-primary-color;
+        text-shadow: 0.5px 0 0;
       }
     }
   }

--- a/assets/css/global.less
+++ b/assets/css/global.less
@@ -1414,44 +1414,54 @@ body .guides .guides-section-white {
 
 .admonitionblock-content  {
   position: relative;
-  padding: 10px;
+  padding: 19px;
   border-top: 9px solid @guides-primary-color;
   background-color: #f5f9fa;
-  font-size: 12px;
   text-align: center;
-  margin: 10px 0;
+  margin: 40px 0;
   table {
     text-align:center; 
     margin-left:auto; 
     margin-right:auto;
     & tbody tr {
       border-bottom: none !important;
-      & td {
+      & .icon .title {
+        margin-right: 20px;
+        line-height: 0;
+        position: relative;
+        font-size: 0;
+        text-align: center;
+        line-height: 10px;
+        &:after {
+          display: block;
+          position: absolute;
+          color: #fff;
+          content: "!";
+          border-radius: 50%;
+          width: 21px;
+          height: 21px;
+          line-height: 22px;
+          font-weight: normal;
+          left: 0;
+          font-size: 16px;
+          margin-top: -9px;
+        }
+      }
+      & td, td p {
         text-align: initial;
+        font-size: 12px;
+        font-weight: 600;
+        line-height: normal;
+        letter-spacing: 0.34px;
+        color: @guides-font;
+        .title {
+          margin-bottom: 12px;
+        }
         code {
           background: #e5ecee !important;
-          color: black;
-        }
-        & .title {
-          margin-right: 20px;
-          line-height: 0;
-          position: relative;
-          font-size: 0;
-          text-align: center;
-          &:after {
-            display: block;
-            position: absolute;
-            color: #fff;
-            content: "!";
-            border-radius: 50%;
-            width: 21px;
-            height: 21px;
-            line-height: 22px;
-            font-weight: normal;
-            left: 0;
-            font-size: 16px;
-            margin-top: -9px;
-          }
+          color: @guides-font;
+          font-family: AndaleMono;
+          font-weight: normal;
         }
         &:nth-child(even) {
           background-color: inherit !important;
@@ -1764,21 +1774,13 @@ body .guides .guides-section-white {
   }
   .breadcrumb {
     font-size: 14px;
+    font-weight: bold;
     letter-spacing: -0.2px;
     background-color: white;
     > a {
       color: @guides-primary-color;
-      &:last-child span {
-        border-bottom: 1px solid @guides-primary-color;
-        text-shadow: 0.5px 0 0;
-      }
-      &:last-child span:hover,
-      &:first-child:hover,
-      &:first-child:active, 
-      & span:hover,
-      & span:active {
-        border-bottom: 2px solid @guides-primary-color;
-        text-shadow: 0.5px 0 0;
+      &:last-child, &:hover {
+        text-decoration: underline;
       }
     }
   }

--- a/assets/css/global.less
+++ b/assets/css/global.less
@@ -1444,12 +1444,10 @@ body .guides .guides-section-white {
             color: #fff;
             content: "!";
             border-radius: 50%;
-            // border: 1px solid #06a6fd;
             width: 21px;
             height: 21px;
             line-height: 22px;
             font-weight: normal;
-            // background-color: #06a6fd;
             left: 0;
             font-size: 16px;
             margin-top: -9px;


### PR DESCRIPTION
Done the following in this PR

- Breadcrumb underline should not include the slash

Style breadcrumb as given in mockup
(Note: Using ```font-weight: bold``` when hover or active made the bread crumb jump. So I used ``shadow: 0.5px``` instead)

- Match title in the breadcrumb to post title

- Fix callouts to display icon not text

- Style callout to match mockup

Screenshots below:

Breadcrumb:
<img width="743" alt="Screenshot 2019-09-09 at 2 50 18 PM" src="https://user-images.githubusercontent.com/26963758/64536715-79a0d900-d311-11e9-9c0d-78c8c112d08b.png">

Callout
<img width="685" alt="Screenshot 2019-09-09 at 1 39 14 PM" src="https://user-images.githubusercontent.com/26963758/64536026-43168e80-d310-11e9-8d17-7285b911e0ec.png">
