### PR TITLE
Fix variables links

### DIFF
--- a/_posts/2019-08-13-how-to-deploy-production-grade-vpc-aws.adoc
+++ b/_posts/2019-08-13-how-to-deploy-production-grade-vpc-aws.adoc
@@ -708,7 +708,7 @@ module "vpc" {
 ----
 
 Note that all of the parameters should be exposed as input variables in `variables.tf`; see this
-https://github.com/gruntwork-io/infrastructure-modules-multi-account-acme/blob/master/networking/vpc-mgmt/vars.tf[vars.tf]
+https://github.com/gruntwork-io/infrastructure-modules-multi-account-acme/blob/master/networking/vpc-mgmt/variables.tf[variables.tf]
 file for reference. This will allow you to set those variables to different values in different environments or AWS
 accounts.
 
@@ -926,7 +926,7 @@ module "vpc" {
 ----
 
 Note that all of the parameters should be exposed as input variables in `variables.tf`; see this
-https://github.com/gruntwork-io/infrastructure-modules-multi-account-acme/blob/master/networking/vpc-app/vars.tf[vars.tf]
+https://github.com/gruntwork-io/infrastructure-modules-multi-account-acme/blob/master/networking/vpc-app/variables.tf[variables.tf]
 file for reference. This will allow you to set those variables to different values in different environments or AWS
 accounts.
 


### PR DESCRIPTION
There are two references/links on this page to vars.tf. This was causing a 404 after the vars.tf was renamed to variables.tf.