### PR TITLE
Fix URLs in prod

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ asciidoc:
   require_front_matter_header: true
 asciidoctor: {}
 
-permalink: /guides/:categories/:title
+permalink: /guides/:categories/:title/
 
 exclude:
  - .dockerignore

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-slug: guides
 custom_js:
 - prism
 - guides

--- a/_posts/2019-05-08-deploying-a-dockerized-app-on-gcp-gke.adoc
+++ b/_posts/2019-05-08-deploying-a-dockerized-app-on-gcp-gke.adoc
@@ -1,14 +1,13 @@
 ---
+title: Deploying a Dockerized app on GCP and GKE
 categories: Kubernetes
 image: /assets/img/guides/gke.jpg
 excerpt: Learn how to deploy a Dockerized app to a Kubernetes (GKE) cluster running on Google Cloud Platform (GCP).
 tags: ["gcp", "gke", "docker", "kubernetes"]
-cloud: [gcp]
+cloud: ["gcp"]
 ---
-= Deploying a Dockerized app on GCP and GKE
 :page-type: guide
 :page-layout: post
-:page-title: Deploying a Dockerized app on GCP and GKE
 
 :toc:
 :toc-placement!:

--- a/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
+++ b/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
@@ -1,15 +1,26 @@
 ---
+title: How to configure a production-grade AWS account structure
 categories: Foundations
 image: /assets/img/guides/aws-account/aws-logo.png
 excerpt: Learn about why you need multiple AWS accounts, AWS Organizations, IAM Users, IAM Roles, IAM Policies, CloudTrail, and more.
-tags: [aws, terraform]
-cloud: aws
+tags: ["aws", "terraform"]
+cloud: ["aws"]
 ---
-
-= How to configure a production-grade AWS account structure
-:type: guide
+:page-type: guide
 :page-layout: post
-:page-title: How to deploy a production-grade VPC on AWS
+
+:toc:
+:toc-placement!:
+
+// GitHub specific settings. See https://gist.github.com/dcode/0cfbf2699a1fe9b46ff04c41721dda74 for details.
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+toc::[]
+endif::[]
 
 
 == Intro

--- a/_posts/2019-08-13-how-to-deploy-production-grade-vpc-aws.adoc
+++ b/_posts/2019-08-13-how-to-deploy-production-grade-vpc-aws.adoc
@@ -1,14 +1,26 @@
 ---
+title: How to deploy a production-grade VPC on AWS
 categories: Networking
 image: /assets/img/guides/vpc/aws-vpc-icon.png
 excerpt: Learn how to configure subnets, route tables, Internet Gateways, NAT Gateways, NACLs, VPC Peering, and more.
-tags: [aws, networking, terraform]
-cloud: aws
+tags: ["aws", "networking", "terraform"]
+cloud: ["aws"]
 ---
-= How to deploy a production-grade VPC on AWS
 :page-type: guide
 :page-layout: post
-:page-title: How to deploy a production-grade VPC on AWS
+
+:toc:
+:toc-placement!:
+
+// GitHub specific settings. See https://gist.github.com/dcode/0cfbf2699a1fe9b46ff04c41721dda74 for details.
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+toc::[]
+endif::[]
 
 == Intro
 

--- a/_posts/2019-08-26-how-to-use-gruntwork-service-catalog.adoc
+++ b/_posts/2019-08-26-how-to-use-gruntwork-service-catalog.adoc
@@ -1,14 +1,13 @@
 ---
+title: How to use the Gruntwork Service Catalog
 categories: Foundations
 image: /assets/img/guides/service-catalog/grunty-grid.png
 excerpt: Learn about production-grade infrastructure, Terraform, Terragrunt, Packer, Docker, immutable infrastructure, versioning for infrastructure code, automated tests for infrastructure code, and more.
-tags: [aws, gcp, terraform, terragrunt]
-cloud: [aws, gcp]
+tags: ["aws", "gcp", "terraform", "terragrunt"]
+cloud: ["aws", "gcp"]
 ---
-= How to use the Gruntwork Service Catalog
 :page-type: guide
 :page-layout: post
-:page-title: How to use the Gruntwork Service Catalog
 
 :toc:
 :toc-placement!:

--- a/_posts/2019-09-03-how-to-deploy-production-grade-kubernetes-cluster-aws.adoc
+++ b/_posts/2019-09-03-how-to-deploy-production-grade-kubernetes-cluster-aws.adoc
@@ -1,17 +1,16 @@
 ---
+title: How to deploy a production-grade Kubernetes cluster on AWS
 categories: Kubernetes
 image: /assets/img/guides/eks/img-eks@3x.png
 excerpt: Learn about EKS, the Kubernetes control plane, worker nodes, auto scaling, auto healing, TLS certs, VPC tagging, DNS forwarding, RBAC, and more.
-tags: [aws, kubernetes, eks]
-cloud: aws
+tags: ["aws", "kubernetes", "eks"]
+cloud: ["aws"]
 ---
-= How to deploy a production-grade Kubernetes cluster on AWS
 :page-type: guide
 :page-layout: post
-:page-title: How to deploy a production-grade Kubernetes cluster on AWS
+
 :toc:
 :toc-placement!:
-
 
 // GitHub specific settings. See https://gist.github.com/dcode/0cfbf2699a1fe9b46ff04c41721dda74 for details.
 ifdef::env-github[]

--- a/_posts/2019-09-03-how-to-deploy-production-grade-kubernetes-cluster-aws.adoc
+++ b/_posts/2019-09-03-how-to-deploy-production-grade-kubernetes-cluster-aws.adoc
@@ -3,7 +3,7 @@ title: How to deploy a production-grade Kubernetes cluster on AWS
 categories: Kubernetes
 image: /assets/img/guides/eks/img-eks@3x.png
 excerpt: Learn about EKS, the Kubernetes control plane, worker nodes, auto scaling, auto healing, TLS certs, VPC tagging, DNS forwarding, RBAC, and more.
-tags: ["aws", "kubernetes", "eks"]
+tags: ["aws", "kubernetes", "eks", "docker"]
 cloud: ["aws"]
 ---
 :page-type: guide


### PR DESCRIPTION
1. Fix the `permalink` setting. It apparently required a trailing slash. That way, if you have a `foo.adoc`, it generates `/foo/index.html`—so you get a nice URL like `/foo`—instead of `foo.index.html`.
1. Fix our front matter. Make it proper YAML, move title to proper portion so it renders correctly (otherwise, you get file name rather than real title for `page.title`), use consistent settings in all posts. 