### PR TITLE
Use replaceState instead of pushState

### DIFF
--- a/assets/js/guides.js
+++ b/assets/js/guides.js
@@ -47,8 +47,8 @@ $(document).ready(function () {
 
   // Update window hash without causing a "jump." https://stackoverflow.com/a/14690177/483528
   const updateHash = function(hash) {
-    if (history.pushState) {
-      history.pushState(null, null, hash);
+    if (history.replaceState) {
+      history.replaceState(null, null, hash);
     } else {
       window.location.hash = hash;
     }


### PR DESCRIPTION
This way, as you scroll, it doesn't go into your browser's history, and make the "back" button useless.