### PR TITLE
Add redirect url to google docs customer form

### DIFF
--- a/pages/partner-customer-setup/index.html
+++ b/pages/partner-customer-setup/index.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Gruntwork Partner Customer Form
+permalink: /forms/partner-customer-setup/
+redirect_to:
+  - https://docs.google.com/forms/d/1xEODKinJjjf3FEwU3QvcHZsc1l4OsXF8jSh99bLRIcM
+---


### PR DESCRIPTION
#### What does this PR do?
- Adds a url "/forms/partner-customer-setup/" to the website for redirecting to the google customer form

#### Screen Recording
![customer-form](https://user-images.githubusercontent.com/21035422/68613294-a7261200-047b-11ea-9ccb-f0391f185c4f.gif)
