### PR TITLE
add ga tracking on click

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,7 +21,7 @@ custom_js:
               {% if forloop.last %}
                 <a href="#"> / <span> {{ page.title | replace:'-',' ' }}</span></a>
               {% else %}
-                <a href="/guides#{{ crumb }}" ga-on="click" ga-event-category="guide-{{ page.title | slugify }}" ga-event-action="deployment-guides-category">/ <span>{{ crumb | replace:'-',' ' | capitalize }}</span></a>
+                <a href="/guides#{{ crumb }}" ga-on="click" ga-event-category="guide-{{ page.title | slugify }}" ga-event-action="breadcrumb-{{ crumb }}">/ <span>{{ crumb | replace:'-',' ' | capitalize }}</span></a>
               {% endif %}
             {% endfor %}
           </ol>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,12 +16,12 @@ custom_js:
         <div class="col-md-7 col-xs-12 guides-section-white">
           <ol class="breadcrumb text-center">
             {% assign crumbs = page.url | split: '/' %}
-            <a href="/guides" ga-event-category="guide-{{ post.title | downcase}}" ga-event-action="deployment-guides">Production Deployment Guides</a>
+            <a href="/guides" ga-on="click" ga-event-category="guide-{{ page.title | slugify }}" ga-event-action="deployment-guides-home">Production Deployment Guides</a>
             {% for crumb in crumbs offset: 2 %}
               {% if forloop.last %}
                 <a href="#"> / <span> {{ page.title | replace:'-',' ' }}</span></a>
               {% else %}
-                <a href="/guides#{{ crumb }}" >/ <span>{{ crumb | replace:'-',' ' | capitalize }}</span></a>
+                <a href="/guides#{{ crumb }}" ga-on="click" ga-event-category="guide-{{ page.title | slugify }}" ga-event-action="deployment-guides-category">/ <span>{{ crumb | replace:'-',' ' | capitalize }}</span></a>
               {% endif %}
             {% endfor %}
           </ol>

--- a/pages/guides/_guides.html
+++ b/pages/guides/_guides.html
@@ -6,7 +6,7 @@
             {% for category in site.categories %}
               {% capture category_name %}{{ category | first }}{% endcapture %}
                 <li class="{{ category_name | downcase }}">
-                    <a href="#{{category_name | slugify}}">{{category_name}}</a>
+                    <a href="#{{category_name | slugify}}" ga-on="click" ga-event-category="guides-listings-{{ page.path | slugify}}" ga-event-action="category-{{ category_name | slugify }}">{{category_name}}</a>
                 </li>
             {% endfor %}
           </ul>
@@ -23,12 +23,12 @@
             <h3 class="category-head">{{ category_name }}</h3>
             {% for post in site.categories[category_name] %}
               <div class="guide-card card-shadow" id="{{ post.title | downcase | split: ' ' | join: '-' | append: '-card' }}">
-                <div class="card">
+                <div class="card" ga-on="click" ga-event-category="guide-{{ post.title | slugify }}" ga-event-action="guide-click">
                   <div class="row no-padding">
                     <div class="col-xs-2 img-inner no-padding">
                       <img src="{{ post.image }}" alt="card image" class="img-center">
                     </div>
-                    <a href="{{ post.url }}" ga-event-category="guide-{{ post.title | downcase}}" ga-event-action="deployment-guides">
+                    <a href="{{ post.url }}">
                       <div class="col-xs-10 card-body guide-card-description float-right">
                         <h5 class="card-title"><b>{{ post.title }}</b></h5>
                         <p class="card-text">{{ post.excerpt | strip_html }}</p>


### PR DESCRIPTION
Add GA tracking to guides
- Breadcrumb
- Categories on listing page
- Guides listing
<img width="1037" alt="Screenshot 2019-10-02 at 11 38 19 AM" src="https://user-images.githubusercontent.com/26963758/66038153-33522a80-e509-11e9-844c-2e597036b61f.png">

