### PR TITLE
Callout CIS Ref Arch

### DIFF
--- a/_data/cis-how-it-works.yml
+++ b/_data/cis-how-it-works.yml
@@ -22,9 +22,9 @@
     </ul>
 
     <p class="alert" style="border: 1px solid #194c5f; background-color: #242e3b;">
-      <strong>Get an End to End Production-Grade Architecture</strong><br>
+      <strong>Get an End-to-End CIS Compliant Production-Grade Architecture</strong><br>
       Request a <a href="/reference-architecture">Gruntwork Reference Architecture</a> to get an end to end
-      production-grade CIS Benchmark compliant architecture in 1 day.
+      production-grade architecture that has been certified by Gruntwork and CIS to be compliant with the CIS Benchmarks, deployed into your AWS accounts, and fully managed as code—all in about 1 day!
     </p>
 
 - title: Pass an audit

--- a/_data/cis-how-it-works.yml
+++ b/_data/cis-how-it-works.yml
@@ -21,6 +21,12 @@
       <li>Avoid overly permissive inbound security group rules</li>
     </ul>
 
+    <p class="alert" style="border: 1px solid #194c5f; background-color: #242e3b;">
+      <strong>Get an End to End Production-Grade Architecture</strong><br>
+      Request a <a href="/reference-architecture">Gruntwork Reference Architecture</a> to get an end to end
+      production-grade CIS Benchmark compliant architecture in 1 day.
+    </p>
+
 - title: Pass an audit
   description: |
     <p>

--- a/_data/cis-how-it-works.yml
+++ b/_data/cis-how-it-works.yml
@@ -24,7 +24,7 @@
     <p class="alert" style="border: 1px solid #194c5f; background-color: #242e3b;">
       <strong>Get an End-to-End CIS Compliant Production-Grade Architecture</strong><br>
       Request a <a href="/reference-architecture">Gruntwork Reference Architecture</a> to get an end to end
-      production-grade architecture that has been certified by Gruntwork and CIS to be compliant with the CIS Benchmarks, deployed into your AWS accounts, and fully managed as code—all in about 1 day!
+      production-grade environment, certified by CIS for the AWS Foundations Benchmark, deployed into your AWS accounts, and fully managed as code—all in about 1 day!
     </p>
 
 - title: Pass an audit

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -963,11 +963,11 @@ examples.
 
 [[aws_config]]
 ==== Enable AWS Config in all regions
-Gruntwork has created a code generation utility to make it simple to enable AWS Config in every region of an
-AWS account. Refer to the
-link:https://github.com/gruntwork-io/cis-compliance-aws/blob/master/modules/generate-aws-config/README.adoc[`generate-aws-config`
-documentation] for the details. Use the utility to enable AWS Config in all regions along with a global
-configuration recorder in one region, as per the Benchmark recommendation.
+Use the link:https://github.com/gruntwork-io/cis-compliance-aws/blob/master/modules/aws-config/README.adoc[`aws-config`
+module]
+to enable AWS Config in every region of an AWS account, along with a global configuration recorder in one region, as per
+the Benchmark recommendation.
+
 
 [[kms]]
 ==== Enable key rotation for KMS keys
@@ -1102,7 +1102,7 @@ sections above.
 1.21,<<iam_user_authentication>>,Create IAM users with the `iam-users` module
 1.22,<<iam_user_authentication>>,Use the Gruntwork modules to create best-practices groups and roles
 2.1-2.4,<<cloudtrail>>,Use the Gruntwork CloudTrail wrapper module
-2.5,<<aws_config>>,Quickly generate AWS Config for all regions
+2.5,<<aws_config>>,Enable AWS Config for all regions
 2.6-2.7,<<cloudtrail>>,Use the Gruntwork CloudTrail wrapper module
 2.8,<<kms>>,Use the KMS module
 2.9,<<vpc_flow_logs>>,Use the VPC flow logs core module

--- a/pages/checkout/_add-ons.html
+++ b/pages/checkout/_add-ons.html
@@ -41,6 +41,10 @@
             <h3 class="addon-type">CIS Benchmark Compliance</h3>
             <hr class="hr-sm hr-reset visible-sm-block visible-md-block visible-lg-block">
             <p>Achieve and maintain compliance with the CIS AWS Foundations Benchmark.</p>
