### PR TITLE
Fix categories clicking on deployment guides listings page

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -23,7 +23,21 @@
                 <div class="collapse" id="filter-options" aria-expanded="true">
                     <div class="card card-body">
                         <p>Tags</p>
-                        <div class="tags"></div>
+                        <div class="tags">
+                          {% assign tags_to_capitalize = "aws,gcp,azure,gke,eks" | split: "," %}
+                          {% assign tags = "" | split: "" %}
+                          {% for post in include.posts %}
+                            {% assign tags = tags | concat: post.tags %}
+                          {% endfor %}
+                          {% assign unique_tags = tags | uniq %}
+                          {% for tag in unique_tags %}
+                            {% assign tag_name = tag %}
+                            {% if tags_to_capitalize contains tag_name %}
+                              {% assign tag_name = tag | upcase %}
+                            {% endif %}
+                            <div class="checkbox"><input value="{{ tag }}" id="filter-{{ tag }}" type="checkbox"><label for="filter-{{ tag }}">{{ tag_name }}</label></div>
+                          {% endfor %}
+                        </div>
                     </div>
                 </div>
             </div>
@@ -39,4 +53,3 @@
         </div>
     </div>
 </div>
-                  

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -44,31 +44,6 @@
   }
 
   /**
-   * Function populates the filter checkboxes with tags
-   */
-  function displayFilterTags() {
-    //A list of tags that should be in uppercase
-    const upperCaseTags = ['aws', 'gke', 'gcp'];
-
-    if (searchEntry.type === 'guideEntries') {
-
-      //Filters the tags from the array of objects and flattens it out since it returns an array of arrays
-      let tags = searchEntry.entries.map(entry => entry.tags.split(',').map(tag => tag.trim())).reduce((a, b) => a.concat(b), []);
-
-      tags.filter((tag, index) => {
-
-        if ((tags.indexOf(tag) === index) && (tag.length != "")) {
-          //Converts tags that should be in uppercase
-          if (upperCaseTags.includes(tag)) {
-            tag = tag.toUpperCase();
-          }
-          $('.tags').append(`<div class="checkbox"><input value=${tag} id=${tag} type="checkbox"><label for="${tag}">${tag}</label></div>`);
-        }
-      });
-    }
-  }
-
-  /**
    * Function to display all items on the page
    */
   function showAllItems() {
@@ -83,7 +58,7 @@
   function showInitialItemsCount() {
     let numSubmodules = 0;
     for (let i = 0; i < searchEntry.entries.length; i++) {
-      if (searchEntry.type == 'libraryEntries') {
+      if (searchEntry.type === 'libraryEntries') {
         numSubmodules += libraryEntries[i].num_submodules;
       }
       searchEntry.entries;
@@ -96,7 +71,6 @@
   function initialEntry() {
     $('#no-matches').hide();
     searchEntry = detectSearchEntry();
-    $(displayFilterTags);
     $(showInitialItemsCount);
     $(performSearch($('.cloud-filter #aws')));
   }
@@ -137,8 +111,8 @@
     categoryArr.each(function () {
       let category = $(this).text().toLowerCase();
       if (entry.category === category) {
-        $(`.categories ul #${category}`).show();
-        $(`#${category}-1.category-head`).show();
+        $(`.categories ul .${category}`).show();
+        $(`#${category}.category-head`).show();
       }
     });
   }
@@ -146,7 +120,7 @@
 
   /**
    * A function to search the IaC Lib and Deployment guides. Can also be used for other pages that need it.
-   * To show/hide the proper elements based on the results. 
+   * To show/hide the proper elements based on the results.
    * @type {Function}
    */
   function filterData(searchValue, type) {
@@ -159,9 +133,9 @@
 
       let searchQueries = lowerText.split(" ");
 
-      if (searchEntry.type == 'libraryEntries') {
+      if (searchEntry.type === 'libraryEntries') {
         $('.table-clickable-row').hide();
-      } else if (searchEntry.type == 'guideEntries') {
+      } else if (searchEntry.type === 'guideEntries') {
         $('#search-results-count').hide();
         $('.guide-card').hide() &&
           $('.category-head').hide() &&
@@ -208,7 +182,7 @@
           (searchEntry.type === 'libraryEntries') ? submoduleMatches += entry.num_submodules: submoduleMatches = 0;
           return;
         }
-      })
+      });
 
 
       if (matches === 0) {
@@ -219,12 +193,12 @@
 
       showItemsCount(matches, submoduleMatches);
     } else {
-      if (searchEntry.type == 'libraryEntries') {
+      if (searchEntry.type === 'libraryEntries') {
 
         showInitialItemsCount();
         $('.table-clickable-row').show();
 
-      } else if (searchEntry.type = 'guideEntries') {
+      } else if (searchEntry.type === 'guideEntries') {
         showAllItems();
       }
     }

--- a/pages/guides/_guides.html
+++ b/pages/guides/_guides.html
@@ -4,7 +4,7 @@
             {% for category in site.categories %}
             {% capture category_name %}{{ category | first }}{% endcapture %}
             <ul id="categories">
-                <li id="{{ category_name | downcase }}">
+                <li class="{{ category_name | downcase }}">
                     <label><b><a href="#{{category_name | slugify}}">{{category_name}}</a></b></label>
                 </li>
             </ul>
@@ -19,9 +19,7 @@
                 </div>
                 {% for category in site.categories %}
                 {% capture category_name %}{{ category | first }}{% endcapture %}
-                <div id="#{{ category_name | slugize }}"></div>   
                 <h3 class="category-head">{{ category_name }}</h3>
-                <a name="{{ category_name | slugize }}"></a>
                 {% for post in site.categories[category_name] %}
                 <div class="guide-card card-shadow" id="{{ post.title | downcase | split: ' ' | join: '-' | append: '-card' }}">
                     <div class="card">

--- a/pages/guides/index.html
+++ b/pages/guides/index.html
@@ -16,7 +16,7 @@ custom_js:
 
   <div class="guides-section-white">
     <div class="container-fluid">
-      {% include search.html %}
+      {% include search.html posts=site.posts %}
       {% include_relative _no-search-results.html %}
       {% include_relative _guides.html %}
     </div>


### PR DESCRIPTION
Fixes https://gruntwork.atlassian.net/browse/HSTN-403.

1. Render all tags in Jekyll instead of in JS. Requires a little Jekyll hackery.
1. Remove duplicated category IDs and unused anchors.
1. Fix selector in JS code to use proper category ID.

Unrelated: fix some equality checks to use `===`.