### PR TITLE
Only load prism css on guides instead of all pages at gruntwork.io

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,6 @@
 <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-<link rel="stylesheet" href="{{ '/assets/css/prism.css' | prepend: site.baseurl }}">
 
 <!--[if lt IE 9]>
     <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -23,4 +22,3 @@
 {% include favicon.html %}
 {% include share-meta.html %}
 {% include newsletter-modal.html %}
-

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,12 +1,12 @@
 <script>window.pricing = {{ site.data.pricing | jsonify }}</script>
-<script src="{{ site.assets_base_url }}js/main.js"></script>
+<script async src="{{ site.assets_base_url }}js/main.js"></script>
 {% if page.custom_js %}
   {% for js_file in page.custom_js %}
-  <script src='/assets/js/{{ js_file }}.js' type="text/javascript"></script>
+  <script async src='/assets/js/{{ js_file }}.js' type="text/javascript"></script>
   {% endfor %}
 {% elsif layout.custom_js %}
   {% for js_file in layout.custom_js %}
-    <script src='/assets/js/{{ js_file }}.js' type="text/javascript"></script>
+    <script async src='/assets/js/{{ js_file }}.js' type="text/javascript"></script>
   {% endfor %}
 {% endif %}
 {% if site.ga_tracker %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,49 +1,59 @@
 ---
-layout: default
 custom_js:
 - prism
 - guides
 ---
-
-<div  class="post-bg">
-  <div class="container-fluid">
-      <div class="post-detail row equal">
-        <div class="col-md-2-5">
-          <div id="toc" class="js-scroll-with-user" data-scroll-after-selector=".navbar-default" data-scroll-until-selector=".guides-section-white">
-              {% toc %} {{page.document | tocify_asciidoc}}
-          </div>
-        </div>
-        <div class="col-md-7 col-xs-12 guides-section-white">
-          <ol class="breadcrumb text-center">
-            {% assign crumbs = page.url | split: '/' %}
-            <a href="/guides" ga-event-category="guide-{{ post.title | downcase}}" ga-event-action="deployment-guides">Production Deployment Guides</a>
-            {% for crumb in crumbs offset: 2 %}
-              {% if forloop.last %}
-                <a href="#"> / <span> {{ page.title | replace:'-',' ' }}</span></a>
-              {% else %}
-                <a href="/guides#{{ crumb }}" >/ <span>{{ crumb | replace:'-',' ' | capitalize }}</span></a>
-              {% endif %}
-            {% endfor %}
-          </ol>
-          <div class="post-title text-center">
-            <img class="img-center post-title-image" src="{{ page.image }}" alt="post logo">
-            <h1>{{ page.title }}</h1>
-            {% if page.tags %}
-              {% for tag in page.tags %}
-                <span class="badge badge-pill badge-default">
-                  {% capture tag-name %}{{tag | upcase }}{% endcapture %}
-                  {% if tag-name=="AWS" or tag-name=="GCP"  or tag-name=="GKE" %} {{ tag-name }} {% else %} {{tag-name | capitalize}}{% endif %}</span>
-              {% endfor %}
-            {% endif %}
-          </div>
-          <div class="post-content js-scroll-spy" data-scroll-spy-nav-selector="#toc">
-              {{ content }}
-          </div>
+<!doctype html>
+<html lang="en">
+    <head>
+        {% include head.html %}
+        <link rel="stylesheet" href="{{ '/assets/css/prism.css' | prepend: site.baseurl }}"/>
+    </head>
+    <body{% if page.slug %} class="{{ page.slug }}{% if page.slug != 'index-page' and page.slug !='how-it-works' and page.slug != 'guides' %} sub-page{% endif %}" {% endif %}>
+        {% include navbar.html %}
+        <div  class="post-bg">
+          <div class="container-fluid">
+              <div class="post-detail row equal">
+                <div class="col-md-2-5">
+                  <div id="toc" class="js-scroll-with-user" data-scroll-after-selector=".navbar-default" data-scroll-until-selector=".guides-section-white">
+                      {% toc %} {{page.document | tocify_asciidoc}}
+                  </div>
+                </div>
+                <div class="col-md-7 col-xs-12 guides-section-white">
+                  <ol class="breadcrumb text-center">
+                    {% assign crumbs = page.url | split: '/' %}
+                    <a href="/guides" ga-event-category="guide-{{ post.title | downcase}}" ga-event-action="deployment-guides">Production Deployment Guides</a>
+                    {% for crumb in crumbs offset: 2 %}
+                      {% if forloop.last %}
+                        <a href="#"> / <span> {{ page.title | replace:'-',' ' }}</span></a>
+                      {% else %}
+                        <a href="/guides#{{ crumb }}" >/ <span>{{ crumb | replace:'-',' ' | capitalize }}</span></a>
+                      {% endif %}
+                    {% endfor %}
+                  </ol>
+                  <div class="post-title text-center">
+                    <img class="img-center post-title-image" src="{{ page.image }}" alt="post logo">
+                    <h1>{{ page.title }}</h1>
+                    {% if page.tags %}
+                      {% for tag in page.tags %}
+                        <span class="badge badge-pill badge-default">
+                          {% capture tag-name %}{{tag | upcase }}{% endcapture %}
+                          {% if tag-name=="AWS" or tag-name=="GCP"  or tag-name=="GKE" %} {{ tag-name }} {% else %} {{tag-name | capitalize}}{% endif %}</span>
+                      {% endfor %}
+                    {% endif %}
+                  </div>
+                  <div class="post-content js-scroll-spy" data-scroll-spy-nav-selector="#toc">
+                      {{ content }}
+                  </div>
+                </div>
+            </div>
         </div>
       </div>
-  </div>
-</div>
-<div class="white-section center">
-  {% include newsletter.html %}
-</div>
-{% include grunty-sub-footer.html %}
+      <div class="white-section center">
+        {% include newsletter.html %}
+      </div>
+      {% include grunty-sub-footer.html %}
+      {% include footer.html %}
+      {% include scripts.html %}
+  </body>
+</html>


### PR DESCRIPTION
1. does not use same layout of default.html for post.html
2. copy pastes contents of default.html around post.html
3. removes prism.css from head 
4. adds prism.css to post.html