### PR TITLE
consolidate canonical urls as non-www version

### DIFF
--- a/_includes/canonical-url.html
+++ b/_includes/canonical-url.html
@@ -1,1 +1,1 @@
-{% if include.url %}{% assign url = include.url %}{% else %}{% assign url = page.url %}{% endif %}{{ site.url }}{{ url | replace:'index.html','' }}
+{% if include.url %}{% assign url = include.url %}{% else %}{% assign url = page.url %}{% endif %}{{ site.url | replace:'www.','' }}{{ url | replace:'index.html','' }}


### PR DESCRIPTION
Should fix canonical url problem causing the duplication of search results between the www and non-www versions (which dilutes our ranking). The decision on non-www was arbitrary as it's simpler to remove it than to insert it and the resulting url is shorter, which I find cleaner. 