### PR TITLE
Point to module-security aws-config-multi-region instead of cis-compliance-aws aws-config

### DIFF
--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -975,7 +975,8 @@ examples.
 
 [[aws_config]]
 ==== Enable AWS Config in all regions
-Use the link:https://github.com/gruntwork-io/cis-compliance-aws/blob/master/modules/aws-config/README.adoc[`aws-config`
+Use the
+link:https://github.com/gruntwork-io/module-security/blob/master/modules/aws-config-multi-region/README.adoc[`aws-config-multi-region`
 module]
 to enable AWS Config in every region of an AWS account, along with a global configuration recorder in one region, as per
 the Benchmark recommendation.


### PR DESCRIPTION
Since we migrated `aws-config` out of `cis-compliance-aws`, the guide should be updated to reflect that.