### PR TITLE
add new sre role to careers [SRE-4]

### DIFF
--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -112,6 +112,7 @@
         less on
         <a
           href="https://landing.google.com/sre/sre-book/chapters/eliminating-toil/"
+          target="_blank"
           >toil</a
         >
         and the rest engineering solutions to reduce it for the whole team

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -88,22 +88,108 @@
 
     <hr />
 
-    <h3>Senior Software Engineer</h3>
+    <a target="site-reliability-engineer"></a>
+    <h3>Site Reliability Engineer (SRE)</h3>
+    <h4>
+      Be an SRE without being on call! Help Gruntwork develop SRE as a product
+      offering and enable our hundreds of customers to achieve best-practices
+      for operations and reliability, all while not being woken up at 3am!
+    </h4>
+    <h4>What You'll Work On</h4>
+    <ul>
+      <li>
+        <strong>Build an SRE product offering:</strong> Develop logging,
+        monitoring, and alerting strategies around availability, latency, and
+        overall systems health and develop solutions that can be deployed
+        internally and externally for our customers.
+      </li>
+      <li>
+        <strong>Toil/Engineering balance:</strong> Spend 50% of your time or
+        less on toil and the rest engineering solutions to reduce it for the
+        whole team.
+      </li>
+      <li>
+        <strong>Document tribal knowledge:</strong> Capture siloed knowledge to
+        create knowledgebase articles, runbooks, and other documentation for the
+        internal team as well as Gruntwork customers.
+      </li>
+      <li>
+        <strong>Gruntwork systems:</strong> Ownership of the systems and
+        infrastructure that power our web presence, internal tooling, and
+        upcoming Software as a Service platform.
+      </li>
+      <li>
+        <strong>World-class customer support:</strong> While participating in
+        business-hours only support rotations, triage customer requests, teach
+        Gruntwork and DevOps best-practices, help resolve problems, escalate to
+        internal SMEs, and automate and document the solutions so that problems
+        are mitigated for future users.
+      </li>
+      <li>
+        <strong>And a little bit of everything else.</strong> Gruntwork is a
+        <a
+          href="https://blog.gruntwork.io/how-we-built-a-distributed-self-funded-family-friendly-profitable-startup-93635feb5ace"
+          target="_blank"
+          >small, distributed, self-funded, profitable startup</a
+        >, so things are changing all the time, and we all wear many hats. You
+        should expect to write plenty of code, but, depending on your interests,
+        there will also be ample opportunity to write blog posts, give talks,
+        contribute to open source, go to conferences, talk with customers, do
+        sales calls, think through financial questions, interview candidates,
+        mentor new hires, design products, come up with marketing ideas, discuss
+        strategy, consider legal questions, and all the other tasks that are
+        part of working at a small company.
+      </li>
+    </ul>
+    <h4>Your Ideal Background</h4>
+    <ul>
+      <li>
+        You hate doing the same thing twice and would rather spend the time to
+        automate a problem away than do the same work again.
+      </li>
+      <li>
+        You have strong communication skills and are comfortable engaging with
+        external customers.
+      </li>
+      <li>You have experience running production software ("Ops").</li>
+      <li>
+        You have a strong background in software engineering (or are working
+        hard on it!).
+      </li>
+      <li>You have a passion for learning new technologies and languages</li>
+      <li>Bonus points for a sense of humor, empathy, and curiosity.</li>
+      <li>
+        Note that we're less concerned with prior experience than we are with
+        curiosity about all areas of the stack and demonstrated ability to learn
+        quickly and go deep when necessary.
+      </li>
+    </ul>
     <p>
-      Just like our <a href="#software-engineer">Software Engineer</a> position,
-      but with the added expectation that you take more ownership, get (complex)
-      things done, and communicate even more effectively.
+      If the above describes you, email us at
+      <a href="mailto:careers@gruntwork.io">careers@gruntwork.io</a>.
     </p>
 
     <hr />
 
-    <h3>Principal Software Engineer</h3>
+    <h3>Senior Software Engineer<br />Senior Site Reliability Engineer</h3>
     <p>
