### PR TITLE
Add hidden viewing form field to contact form [HSTN-969]

### DIFF
--- a/pages/contact/_form.html
+++ b/pages/contact/_form.html
@@ -1,6 +1,7 @@
 <div id="error-message"></div>
 <form id="contact-form" method="post" target="_blank" action="https://api.formbucket.com/f/buk_7iB8j7vEJPW9ad2ClJwFfm5M" >
   <input type="hidden" name="_subject" id="_subject" value="New inquiry from {{ site.url }}" />
+  <input type="hidden" name="_viewing" id="_viewing" value="Static Website" />
   <input type="hidden" name="_next" value="{{ site.url }}/thanks/" />
   <input type="text" name="_gotcha" style="display:none" />
   {% include_relative _input-text.html id="contact-name" label="Name" required=true placeholder="Jon Doe" %}


### PR DESCRIPTION
Half of requirement for [capturing in the contact form which A/B testing bucket a user is in.](https://gruntwork.atlassian.net/browse/HSTN-969)

The other part will be done in the [mission control repo](https://github.com/gruntwork-io/mission-control/pull/230).