### PR TITLE
Remove / from title

### DIFF
--- a/_posts/2020-02-06-how-to-configure-a-production-grade-ci-cd-setup-for-apps-and-infrastructure-code.adoc
+++ b/_posts/2020-02-06-how-to-configure-a-production-grade-ci-cd-setup-for-apps-and-infrastructure-code.adoc
@@ -1,5 +1,5 @@
 ---
-title: How to configure a production-grade CI/CD workflow for infrastructure code
+title: How to configure a production-grade CICD workflow for infrastructure code
 categories: Automations
 image: /assets/img/guides/infrastructure-cicd-pipeline/terraform-icon.png
 excerpt: Learn about CI/CD workflows for Terraform and Terragrunt, including the differences between application code, different CI servers, threat models, and more.


### PR DESCRIPTION
This looks like what broke the guide listing page.