### PR TITLE
change static bucket

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,4 +1,4 @@
-s3_bucket: www.gruntwork.io
+s3_bucket: www-static.gruntwork.io
 cache_control: max-age=600
 gzip: true
 concurrency_level: 4


### PR DESCRIPTION
This PR changes the s3 bucket that the static site is deployed to now that we are running production in the dogfood-prod account