### PR TITLE
Add detailed event tracking

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -12,13 +12,122 @@
 {% if site.ga_tracker %}
 
 <script>
-  window.ga = window.ga || function () { (ga.q = ga.q || []).push(arguments) }; ga.l = +new Date;
-  ga('create', '{{ site.ga_tracker }}', 'auto');
-  ga('require', 'eventTracker');
-  ga('require', 'maxScrollTracker');
-  ga('require', 'outboundFormTracker');
-  ga('require', 'outboundLinkTracker');
-  ga('send', 'pageview');
+  window.ga =
+    window.ga ||
+    function() {
+      (ga.q = ga.q || []).push(arguments);
+    };
+  ga.l = +new Date();
+
+  ga("create", "{{ site.ga_tracker }}", "auto");
+  ga("require", "eventTracker");
+  ga("require", "maxScrollTracker");
+  ga("require", "outboundFormTracker");
+  ga("require", "outboundLinkTracker");
+  ga("send", "pageview");
+
+  // Google Analytics Event Tracking for IAC Page A/B Tests
+  const IACVersion = getCookiebyName("IACLibraryVersion");
+
+  $("a").on("click", function() {
+    const href = $(this).attr("href");
+    if (!href) return;
+
+    if (href.includes("/contact")) {
+      const tag = "Click Contact Us";
+      const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+      ga("send", {
+        hitType: "event",
+        eventCategory: "CTA Clicks",
+        eventAction,
+        eventLabel: "User went to Contact Page",
+        eventValue: 1
+      });
+    } else if (href.includes("/pricing")) {
+      const tag = "Click Buy Now";
+      const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+      ga("send", {
+        hitType: "event",
+        eventCategory: "CTA Clicks",
+        eventAction,
+        eventLabel: "User went to Pricing Page",
+        eventValue: 1
+      });
+    } else if (href.includes("/checkout")) {
+      const tag = "Select Plan";
+      const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+      ga("send", {
+        hitType: "event",
+        eventCategory: "CTA Clicks",
+        eventAction,
+        eventLabel: "User selected Plan on Pricing Page",
+        eventValue: 1
+      });
+    }
+  });
+
+  $("#submit-button").on("click", () => {
+    const tag = "Submit Contact Form";
+    const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+    ga("send", {
+      hitType: "event",
+      eventCategory: "CTA Clicks",
+      eventAction,
+      eventLabel: "User submitted contact form",
+      eventValue: 1
+    });
+  });
+
+  $("#checkout-btn").on("click", () => {
+    const tag = "Click Checkout";
+    const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+    ga("send", {
+      hitType: "event",
+      eventCategory: "CTA Clicks",
+      eventAction,
+      eventLabel: "User clicked checkout button",
+      eventValue: 1
+    });
+  });
+
+  $("#pricing-cta-aws").on("click", () => {
+    const tag = "Select AWS";
+    const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+    ga("send", {
+      hitType: "event",
+      eventCategory: "CTA Clicks",
+      eventAction,
+      eventLabel: "User selected AWS plan.",
+      eventValue: 1
+    });
+  });
+
+  $("#pricing-cta-gcp").on("click", () => {
+    const tag = "Select GCP";
+    const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+    ga("send", {
+      hitType: "event",
+      eventCategory: "CTA Clicks",
+      eventAction,
+      eventLabel: "User selected GCP plan.",
+      eventValue: 1
+    });
+  });
+
+  $("#refarch-button-gcp").on("click", () => {
+    const tag = "Select GCP Refarch";
+    const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+    ga("send", {
+      hitType: "event",
+      eventCategory: "CTA Clicks",
+      eventAction,
+      eventLabel: "User selected GCP refarch addon.",
+      eventValue: 1
+    });
+  });
+
+  // TODO: Add Tracking for GCP AND AWS Pro Support Addon. They currently use same button so not
+  // quite straightforward
 </script>
 <script async src="https://www.google-analytics.com/analytics.js"></script>
 <script async src="https://cdnjs.cloudflare.com/ajax/libs/autotrack/2.4.1/autotrack.js"></script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -29,100 +29,94 @@
   // Google Analytics Event Tracking for IAC Page A/B Tests
   const IACVersion = getCookiebyName("IACLibraryVersion");
 
