### PR TITLE
implement ga scroll tracking

### DIFF
--- a/assets/js/guides.js
+++ b/assets/js/guides.js
@@ -47,7 +47,7 @@ $(document).ready(function () {
   };
 
   // Update window hash without causing a "jump." https://stackoverflow.com/a/14690177/483528
-  const updateHash = function(hash) {
+  const updateHash = function (hash) {
     if (history.replaceState) {
       history.replaceState(null, null, hash);
     } else {
@@ -58,7 +58,7 @@ $(document).ready(function () {
   // Show a dot next to the part of the TOC where the user has scrolled to. We can't use bootstrap's built-in ScrollSpy
   // because with Bootstrap 3.3.7, it only works with a Bootstrap Nav, whereas our TOC is auto-generated and does not
   // use Bootstrap Nav classes/markup.
-  const scrollSpy = function() {
+  const scrollSpy = function () {
     const content = $(".js-scroll-spy");
 
     const nav = getElementForDataSelector(content, 'scroll-spy-nav-selector', 'scrollSpy');
@@ -104,9 +104,52 @@ $(document).ready(function () {
     }
   };
 
+  /**
+   * Retrieves the scroll depth and returns it as percentage
+   */
+  function retrieveScrollDepth() {
+    return Math.floor(
+      ((window.pageYOffset + window.innerHeight) /
+        document.body.scrollHeight) * 100
+    )
+  }
+
+  /**
+   * Sends location and scroll depth to GA on event beforeunload
+   */
+  function exitPageView() {
+    let scrollDepth = retrieveScrollDepth();
+
+    ga('send', 'event', `Scrolling-${location.pathname}`, 'Scrolling', `label-${location.pathname}`, scrollDepth, {
+      nonInteractive: true
+    });
+  }
+
+  /**
+   * scroll tracking function
+   */
+  const scrollTracking = function () {
+
+    const timeThreshold = 15;
+
+    window.addEventListener("scroll", {scrolling: true});
+
+    window.addEventListener("beforeunload", exitPageView);
+
+    // *1000 to convert s to ms
+    setTimeout({ nonInteractive: false}, timeThreshold * 1000)
+
+  };
+
   $(window).scroll(moveToCWithScrolling);
   $(moveToCWithScrolling);
 
   $(window).scroll(scrollSpy);
   $(scrollSpy);
+
+  $(scrollTracking);
+
+  $('.post-detail img').on('click', function () {
+    window.open(this.src, '_blank')
+  })
 });


### PR DESCRIPTION
Implement scroll tracking 

<img width="1269" alt="Screenshot 2019-10-02 at 12 06 57 PM" src="https://user-images.githubusercontent.com/26963758/66039586-3222fc80-e50d-11e9-8eb5-cb88b169e27d.png">

https://drive.google.com/file/d/13PxtLDharr4meofxvGgpYZkhlj3FGwnW/view?usp=sharing

How to Test:
1. Create an account in GA
N/B Expose your port locally to ngrok and use the ngrok url as your website link. Example below:
<img width="458" alt="Screenshot 2019-10-02 at 11 22 01 AM" src="https://user-images.githubusercontent.com/26963758/66037856-72cc4700-e508-11e9-8097-360a3cf17c9f.png">

2. Change the `ga_tracker` number within our config.yml [file](https://github.com/gruntwork-io/gruntwork-io.github.io/blob/master/_config.yml#L16) with your Tracking ID


