### PR TITLE
Update the compliance guide to reflect new developments

### DIFF
--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -423,8 +423,8 @@ the documentation for more information on using a hardware device with the root 
 ===== Subscribe to SNS topic
 The Config alerts and CloudWatch Metric Alarms all go to an SNS topic. Unfortunately, there is no way to automate
 subscribing to the SNS topic as each of the steps require validating the delivery target. Follow the steps outlined in
-the link:https://docs.aws.amazon.com/sns/latest/dg/sns-user-notifications.html[AWS docs] for configuring notifications
-to you for each of the alerts.
+the link:https://docs.aws.amazon.com/sns/latest/dg/sns-user-notifications.html[AWS docs] to be notified by Email, Phone,
+or SMS for each of the alerts.
 
 You can also configure an automated system integration if you have a third party alerting system or central dashboard.
 Follow the steps in the link:https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subscriber.html[AWS

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -419,6 +419,18 @@ factors. Refer to
 link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_physical.html#enable-hw-mfa-for-root[
 the documentation for more information on using a hardware device with the root user].
 
+[[subscribe_sns]]
+===== Subscribe to SNS topic
+The Config alerts and CloudWatch Metric Alarms all go to an SNS topic. Unfortunately, there is no way to automate
+subscribing to the SNS topic as each of the steps require validating the delivery target. Follow the steps outlined in
+the link:https://docs.aws.amazon.com/sns/latest/dg/sns-user-notifications.html[AWS docs] for configuring notifications
+to you for each of the alerts.
+
+You can also configure an automated system integration if you have a third party alerting system or central dashboard.
+Follow the steps in the link:https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subscriber.html[AWS
+docs] on how to add an HTTPS endpoint as a subscriber to the alerts.
+
+
 [[security_questions]]
 ===== Answer security questions and complete contact details
 When setting up a new account, AWS asks for contact information and security questions. Unfortunately, there
@@ -1049,7 +1061,13 @@ link:https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.
 Filters]. Gruntwork has simplified this section to a single module: the
 link:https://github.com/gruntwork-io/cis-compliance-aws/blob/master/modules/cloudwatch-logs-metric-filters/README.adoc[`cloudwatch-logs-metric
 -filters` wrapper module]. It will create and configure all the CloudWatch Logs metric filters necessary for
-compliance with the Benchmark.
+compliance with the Benchmark. Note that when you use the
+link:https://github.com/gruntwork-io/cis-compliance-aws/blob/master/modules/cloudtrail/README.adoc[`cloudtrail`
+wrapper module] as recommeneded in <<cloudtrail>>, this module will automatically be invoked inline so that you don't
+have to do anything special to enable the metric filters on the deployed CloudTrail configuration.
+
+Note that you must have a subscriber on the SNS topic to be compliant. Refer to <<subscribe_sns>> for details on how to
+setup a subscriber to the SNS topics that are created.
 
 [[configure_networking]]
 === Configure networking
@@ -1069,11 +1087,14 @@ Benchmark. Now it's time to confirm that your configurations are correct and you
  +
  +
 
-You can enable the link:https://aws.amazon.com/security-hub/[AWS Security Hub] to check your account
-link:https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards.html[for compliance with the AWS CIS
-Foundations Benchmark]. The Security Hub runs the exact audit steps specified in the Benchmark using AWS Config managed
-rules. By enabling the Security Hub, you can track your compliance efforts and be notified if any recommendations have
-not been implemented. Follow the AWS documentation to enable Security Hub.
+Use the
+link:https://github.com/gruntwork-io/cis-compliance-aws/blob/master/modules/aws-securityhub/README.adoc[`aws-securityhub`
+module]
+to enable link:https://aws.amazon.com/security-hub/[AWS Security Hub] in every region of an AWS account to check your
+account link:https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards.html[for compliance with the
+AWS CIS Foundations Benchmark]. The Security Hub runs the exact audit steps specified in the Benchmark using AWS Config
+managed rules. By enabling the Security Hub, you can track your compliance efforts and be notified if any
+recommendations have not been implemented.
 
 
 [[traceability_matrix]]
@@ -1087,10 +1108,10 @@ sections above.
 #,Section,Description
 1.1,<<manual_steps>>,Take manual steps to complete this recommendation
 1.2,<<configure_authentication>>,Configure authentication using SAML or IAM
-1.3,<<next_steps>>,Enable AWS Security Hub to ensure that there are no unused credentials
-1.4,<<next_steps>>,Enable AWS Security Hub to ensure that there are no unused access keys
+1.3,<<next_steps>>,Use the Gruntwork Security Hub module to enable AWS Security Hub to ensure that there are no unused credentials
+1.4,<<next_steps>>,Use the Gruntwork Security Hub module to enable AWS Security Hub to ensure that there are no unused access keys
 1.5-11,<<create_password_policy>>,Use the IAM password policy module
-1.12,<<next_steps>>,Enable AWS Security Hub to ensure that no access key exists for the root user
+1.12,<<next_steps>>,Use the Gruntwork Security Hub module to enable AWS Security Hub to ensure that no access key exists for the root user
 1.13,<<root_mfa>>,Manually configure MFA for the root user
 1.14,<<root_mfa>>,Use a Yubikey (or other hardware MFA) for the root user
 1.15,<<security_questions>>,Answer the security questions on the AWS account page

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -1063,7 +1063,7 @@ link:https://github.com/gruntwork-io/cis-compliance-aws/blob/master/modules/clou
 -filters` wrapper module]. It will create and configure all the CloudWatch Logs metric filters necessary for
 compliance with the Benchmark. Note that when you use the
 link:https://github.com/gruntwork-io/cis-compliance-aws/blob/master/modules/cloudtrail/README.adoc[`cloudtrail`
-wrapper module] as recommeneded in <<cloudtrail>>, this module will automatically be invoked inline so that you don't
+wrapper module] as recommended in <<cloudtrail>>, this module will automatically be invoked inline so that you don't
 have to do anything special to enable the metric filters on the deployed CloudTrail configuration.
 
 Note that you must have a subscriber on the SNS topic to be compliant. Refer to <<subscribe_sns>> for details on how to


### PR DESCRIPTION
- Add section in "Manual steps" to subscribe to the SNS topic as that is necessary to pass the benchmark.
- Make sure to refer back to the new SNS topic subscribe instructions in `configure_monitoring`
- Extend `configure_monitoring` to mention that the metric filters are now called directly in the `cloudtrail` module.
- Update Security Hub instructions to refer to our new module