### PR TITLE
Update contact form [HSTN-1284 HSTN-1285]

### DIFF
--- a/pages/contact/_form.html
+++ b/pages/contact/_form.html
@@ -1,7 +1,7 @@
 <div id="error-message"></div>
 <form id="contact-form" method="post" target="_blank" action="https://api.formbucket.com/f/buk_7iB8j7vEJPW9ad2ClJwFfm5M" >
   <input type="hidden" name="_subject" id="_subject" value="New inquiry from {{ site.url }}" />
-  <input type="hidden" name="_viewing" id="_viewing" value="Static Website" />
+  <input type="hidden" name="_viewing" id="_viewing" value="v1-static" />
   <input type="hidden" name="_next" value="{{ site.url }}/thanks/" />
   <input type="text" name="_gotcha" style="display:none" />
   {% include_relative _input-text.html id="contact-name" label="Name" required=true placeholder="Jon Doe" %}
@@ -16,8 +16,6 @@
         {% include_relative _input-check.html id="interested-subscription" label="Gruntwork Subscription" small_text="Includes access to: Infrastructure as Code Library, DevOps Training Library" %}
         {% include_relative _input-check.html id="interested-pro-support" label="Pro Support" %}
         {% include_relative _input-check.html id="interested-ref-arch" label="Reference Architecture" %}
-        {% include_relative _input-check.html id="interested-devops-bootcamp" label="DevOps Bootcamp" %}
-        {% include_relative _input-check.html id="interested-custom-module-development" label="Custom Module Development" %}
         {% include_relative _input-check.html id="interested-cis-compliance" label="CIS compliance" small_text="Achieve compliance with the CIS AWS Foundations Benchmark" %}
         {% include_relative _input-hidden.html id="user-utc-timezone-offset" %}
       </div>


### PR DESCRIPTION
- Removes "custom-module-development" and "devops-bootcamp" options from contact form
- Renames `_viewing` field value as `v1-static`


#### Screenshots
<img width="1912" alt="Screen Shot 2020-04-10 at 10 45 02 AM" src="https://user-images.githubusercontent.com/21035422/79007429-63156700-7b18-11ea-86ff-03e91d5cd378.png">
<img width="1074" alt="Screen Shot 2020-04-10 at 10 44 19 AM" src="https://user-images.githubusercontent.com/21035422/79007426-627cd080-7b18-11ea-8743-de77f5516e40.png">