+  const createEventAction = (tag) => {
+    return IACVersion ? `${tag} (${IACVersion})` : tag;
+  }
+
+  const gaEventBaseObject = {
+    hitType: "event",
+    eventCategory: "CTA Clicks",
+    eventValue: 1
+  }
+
   $("a").on("click", function() {
     const href = $(this).attr("href");
     if (!href) return;
 
     if (href.includes("/contact")) {
       const tag = "Click Contact Us";
-      const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+      const eventAction = createEventAction(tag);
       ga("send", {
-        hitType: "event",
-        eventCategory: "CTA Clicks",
+        ...gaEventBaseObject,
         eventAction,
-        eventLabel: "User went to Contact Page",
-        eventValue: 1
+        eventLabel: "User went to Contact Page"
       });
     } else if (href.includes("/pricing")) {
       const tag = "Click Buy Now";
-      const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+      const eventAction = createEventAction(tag);
       ga("send", {
-        hitType: "event",
-        eventCategory: "CTA Clicks",
+        ...gaEventBaseObject,
         eventAction,
-        eventLabel: "User went to Pricing Page",
-        eventValue: 1
+        eventLabel: "User went to Pricing Page"
       });
     } else if (href.includes("/checkout")) {
       const tag = "Select Plan";
-      const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+      const eventAction = createEventAction(tag);
       ga("send", {
-        hitType: "event",
-        eventCategory: "CTA Clicks",
+        ...gaEventBaseObject,
         eventAction,
-        eventLabel: "User selected Plan on Pricing Page",
-        eventValue: 1
+        eventLabel: "User selected Plan on Pricing Page"
       });
     }
   });
 
   $("#submit-button").on("click", () => {
     const tag = "Submit Contact Form";
-    const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+    const eventAction = createEventAction(tag);
     ga("send", {
-      hitType: "event",
-      eventCategory: "CTA Clicks",
+      ...gaEventBaseObject,
       eventAction,
-      eventLabel: "User submitted contact form",
-      eventValue: 1
+      eventLabel: "User submitted contact form"
     });
   });
 
   $("#checkout-btn").on("click", () => {
     const tag = "Click Checkout";
-    const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+    const eventAction = createEventAction(tag);
     ga("send", {
-      hitType: "event",
-      eventCategory: "CTA Clicks",
+      ...gaEventBaseObject,
       eventAction,
-      eventLabel: "User clicked checkout button",
-      eventValue: 1
+      eventLabel: "User clicked checkout button"
     });
   });
 
   $("#pricing-cta-aws").on("click", () => {
     const tag = "Select AWS";
-    const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+    const eventAction = createEventAction(tag);
     ga("send", {
-      hitType: "event",
-      eventCategory: "CTA Clicks",
+      ...gaEventBaseObject,
       eventAction,
-      eventLabel: "User selected AWS plan.",
-      eventValue: 1
+      eventLabel: "User selected AWS plan"
     });
   });
 
   $("#pricing-cta-gcp").on("click", () => {
     const tag = "Select GCP";
-    const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+    const eventAction = createEventAction(tag);
     ga("send", {
-      hitType: "event",
-      eventCategory: "CTA Clicks",
+      ...gaEventBaseObject,
       eventAction,
-      eventLabel: "User selected GCP plan.",
-      eventValue: 1
+      eventLabel: "User selected GCP plan"
     });
   });
 
   $("#refarch-button-gcp").on("click", () => {
     const tag = "Select GCP Refarch";
-    const eventAction = IACVersion ? `${tag} (${IACVersion})` : tag;
+    const eventAction = createEventAction(tag);
     ga("send", {
-      hitType: "event",
-      eventCategory: "CTA Clicks",
+      ...gaEventBaseObject,
       eventAction,
-      eventLabel: "User selected GCP refarch addon.",
-      eventValue: 1
+      eventLabel: "User selected GCP refarch addon"
     });
   });
 

