### PR TITLE
Chore/restore cookie notification [WWW-24]

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -41,46 +41,56 @@
     a.appendChild(r);
   })(window, document, "https://static.hotjar.com/c/hotjar-", ".js?sv=");
 </script>
-<script>
-  window.intercomSettings = {
-    app_id: "rzcjacgd"
-  };
-</script>
 {% endif %}
 
 <!-- Intercom -->
 <script>
-  (function() {
+  console.log("Runnning this script!!!!!")
+  window.intercomSettings = {
+    app_id: "rzcjacgd"
+  };
+</script>
+<script>
+  (function () {
     var w = window;
     var ic = w.Intercom;
     if (typeof ic === "function") {
       ic("reattach_activator");
-      ic("update", intercomSettings);
+      ic("update", w.intercomSettings);
     } else {
       var d = document;
-      var i = function() {
+      var i = function () {
         i.c(arguments);
       };
       i.q = [];
-      i.c = function(args) {
+      i.c = function (args) {
         i.q.push(args);
       };
       w.Intercom = i;
-      function l() {
+      var l = function () {
         var s = d.createElement("script");
         s.type = "text/javascript";
         s.async = true;
-        s.src = "https://widget.intercom.io/widget/rzcjacgd";
+        s.src = `https://widget.intercom.io/widget/${w.intercomSettings.app_id}` ;
         var x = d.getElementsByTagName("script")[0];
         x.parentNode.insertBefore(s, x);
-      }
-      if (w.attachEvent) {
+      };
+      if (document.readyState === "complete") {
+        l();
+      } else if (w.attachEvent) {
         w.attachEvent("onload", l);
       } else {
         w.addEventListener("load", l, false);
       }
     }
-  })();
+})();
 </script>
+<script>
+  window.Intercom("boot", {
+    app_id: window.intercomSettings.app_id
+  });
+</script>
+
+<!-- Cookie Policy Notification -->
 <script src="{{ site.assets_base_url }}js/cookie.js" async></script>
 {% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -45,7 +45,6 @@
 
 <!-- Intercom -->
 <script>
-  console.log("Runnning this script!!!!!")
   window.intercomSettings = {
     app_id: "rzcjacgd"
   };

--- a/assets/css/global.less
+++ b/assets/css/global.less
@@ -2571,9 +2571,14 @@ body.checkout .section-heading .gw-icon {
   box-shadow: 0 8px 16px 0 rgba(34,50,84,.06);
   border-radius: 8px;
   text-align: center;
+
+  .cookie-notification {
+    display: flex;
+    align-items: center;
+  }
+
   p {
     margin: 0;
-    float: left;
     padding: 15px 0 10px;
     font-size: 18px;
     line-height: 22px;

--- a/assets/js/cookie.js
+++ b/assets/js/cookie.js
@@ -2,15 +2,14 @@
  * Cookie notice
  * @author AKOS
  *
- * This cookie script must load AFTER the Intercom code above to detect the global "Intercom" variable
- * and render the cookie notice right after Intercom's script is injected into the <body>. This will ensure
+ * This cookie script must load AFTER the Intercom code. This will ensure
  * that our cookie notice renders ABOVE the Intercom bubble to avoid conflicts with z-index.
  */
 
 (function ($) {
   "use strict";
   var cookieInnerHtml =
-    '<div><p>By using this website you agree to our <a href="/cookie-policy/">cookie policy</a></p><button id="cookieModalClose" class="btn btn-primary">OK</button></div>';
+    '<div class="cookie-notification"><p>By using this website you agree to our <a href="/cookie-policy/">cookie policy</a></p><button id="cookieModalClose" class="btn btn-primary">OK</button></div>';
 
   var displayCookiePopUp = function () {
     // Don't create cookie notice if already acknowledged

--- a/assets/js/cookie.js
+++ b/assets/js/cookie.js
@@ -7,12 +7,12 @@
  * that our cookie notice renders ABOVE the Intercom bubble to avoid conflicts with z-index.
  */
 
-(function($) {
+(function ($) {
   "use strict";
   var cookieInnerHtml =
     '<div><p>By using this website you agree to our <a href="/cookie-policy/">cookie policy</a></p><button id="cookieModalClose" class="btn btn-primary">OK</button></div>';
 
-  var initCookie = function() {
+  var displayCookiePopUp = function () {
     // Don't create cookie notice if already acknowledged
     if (getCookiebyName("GruntyCookie")) {
       return;
@@ -24,7 +24,7 @@
     $cookieModal.css("z-index", "2147483647");
     $cookieModal.html(cookieInnerHtml);
 
-    $(document).on("click", "#cookieModalClose", function() {
+    $(document).on("click", "#cookieModalClose", function () {
       setCookie("GruntyCookie", "1", 365);
       $cookieModal.hide();
     });
@@ -32,27 +32,5 @@
     $("body").append($cookieModal);
   };
 
-  // Checks for the global Intercom object is set from the Intercom script.
-  if (!!window.Intercom) {
-    var cookieInterval;
-    cookieInterval = setInterval(function() {
-      // Perform multiple checks on Intercom.booted property.
-      // https://gist.github.com/FokkeZB/033d4a9089fff392f7990a452e1d323d#gistcomment-2653218
-      if (!window.Intercom.booted) {
-        return;
-      }
-
-      // Try to find the Intercom container element.
-      if (document.getElementById("intercom-container") === null) {
-        return;
-      }
-
-      // Remove interval after Intercom has booted
-      clearInterval(cookieInterval);
-      initCookie();
-    }, 250);
-  } else {
-    // Intercom wasn't detected on this page, render cookie as usual.
-    initCookie();
-  }
+  displayCookiePopUp();
 })(window.jQuery);


### PR DESCRIPTION

<img width="1711" alt="Screen Shot 2020-06-01 at 6 16 03 PM" src="https://user-images.githubusercontent.com/21035422/83466356-1709e300-a434-11ea-921b-2cee6db72edd.png">


Below are the issues that were identified & resolved.
- The intercom app_id was only being set when the application permits hotjar recording. Fixed by removing the dependency.
- The intercom setup didn't call intercom's boot method as specified here: https://developers.intercom.com/installing-intercom/docs/basic-javascript#section-step-2-launch-messenger
- The cookie notification display was predicated on not only intercom being loaded and but also opened by the user. Fixed by removing the dependency.