### PR TITLE
fix social media share thumbnail

### DIFF
--- a/_includes/share-meta.html
+++ b/_includes/share-meta.html
@@ -1,17 +1,19 @@
 {% capture title %}{% if page.title %}{{ page.title }}{% else %}{{ site.name }}{% endif %}{% endcapture %}
 {% capture description %}{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines }}{% else %}{{ site.description }}{% endif %}{% endcapture %}
+{% capture img %}{% if page.image %}{{ page.image }}{% else %}{{ site.thumbnail_path }}{% endif %}{% endcapture %}
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="{{ site.data.contact.twitter.username }}" />
 <meta name="twitter:title" content="{{ title }}" />
 <meta name="twitter:url" content="{% include canonical-url.html %}" />
 <meta name="twitter:description" content="{{ description }}" />
-<meta name="twitter:image" content="{{ site.url }}{{ site.thumbnail_path }}" />
+<meta name="twitter:image" content="{{ site.url }}{{ img }}" />
 
 <meta property="og:title" content="{{ title }}"/>
 <meta property="og:url" content="{% include canonical-url.html %}"/>
 <meta property="og:site_name" content="{{ site.name }}"/>
 <meta property="article:author" content="{{ site.data.contact.facebook.url }}"/>
-<meta property="og:description" content="{{ description }}"/>
-<meta property="og:image" content="{{ site.url }}{{ site.thumbnail_path }}"/>
+<meta property="og:description" content="{{img}}"/>
+<meta property="og:image" content="{{site.url}}{{ img }}"/>
+
 

--- a/_includes/share-meta.html
+++ b/_includes/share-meta.html
@@ -13,7 +13,7 @@
 <meta property="og:url" content="{% include canonical-url.html %}"/>
 <meta property="og:site_name" content="{{ site.name }}"/>
 <meta property="article:author" content="{{ site.data.contact.facebook.url }}"/>
-<meta property="og:description" content="{{img}}"/>
+<meta property="og:description" content="{{ description }}"/>
 <meta property="og:image" content="{{site.url}}{{ img }}"/>
 
 


### PR DESCRIPTION
I was not able to test sharing facebook sharing locally. I also tried using ngrok, but to no avail. I'm guessing this should work as the `og:image` and `twitter:image` url no longer points to the fixed thumbnail that always displays when we share

**Before:**
<img width="883" alt="Screenshot 2019-10-07 at 1 02 23 PM" src="https://user-images.githubusercontent.com/26963758/66309905-beb12e80-e902-11e9-93ba-5cb12710fbd0.png">

**After**
<img width="901" alt="Screenshot 2019-10-07 at 12 56 18 PM" src="https://user-images.githubusercontent.com/26963758/66309766-56624d00-e902-11e9-80e0-8a9a0dfbf06c.png">
