### PR TITLE
fix accordion error in console

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -387,30 +387,31 @@ $(function(){
 });
 // open accordion for direct links to panel id
 $(window).load(function() {
-  var getHash = location.hash; //get hash from js object location
-  var accordion = $('a[href="' + getHash + '"]');
-  $panelHeight = accordion.parents('.panel').height();
+  const getHash = location.hash; //get hash from js object location
 
-  //Handle cases that do not return a null height
-  if($panelHeight){
-    function activateAccordion(id) {
-      if (id.length)//check if hash isn't empty
-      {
-        $('html,body').animate({
-            scrollTop: accordion.parents('.panel').offset().top //scroll to accordion
-        }, 100, function () {
-            accordion.click(); //simulate click
-            accordion.parents('.panel').find('.panel-title a.no-scroll i.fa').addClass('panel-isOpen'); //point caret down for oepned panel
-        });
-      }
-      else{
-        //if no hash is called, open first panel
-        $('.panel-group .panel:first-child .panel-collapse').addClass('in');
-        $('.panel-group .panel:first-child .panel-title a.no-scroll i.fa').addClass('panel-isOpen');
-      }
-    };
+  function activateAccordion(id) {
+    const accordion = $('a[href="' + id + '"]');
+    const $panelHeight = accordion.parents('.panel').height();
+
+    //Handle cases that do not return a null height
+    if($panelHeight){
+        if (id.length)//check if hash isn't empty
+        {
+          $('html,body').animate({
+              scrollTop: accordion.parents('.panel').offset().top //scroll to accordion
+          }, 100, function () {
+              accordion.click(); //simulate click
+              accordion.parents('.panel').find('.panel-title a.no-scroll i.fa').addClass('panel-isOpen'); //point caret down for oepned panel
+          });
+        }
+        else{
+          //if no hash is called, open first panel
+          $('.panel-group .panel:first-child .panel-collapse').addClass('in');
+          $('.panel-group .panel:first-child .panel-title a.no-scroll i.fa').addClass('panel-isOpen');
+        }
+      };
+    }
     activateAccordion(getHash);
-  }
 });
 
 // Use regular expression to find the cookie we made. Inspired from https://stackoverflow.com/a/25490531

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -44,7 +44,7 @@ new function(e){var t=e.separator||"&",s=!1!==e.spaces,n=(e.suffix,!1!==e.prefix
 $(function () {
   if (window.location.href.indexOf('newsletter_success') !== -1) {
     $("#newsletter-success").modal('show');
-  } 
+  }
 });
 
 /* Repo modal link handler */
@@ -391,27 +391,26 @@ $(window).load(function() {
 
   function activateAccordion(id) {
     const accordion = $('a[href="' + id + '"]');
-    const $panelHeight = accordion.parents('.panel').height();
 
-    //Handle cases that do not return a null height
-    if($panelHeight){
-        if (id.length)//check if hash isn't empty
-        {
-          $('html,body').animate({
-              scrollTop: accordion.parents('.panel').offset().top //scroll to accordion
-          }, 100, function () {
-              accordion.click(); //simulate click
-              accordion.parents('.panel').find('.panel-title a.no-scroll i.fa').addClass('panel-isOpen'); //point caret down for oepned panel
-          });
-        }
-        else{
-          //if no hash is called, open first panel
-          $('.panel-group .panel:first-child .panel-collapse').addClass('in');
-          $('.panel-group .panel:first-child .panel-title a.no-scroll i.fa').addClass('panel-isOpen');
-        }
-      };
-    }
-    activateAccordion(getHash);
+    //Check panel class exists 
+    if(accordion.length > 0 && accordion.parents('.panel').length > 0){
+      if (id.length)//check if hash isn't empty
+      {
+        $('html,body').animate({
+            scrollTop: accordion.parents('.panel').offset().top //scroll to accordion
+        }, 100, function () {
+            accordion.click(); //simulate click
+            accordion.parents('.panel').find('.panel-title a.no-scroll i.fa').addClass('panel-isOpen'); //point caret down for oepned panel
+        });
+      }
+      else{
+        //if no hash is called, open first panel
+        $('.panel-group .panel:first-child .panel-collapse').addClass('in');
+        $('.panel-group .panel:first-child .panel-title a.no-scroll i.fa').addClass('panel-isOpen');
+      }
+    };
+  }
+  activateAccordion(getHash);
 });
 
 // Use regular expression to find the cookie we made. Inspired from https://stackoverflow.com/a/25490531

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -387,13 +387,15 @@ $(function(){
 });
 // open accordion for direct links to panel id
 $(window).load(function() {
-  if(location.pathname.split('/')[1] !== 'guides') {
-    var getHash = location.hash; //get hash from js object location
+  var getHash = location.hash; //get hash from js object location
+  var accordion = $('a[href="' + getHash + '"]');
+  $panelHeight = accordion.parents('.panel').height();
+
+  //Handle cases that do not return a null height
+  if($panelHeight){
     function activateAccordion(id) {
       if (id.length)//check if hash isn't empty
       {
-        var accordion = $('a[href="' + id + '"]');
-        $panelHeight = accordion.parents('.panel').height();
         $('html,body').animate({
             scrollTop: accordion.parents('.panel').offset().top //scroll to accordion
         }, 100, function () {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -387,27 +387,28 @@ $(function(){
 });
 // open accordion for direct links to panel id
 $(window).load(function() {
-  var getHash = location.hash; //get hash from js object location
-  function activateAccordion(id) {
-    if (id.length)//check if hash isn't empty
-    {
-      var accordion = $('a[href="' + id + '"]');
-      $panelHeight = accordion.parents('.panel').height();
-      console.log('Offset Top: ' + accordion.parents('.panel').offset().top);
-      $('html,body').animate({
-          scrollTop: accordion.parents('.panel').offset().top //scroll to accordion
-      }, 100, function () {
-          accordion.click(); //simulate click
-          accordion.parents('.panel').find('.panel-title a.no-scroll i.fa').addClass('panel-isOpen'); //point caret down for oepned panel
-      });
-    }
-    else{
-      //if no hash is called, open first panel
-      $('.panel-group .panel:first-child .panel-collapse').addClass('in');
-      $('.panel-group .panel:first-child .panel-title a.no-scroll i.fa').addClass('panel-isOpen');
-    }
-  };
-  activateAccordion(getHash);
+  if(location.pathname.indexOf('/guides') === -1) {
+    var getHash = location.hash; //get hash from js object location
+    function activateAccordion(id) {
+      if (id.length)//check if hash isn't empty
+      {
+        var accordion = $('a[href="' + id + '"]');
+        $panelHeight = accordion.parents('.panel').height();
+        $('html,body').animate({
+            scrollTop: accordion.parents('.panel').offset().top //scroll to accordion
+        }, 100, function () {
+            accordion.click(); //simulate click
+            accordion.parents('.panel').find('.panel-title a.no-scroll i.fa').addClass('panel-isOpen'); //point caret down for oepned panel
+        });
+      }
+      else{
+        //if no hash is called, open first panel
+        $('.panel-group .panel:first-child .panel-collapse').addClass('in');
+        $('.panel-group .panel:first-child .panel-title a.no-scroll i.fa').addClass('panel-isOpen');
+      }
+    };
+    activateAccordion(getHash);
+  }
 });
 
 // Use regular expression to find the cookie we made. Inspired from https://stackoverflow.com/a/25490531

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -387,7 +387,7 @@ $(function(){
 });
 // open accordion for direct links to panel id
 $(window).load(function() {
-  if(location.pathname.indexOf('/guides') === -1) {
+  if(location.pathname.split('/')[1] !== 'guides') {
     var getHash = location.hash; //get hash from js object location
     function activateAccordion(id) {
       if (id.length)//check if hash isn't empty

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -391,19 +391,16 @@ $(window).load(function() {
 
   function activateAccordion(id) {
     const accordion = $('a[href="' + id + '"]');
-
     //Check panel class exists 
     if(accordion.length > 0 && accordion.parents('.panel').length > 0){
-      if (id.length)//check if hash isn't empty
-      {
+      if (id.length){ //check if hash isn't empty
         $('html,body').animate({
             scrollTop: accordion.parents('.panel').offset().top //scroll to accordion
         }, 100, function () {
             accordion.click(); //simulate click
             accordion.parents('.panel').find('.panel-title a.no-scroll i.fa').addClass('panel-isOpen'); //point caret down for oepned panel
         });
-      }
-      else{
+      } else {
         //if no hash is called, open first panel
         $('.panel-group .panel:first-child .panel-collapse').addClass('in');
         $('.panel-group .panel:first-child .panel-title a.no-scroll i.fa').addClass('panel-isOpen');


### PR DESCRIPTION
This PR fixes the accordion error in the console.

Some pages have a `.panel` class which doesn't exist in the deployment guides so I put a condition to check if guides is found in the path.