--- a/assets/js/iac-library.js
+++ b/assets/js/iac-library.js
@@ -1,0 +1,9 @@
+(function() {
+  /**
+   * A user sees either the new IAC Page or this one on the static app.
+   * This script will only run on the IAC Page.
+   * We need to keep track of which page the user has seen to compare the impact
+   * on the user's engagement.
+   */
+  setCookie("IACLibraryVersion", "Old-IAC");
+})();

--- a/pages/checkout/_checkout.html
+++ b/pages/checkout/_checkout.html
@@ -49,6 +49,7 @@
         <p class="small text-white text-bold margin-top-none text-center" id="deposit-due" style="margin-bottom: 0">Deposit Due<span class="hide-on-tiny"> Today</span>: $500</p>
       </div>
       <button
+        id="checkout-btn"
         type="button"
         class="btn btn-info btn-block btn-checkout"
         data-cb-type="checkout"

--- a/pages/infrastructure-as-code-library/_hero.html
+++ b/pages/infrastructure-as-code-library/_hero.html
@@ -10,10 +10,6 @@
           href="/contact"
           class="btn get-a-demo"
           role="button"
-          ga-on="click"
-          ga-event-category="CTA Clicks"
-          ga-event-action="Click Contact Us(Old IAC Page)"
-          ga-event-label="User clicked contact button in old IAC page"
           >{{ link.title }}Get a Demo</a
         >
       </p>

--- a/pages/infrastructure-as-code-library/index.html
+++ b/pages/infrastructure-as-code-library/index.html
@@ -7,6 +7,7 @@ slug: gruntwork-library
 footer_heading: Ready to hand off the Gruntwork?
 custom_js:
   - search
+  - iac-library
 redirect_from:
   - /infrastructure/
   - /gruntwork-library/

--- a/pages/pricing/_aws-pricing.html
+++ b/pages/pricing/_aws-pricing.html
@@ -11,7 +11,7 @@
         <p class="help-block" style="margin-top:-9px;">per month</p>
       </div>
       <div data-mh="plans-pricing-bottom" style="height:100px">
-        <p><a class="btn btn-info pricing-ctas pricing-cta-aws" href="{{ site.data.pricing.subscriptions.aws.checkout_url }}">Select</a></p>
+        <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="{{ site.data.pricing.subscriptions.aws.checkout_url }}">Select</a></p>
         <p class="text-muted small"><em>Annual contract<br>Billed monthly or annually.</em></p>
       </div>
     </div>

--- a/pages/pricing/_gcp-pricing.html
+++ b/pages/pricing/_gcp-pricing.html
@@ -14,7 +14,7 @@
         <p class="help-block" style="margin-top:-9px;">per month</p>
       </div>
       <div data-mh="plans-pricing-bottom" style="height:100px">
-        <p><a class="btn btn-info pricing-ctas pricing-cta-gcp" href="{{ site.data.pricing.subscriptions.gcp.checkout_url }}">Select</a></p>
+        <p><a id="pricing-cta-gcp" class="btn btn-info pricing-ctas" href="{{ site.data.pricing.subscriptions.gcp.checkout_url }}">Select</a></p>
         <p class="text-muted small"><em>Annual contract.<br>Billed monthly or annually.</em></p>
         <p id="gcp-special-pricing">Special Introductory Price!</p>
       </div>


### PR DESCRIPTION
When the counterpart[ PR on the SAAS App](https://github.com/gruntwork-io/mission-control/pull/173) is merged; we will be able to have events tracked as shown below for the IAC Page A/B test.

<img width="1899" alt="Screen Shot 2019-12-31 at 12 49 07 PM" src="https://user-images.githubusercontent.com/21035422/71633146-c31e7800-2bcf-11ea-8a7a-3aa4fdfe466d.png">