+            <p class="text-muted small text-center margin-bottom-none visible-sm-block visible-md-block visible-lg-block">
+              Add <a href="#reference-architecture">Reference Architecture</a> to get a CIS compliant end to end
+              production-grade AWS architecture in 1 day.
+            </p>
             <p id="cis-button-aws"><a class="btn btn-primary addon-button" href="/contact/">Contact us for pricing</a></p>
           </div>
         </div>

--- a/pages/checkout/_add-ons.html
+++ b/pages/checkout/_add-ons.html
@@ -40,11 +40,10 @@
           <div class="panel-body text-center">
             <h3 class="addon-type">CIS Benchmark Compliance</h3>
             <hr class="hr-sm hr-reset visible-sm-block visible-md-block visible-lg-block">
-            <p>Achieve and maintain compliance with the CIS AWS Foundations Benchmark.</p>
-            <p class="text-muted small text-center visible-sm-block visible-md-block visible-lg-block">
-              Add <a href="#reference-architecture">Reference Architecture</a> to get an end-to-end production-grade
-              architecture architecture that has been certified by Gruntwork and CIS to be compliant with the CIS
-              Benchmarks, deployed into your AWS accounts, and fully managed as code—all in about 1 day!
+            <p>
+                Achieve and maintain compliance with the CIS AWS Foundations Benchmark. Our code is certified compliant
+                by the Center for Internet Security. Add the Reference Architecture to get an end-to-end,
+                production-grade architecture in your own AWS environment, fully managed as code - all in about 1 day!
             </p>
             <p id="cis-button-aws"><a class="btn btn-primary addon-button" href="/contact/">Contact us for pricing</a></p>
           </div>

--- a/pages/checkout/_add-ons.html
+++ b/pages/checkout/_add-ons.html
@@ -41,9 +41,10 @@
             <h3 class="addon-type">CIS Benchmark Compliance</h3>
             <hr class="hr-sm hr-reset visible-sm-block visible-md-block visible-lg-block">
             <p>Achieve and maintain compliance with the CIS AWS Foundations Benchmark.</p>
-            <p class="text-muted small text-center margin-bottom-none visible-sm-block visible-md-block visible-lg-block">
-              Add <a href="#reference-architecture">Reference Architecture</a> to get a CIS compliant end to end
-              production-grade AWS architecture in 1 day.
+            <p class="text-muted small text-center visible-sm-block visible-md-block visible-lg-block">
+              Add <a href="#reference-architecture">Reference Architecture</a> to get an end-to-end production-grade
+              architecture architecture that has been certified by Gruntwork and CIS to be compliant with the CIS
+              Benchmarks, deployed into your AWS accounts, and fully managed as code—all in about 1 day!
             </p>
             <p id="cis-button-aws"><a class="btn btn-primary addon-button" href="/contact/">Contact us for pricing</a></p>
           </div>

--- a/pages/reference-architecture/_sub-hero.html
+++ b/pages/reference-architecture/_sub-hero.html
@@ -13,6 +13,12 @@
       the code. The whole process takes about one day for AWS! If you're interested in a Reference Architecture for
       GCP, <a href="/contact">Contact Us</a>!
     </p>
+    <p>
+      We also offer a
+      <a href="https://www.cisecurity.org/benchmark/amazon_web_services/">CIS AWS Foundations Benchmark</a> compliant
+      version of the Reference Architecture. See our <a href="/achieve-compliance">Compliance offering</a> to learn
+      more.
+    </p>
     <p class="alert" style="border: 1px solid #194c5f; background-color: #242e3b;">
       <strong>Get a Detailed Walkthrough of the Reference Architecture</strong><br>
       See our blog post


### PR DESCRIPTION
We are very close to having the CIS Ref Arch ready for launch (https://github.com/gruntwork-io/cis-compliance-aws/pull/16 and https://github.com/gruntwork-io/usage-patterns/pull/356 are the two remaining PRs for the must have items from https://github.com/gruntwork-io/team-product/pull/7), so decided to open this PR to tee up the marketing activities for launching the offering.