-      Just like our
-      <a href="#senior-software-engineer">Senior Software Engineer</a> position,
-      but with the added expectation that you can take full ownership of a
-      complex project, get (highly complex) things done, and communicate even
-      more effectively.
+      Just like our <a href="#software-engineer">Software Engineer</a> and
+      <a href="#site-reliability-engineer">Site Reliability Engineer</a>
+      positions, but with the added expectation that you take more ownership,
+      get (complex) things done, and communicate even more effectively.
+    </p>
+
+    <hr />
+
+    <h3>
+      Principal Software Engineer<br />Principal Site Reliability Engineer
+    </h3>
+    <p>
+      Just like our <a href="#software-engineer">Software Engineer</a> and
+      <a href="#site-reliability-engineer">Site Reliability Engineer</a>
+      positions, but with the added expectation that you can take full ownership
+      of a complex project, get (highly complex) things done, and communicate
+      even more effectively.
     </p>
   </div>
 </div>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -108,14 +108,16 @@
         internally for Gruntwork and externally for our customers.
       </li>
       <li>
-        <strong>Toil/Engineering balance:</strong> Spend 50% of your time or
-        less on
+        <strong>Spend Max 50% of Your Time On Toil:</strong> We are adamant
+        about having our SREs spend 50% of their time or less on
         <a
           href="https://landing.google.com/sre/sre-book/chapters/eliminating-toil/"
           target="_blank"
           >toil</a
         >
-        and the rest engineering solutions to reduce it for the whole team
+        and the rest on engineering solutions to reduce it for the whole team.
+        We enforce this by using a rotational schedule that ensures at least 50%
+        of your time is free for engineering work.
       </li>
       <li>
         <strong>No On-Call:</strong> A key goal at Gruntwork is that no one

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -127,7 +127,7 @@
         products where outages don’t require paging someone? How do we design
         infrastructure where these outages are rare? What sorts of SLIs, SLOs,
         and SLAs should we promise customers? and the rest engineering solutions
-        to reduce it for the whole team
+        to reduce it for the whole team.
       </li>
       <li>
         <strong>Document tribal knowledge:</strong> Capture siloed knowledge and

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -88,7 +88,7 @@
 
     <hr />
 
-    <a target="site-reliability-engineer"></a>
+    <a target="site-reliability-engineer-sre"></a>
     <h3>Site Reliability Engineer (SRE)</h3>
     <h4>
       Be an SRE without being on call! Help Gruntwork develop SRE as a product
@@ -174,7 +174,7 @@
     <h3>Senior Software Engineer<br />Senior Site Reliability Engineer</h3>
     <p>
       Just like our <a href="#software-engineer">Software Engineer</a> and
-      <a href="#site-reliability-engineer">Site Reliability Engineer</a>
+      <a href="#site-reliability-engineer-sre">Site Reliability Engineer</a>
       positions, but with the added expectation that you take more ownership,
       get (complex) things done, and communicate even more effectively.
     </p>
@@ -186,7 +186,7 @@
     </h3>
     <p>
       Just like our <a href="#software-engineer">Software Engineer</a> and
-      <a href="#site-reliability-engineer">Site Reliability Engineer</a>
+      <a href="#site-reliability-engineer-sre">Site Reliability Engineer</a>
       positions, but with the added expectation that you can take full ownership
       of a complex project, get (highly complex) things done, and communicate
       even more effectively.

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -26,10 +26,10 @@
         Docker, Packer, etc), across many clouds (e.g., AWS, GCP, and Azure).
       </li>
       <li>
-        <strong>Gruntwork Launch:</strong> build a fundamentally better DevOps
-        experience. Launch consists of a REST API (Node.js, TypeScript), a
-        web-based single-page app (React, TypeScript, SASS), and a CLI tool
-        (Go).
+        <strong>Gruntwork Platform:</strong> build a fundamentally better DevOps
+        experience. Our SaaS Platform consists of a REST API (Node.js,
+        TypeScript), a web-based single-page app (React, TypeScript, SASS), and
+        a CLI tool (Go).
       </li>
       <li>
         <strong>Open Source:</strong> contribute to our open source projects,

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -91,32 +91,50 @@
     <a target="site-reliability-engineer-sre"></a>
     <h3>Site Reliability Engineer (SRE)</h3>
     <h4>
