### PR TITLE
[WWW-51] Added Footer link to Repos

### DIFF
--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -3,6 +3,9 @@
     - title: Infrastructure Code Library
       url: /infrastructure-as-code-library/
 
+    - title: Repo Browser
+      url: /repos/      
+
     - title: Reference Architecture
       url: /reference-architecture/
 

--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -1,10 +1,7 @@
 - title: Products &amp; Services
   links:
     - title: Infrastructure Code Library
-      url: /infrastructure-as-code-library/
-
-    - title: Repo Browser
-      url: /repos/      
+      url: /infrastructure-as-code-library/  
 
     - title: Reference Architecture
       url: /reference-architecture/
@@ -14,6 +11,9 @@
 
     - title: Support
       url: /support/
+
+    - title: Repo Browser
+      url: /repos/          
 
 - title: Learn
   links:


### PR DESCRIPTION
This PR adds the `/repos` link to the footer of the page.

**Note:** it will not be possible to verify that this URL works properly in the preview environment as we don't have the concept of redirecting to the SaaS app from Netlify.

[WWW-51] 

[WWW-51]: https://gruntwork.atlassian.net/browse/WWW-51