### PR TITLE
Fix Contact-Us URL 2

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -155,7 +155,7 @@ $(function () {
 
     $.ajax(postParams).done(function() {
       inCall = false;
-      window.location.replace('/thanks');
+      window.location.replace('/static/thanks');
     }).fail(function(error) {
       showFormError('Oops, something went wrong! Please try again. If the issue persists please email us directly at info@gruntwork.io');
       inCall = false;


### PR DESCRIPTION
This is another place where the URL should have been changed to include
`/static`.