### PR TITLE
Switch footer text to "Deployment Guides"

### DIFF
--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -26,7 +26,7 @@
     - title: Pricing
       url: /pricing/
 
-    - title: Production Deployment Guides
+    - title: Deployment Guides
       url: /guides
 
     - title: FAQ


### PR DESCRIPTION
Otherwise, it ends up wrapping in the footer, which is confusing:

![Screen Shot 2019-09-19 at 10 01 48 PM](https://user-images.githubusercontent.com/711908/65280977-6966d600-db29-11e9-8c41-ade4777d6a25.png)
