### PR TITLE
Fix ci cd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ references:
     run:
       name: install jdk 8
       command: |
-        apt install -y wget gnupg software-properties-common
+        sudo apt-get install -y wget gnupg software-properties-common
         wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
         sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
         apt update -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ references:
       name: deploy to staging
       command: |
         set +o pipefail
-        if [[ "$CIRCLE_BRANCH" == "fix-ci-cd" ]]; then
+        if [[ "$CIRCLE_BRANCH" == "master" ]]; then
           export CREDENTIALS=`aws sts assume-role --role-arn arn:aws:iam::151025255439:role/allow-gruntwork-website-ci-cd-access-from-other-accounts --role-session-name CircleCI --duration-seconds 900 --output=json`
           export AWS_ACCESS_KEY_ID=`echo ${CREDENTIALS} | jq -r '.Credentials.AccessKeyId'`
           export AWS_SECRET_ACCESS_KEY=`echo ${CREDENTIALS} | jq -r '.Credentials.SecretAccessKey'`
@@ -127,7 +127,7 @@ workflows:
       - deploy-to-stage:
           filters:
             branches:
-              only: fix-ci-cd
+              only: master
       - deploy-to-prod:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,17 +32,20 @@ references:
 
   install_jdk: &install-jdk
     run:
-      name: install jdk
+      name: install jdk 8
       command: |
-        sudo apt-get update
-        sudo apt-get install -y default-jre texlive texlive-xetex texlive-latex-recommended texlive-latex-extra texlive-lang-cjk
+        apt install -y wget gnupg software-properties-common
+        wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+        sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+        apt update -y
+        sudo apt-get install -y adoptopenjdk-8-hotspot texlive texlive-xetex texlive-latex-recommended texlive-latex-extra texlive-lang-cjk
 
   deploy_to_staging: &deploy-to-staging
     run:
       name: deploy to staging
       command: |
         set +o pipefail
-        if [[ "$CIRCLE_BRANCH" == "master" ]]; then
+        if [[ "$CIRCLE_BRANCH" == "fix-ci-cd" ]]; then
           export CREDENTIALS=`aws sts assume-role --role-arn arn:aws:iam::151025255439:role/allow-gruntwork-website-ci-cd-access-from-other-accounts --role-session-name CircleCI --duration-seconds 900 --output=json`
           export AWS_ACCESS_KEY_ID=`echo ${CREDENTIALS} | jq -r '.Credentials.AccessKeyId'`
           export AWS_SECRET_ACCESS_KEY=`echo ${CREDENTIALS} | jq -r '.Credentials.SecretAccessKey'`
@@ -124,7 +127,7 @@ workflows:
       - deploy-to-stage:
           filters:
             branches:
-              only: master
+              only: fix-ci-cd
       - deploy-to-prod:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ references:
         sudo apt-get install -y wget gnupg software-properties-common
         wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
         sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-        apt update -y
+        sudo apt-get update -y
         sudo apt-get install -y adoptopenjdk-8-hotspot texlive texlive-xetex texlive-latex-recommended texlive-latex-extra texlive-lang-cjk
 
   deploy_to_staging: &deploy-to-staging


### PR DESCRIPTION
This PR addresses the recent break in CI/CD that was caused by `s3_website` script. This script relies on Java 8 and cannot go beyond that. 

In my previous PR, the updated OS installed OpenJDK 11. In order to test the CI/CD, I had to manually change the "branch" parameter and I didn't get _all_ of the instances where that change had to be made so I was able to observe the CI/CD job run, each step showed up as "green" but upon closer inspection, they were actually being skipped and this only became evident when the whole PR got merged into `master`

In this PR, I updated the CI/CD to install OpenJDK 8 and now we should be ok