### PR TITLE
Chore/update pages [PLFM-1328]

### DIFF
--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -256,15 +256,3 @@
           For monthly billing, we require automated payments via credit card or ACH transfer. If you wish to use invoices and pay by wire transfer or check instead, you must do annual billing.
         </p>
 
-- category_name: Infrastructure as Code Library
-  items:
-    - question: What do I do if I need infrastructure that isn't in the Infrastructure as Code Library?
-      answer: |
-        <p>
-          If the infrastructure you need is something general-purpose that applies to many companies (i.e., isn't a
-          custom, one-off project completely unique to your company), we'd be happy to build it, add it to the
-          Infrastructure as Code Library, and provide support, maintenance, and updates for it long-term! For example, we're
-          currently looking into adding ElasticSearch, Kubernetes, and DataDog to our Library and are looking for
-          companies willing to fund those projects. See <a href="/static/custom-module-development/">Custom Module Development</a>
-          for more info.
-        </p>

--- a/_data/initial-setup-how-it-works.yml
+++ b/_data/initial-setup-how-it-works.yml
@@ -17,8 +17,6 @@
       <li>Kafka, ZooKeeper, ELK, MongoDB, and many other options</li>
     </ul>
 
-    <p class="text-muted"><em>Are we missing something you want? Pay us a one-time fee to <a href="/static/custom-module-development/">build it for you</a>.</em></p>
-
 - title: We build your architecture
   description: |
     <p>

--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -12,12 +12,6 @@
     - title: Support
       url: /static/support/
 
-    - title: DevOps Bootcamp
-      url: /static/devops-bootcamp/
-
-    - title: Module Development
-      url: /static/custom-module-development/
-
 - title: Learn
   links:
     - title: How it Works

--- a/_data/steps.yml
+++ b/_data/steps.yml
@@ -37,8 +37,7 @@
 - title: Get ongoing maintenance and updates
   description: |
     At Gruntwork, we provide ongoing maintenance and updates for all the code in the IaC Library and Reference
-    Architecture. We regularly add new modules (see <a href="/static/custom-module-development/">Custom Module Development</a>)
-    and every time Terraform comes out with a new version, AWS or GCP release new services, or a security vulnerability
+    Architecture. We regularly add new modules and every time Terraform comes out with a new version, AWS or GCP release new services, or a security vulnerability
     is announced, we update our code, release a new version, and announce it in our
     <a href="https://blog.gruntwork.io/tagged/gruntwork-newsletter" target="_blank">newsletter</a>. As a Subscriber,
     you get better infrastructure just by bumping a version number in your code!

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -76,40 +76,11 @@
           </li>
           <li id="services-nav-item-beta" class="dropdown">
             <a
-              href="#"
-              class="dropdown-toggle"
-              data-toggle="dropdown"
-              role="button"
-              aria-expanded="false"
-              >Services <i class="fa fa-caret-down" aria-hidden="true"></i
-            ></a>
-            <ul class="dropdown-menu dropdown-menu-left" role="menu">
-              <li>
-                <a
-                  href="/static/support/"
-                  ga-event-category="nav-{{ page.path | slugify }}"
-                  ga-event-action="support"
-                  >Support</a
-                >
-              </li>
-              <li>
-                <a
-                  href="/static/devops-bootcamp/"
-                  ga-on="click"
-                  ga-event-category="nav-{{ page.path | slugify }}"
-                  ga-event-action="devops-bootcamp"
-                  >DevOps Bootcamp</a
-                >
-              </li>
-              <li>
-                <a
-                  href="/static/custom-module-development/"
-                  ga-event-category="nav-{{ page.path | slugify }}"
-                  ga-event-action="custom-module-dev"
-                  >Custom Module Development</a
-                >
-              </li>
-            </ul>
+              href="/static/support/"
+              ga-event-category="nav-{{ page.path | slugify }}"
+              ga-event-action="support"
+              >Support</a
+            >
           </li>
           <li>
             <a

--- a/pages/custom-module-development/index.html
+++ b/pages/custom-module-development/index.html
@@ -4,16 +4,5 @@ title: Custom Module Development
 excerpt: Reusable, documented, tested modules for deploying and managing any type of software.
 permalink: /static/custom-module-development/
 slug: custom-module-development
-footer_heading: Ready to hand off the Gruntwork?
+redirect_to: /static/support
 ---
-
-<div class="main">
-  <div class="section section-hero section-hero-with-button">
-    {% include_relative _hero.html %}
-  </div>
-  <div class="section section-dark">
-    <div class="container">
-      {% include_relative _sub-hero.html %}
-    </div>
-  </div>
-</div>

--- a/pages/devops-bootcamp/index.html
+++ b/pages/devops-bootcamp/index.html
@@ -4,18 +4,5 @@ title: DevOps Bootcamp
 excerpt: Learn DevOps best practices and get your entire infrastructure defined as code in this 3-day, on-site training session.
 permalink: /static/devops-bootcamp/
 slug: devops-bootcamp
-footer_heading: Ready to hand off the Gruntwork?
+redirect_to: /static/support
 ---
-
-<div class="main">
-  <div class="section section-hero section-hero-with-button">
-    {% include_relative _hero.html %}
-  </div>
-  <div class="section section-dark">
-    <div class="container">
-      {% include_relative _sub-hero.html %}
-      {% include_relative _gcp.html %}
-      {% include_relative _pricing.html %}
-    </div>
-  </div>
-</div>

--- a/pages/training/_more-info.html
+++ b/pages/training/_more-info.html
@@ -3,11 +3,6 @@
   Access to the DevOps Training Library, including all current courses as well as future updates and additions, is
   available as part of the Gruntwork Subscription. Check out the <a href="/static/pricing/">pricing page</a> for details.
 </p>
-<h3 class="h2">Looking for live, on-site training?</h3>
-<p>
-  For teams that want a personalized, accelerated, hands-on way to learn DevOps best practices, check out our
-  <a href="/static/devops-bootcamp/">DevOps Bootcamps</a>.
-</p>
 <h3 class="h2">Looking for resources to learn DevOps?</h3>
 <p>
   You can find a collection of blog posts, talks, and books about DevOps on our <a href="/static/devops-resources/">DevOps Resources</a> page.


### PR DESCRIPTION
- Removes custom-module-development & devops-bootcamp pages and their references
- Redirects `static/custom-module-development` & `static/devops-bootcamp` to "/static/support"

<img width="1918" alt="Screen Shot 2020-05-05 at 4 58 13 PM" src="https://user-images.githubusercontent.com/21035422/81124131-eb0d4780-8ef1-11ea-8985-3c27e50e02b3.png">
