### PR TITLE
Fix minor typo in cicd deploy guide

### DIFF
--- a/_posts/2020-02-06-how-to-configure-a-production-grade-ci-cd-setup-for-apps-and-infrastructure-code.adoc
+++ b/_posts/2020-02-06-how-to-configure-a-production-grade-ci-cd-setup-for-apps-and-infrastructure-code.adoc
@@ -801,7 +801,7 @@ relying on a single platform for implementing the entire workflow. Instead, we r
 advantage of the strengths of each platform, and cover the weaknesses. The design looks as follows:
 
 - Deploy a self-hosted deploy server within your AWS account that has the permissions it needs to run infrastructure
-  deployments and is locked down so it is only accessible via a trigger that can be used to define pre-defined commands
+  deployments and is locked down so it is only accessible via a trigger that can be used to run pre-defined commands
   (e.g., `terraform plan` and `terraform apply`) in pre-defined repos (e.g., `infrastructure-live`).
 - Use any generic CI/CD server (e.g., Jenkins, CircleCI, GitLab) to implement a CI/CD workflow where you trigger a
   dry-run in the deploy server (e.g., `terraform plan`), get approval to proceed from an admin on your team (e.g., via a


### PR DESCRIPTION
Fix minor typo from https://github.com/gruntwork-io/gruntwork-io.github.io/pull/272