### PR TITLE
Add redirect for prod-grade infra checklist

### DIFF
--- a/pages/checklist-redirect/index.html
+++ b/pages/checklist-redirect/index.html
@@ -1,0 +1,16 @@
+---
+layout: none
+permalink: /checklist/
+redirect_url: /guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library/#production_grade_infra_checklist
+---
+
+<html lang="en">
+  <head>
+    <title>Redirecting to the Gruntwork Production Grade Infrastructure Checklist...</title>
+    <meta http-equiv="refresh" content="0; url={{ page.redirect_url }}"/>
+  </head>
+  <body>
+    Redirecting you to the <a href="{{ page.redirect_url }}">Gruntwork Production Grade Infrastructure Checklist</a>...
+  </body>
+</html>
+


### PR DESCRIPTION
This allows us to have https://www.gruntwork.io/checklist go directl to the Production-Grade Infrastructure Checklist. This is a handy short URL to use in talks.