-      Be an SRE without being on call! Help Gruntwork develop SRE as a product
-      offering and enable our hundreds of customers to achieve best-practices
-      for operations and reliability, all while not being woken up at 3am!
+      Be an SRE without being on call! Help Gruntwork develop its internal SRE
+      practices as well as offer SRE as a product to enable our hundreds of
+      customers to achieve world-class operations and reliability, all while not
+      being woken up at 3am!
     </h4>
     <h4>What You'll Work On</h4>
     <ul>
       <li>
-        <strong>Build an SRE product offering:</strong> Develop logging,
-        monitoring, and alerting strategies around availability, latency, and
-        overall systems health and develop solutions that can be deployed
-        internally and externally for our customers.
+        <strong>Build an SRE product offering:</strong> Create a new product
+        offering for Gruntwork customers that includes Production Readiness
+        Reviews, training and implementation strategies for SLIs/SLOs/SLAs,
+        error budgets, chaos engineering strategies, blame-free post-mortems,
+        logging, monitoring, and alerting strategies around availability,
+        latency, and overall systems health. This solution will be deployed both
+        internally for Gruntwork and externally for our customers.
       </li>
       <li>
         <strong>Toil/Engineering balance:</strong> Spend 50% of your time or
-        less on toil and the rest engineering solutions to reduce it for the
-        whole team.
+        less on
+        <a
+          href="https://landing.google.com/sre/sre-book/chapters/eliminating-toil/"
+          >toil</a
+        >
+        and the rest engineering solutions to reduce it for the whole team
       </li>
       <li>
-        <strong>Document tribal knowledge:</strong> Capture siloed knowledge to
+        <strong>No On-Call:</strong> A key goal at Gruntwork is that no one
+        should have to be woken up in the middle of the night or on New Year's
+        Day due to an outage. We do not have an on-call rotation now and we’re
+        building out an SRE team to help us keep it that way. How do we design
+        products where outages don’t require paging someone? How do we design
+        infrastructure where these outages are rare? What sorts of SLIs, SLOs,
+        and SLAs should we promise customers? and the rest engineering solutions
+        to reduce it for the whole team
+      </li>
+      <li>
+        <strong>Document tribal knowledge:</strong> Capture siloed knowledge and
         create knowledgebase articles, runbooks, and other documentation for the
         internal team as well as Gruntwork customers.
       </li>
       <li>
-        <strong>Gruntwork systems:</strong> Ownership of the systems and
-        infrastructure that power our web presence, internal tooling, and
-        upcoming Software as a Service platform.
+        <strong>Gruntwork systems:</strong> Own the systems and infrastructure
+        that power our web presence, internal tooling, and upcoming Software as
+        a Service platform.
       </li>
       <li>
         <strong>World-class customer support:</strong> While participating in
@@ -151,6 +169,7 @@
         You have strong communication skills and are comfortable engaging with
         external customers.
       </li>
+      <li>You know how to write code across the stack (“Dev”).</li>
       <li>You have experience running production software ("Ops").</li>
       <li>
         You have a strong background in software engineering (or are working

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -90,12 +90,12 @@
 
     <a target="site-reliability-engineer-sre"></a>
     <h3>Site Reliability Engineer (SRE)</h3>
-    <h4>
+    <p>
       Be an SRE without being on call! Help Gruntwork develop its internal SRE
       practices as well as offer SRE as a product to enable our hundreds of
       customers to achieve world-class operations and reliability, all while not
       being woken up at 3am!
-    </h4>
+    </p>
     <h4>What You'll Work On</h4>
     <ul>
       <li>


### PR DESCRIPTION
- Add new SRE role to careers section of website
- Remove references to `Launch` in favor of `Gruntwork Platform`