### PR TITLE
fix blue background

### DIFF
--- a/assets/css/global.less
+++ b/assets/css/global.less
@@ -1632,6 +1632,11 @@ body .guides .guides-section-white {
 }
 
 // Sections that have a blue background
+.section-blue {
+  background-color: #0FC0EF;	
+  color: #fff;
+}
+
 .section-hero-blue {
   height: 409px;
   color: #fff;


### PR DESCRIPTION
Added blue background that was mistakenly removed 
Ref: 
https://github.com/gruntwork-io/gruntwork-io.github.io/commit/fb11aacc7c2ed07fda967c7e1beae738cff22c49#diff-1e69babe6c50a615d3a6ef7b48cf7484L969


<img width="1280" alt="Screenshot 2019-09-19 at 4 10 35 PM" src="https://user-images.githubusercontent.com/26963758/65256836-19bbe680-daf8-11e9-8db2-b9cbd3457135.png">
<img width="1280" alt="Screenshot 2019-09-19 at 4 10 49 PM" src="https://user-images.githubusercontent.com/26963758/65256856-22acb800-daf8-11e9-88cd-5a78348453ee.png">
