### PR TITLE
Create new "Trust" page [WWW-59]

### DIFF
--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -58,6 +58,9 @@
     - title: Cookie Policy
       url: /legal/cookie-policy/
 
+    - title: Trust
+      url: /trust
+
 - title: Connect
   links:
     - title: Blog

--- a/pages/trust/_hero.html
+++ b/pages/trust/_hero.html
@@ -1,0 +1,15 @@
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12">
+      <h1>{{ page.title }}</h1>
+      <p class="lead">
+        {{ page.excerpt }}
+      </p>
+      <p>
+        <a class="btn btn-primary-hollow btn-sm d-inline-block" href="/contact/"
+          >Contact Gruntwork</a
+        >
+      </p>
+    </div>
+  </div>
+</div>

--- a/pages/trust/_legal-docs.html
+++ b/pages/trust/_legal-docs.html
@@ -1,0 +1,25 @@
+<div class="row row-page-header">
+  <div class="col-xs-12">
+    <ul>
+      <li>
+        <a href="/terms">Terms of Service</a>
+      </li>
+      <li>
+        <a href="/legal/cookie-policy">Cookie Policy</a>
+      </li>
+      <li>
+        <a href="/legal/privacy-policy">Privacy Policy</a>
+      </li>
+      <li><a href="/legal/dpa">Data Processing Agreement</a> (see below)</li>
+      <li>
+        <a href="/legal/subprocessors">Data Subprocessor List</a> (see below)
+      </li>
+    </ul>
+
+    <p>
+     <a href="/legal.rss">Subscribe to our RSS feed</a> to be notified when we add new Subprocessors.
+      Note that you’ll need to cut and paste the RSS URL into your favorite RSS
+      Feed Reader to monitor updates.
+    </p>
+  </div>
+</div>

--- a/pages/trust/_legal-docs.html
+++ b/pages/trust/_legal-docs.html
@@ -1,6 +1,6 @@
 <div class="row row-page-header">
   <div class="col-xs-12">
-    <ul>
+    <ul style="margin-left: -20px;">
       <li>
         <a href="/terms">Terms of Service</a>
       </li>

--- a/pages/trust/_legal-docs.html
+++ b/pages/trust/_legal-docs.html
@@ -10,16 +10,18 @@
       <li>
         <a href="/legal/privacy-policy">Privacy Policy</a>
       </li>
-      <li><a href="/legal/dpa">Data Processing Agreement</a> (see below)</li>
       <li>
-        <a href="/legal/subprocessors">Data Subprocessor List</a> (see below)
+        <a href="/legal/dpa">Data Processing Agreement</a>
+      </li>
+      <li>
+        <a href="/legal/subprocessors">Data Subprocessor List</a>
       </li>
     </ul>
 
     <p>
-     <a href="/legal.rss">Subscribe to our RSS feed</a> to be notified when we add new Subprocessors.
-      Note that you’ll need to cut and paste the RSS URL into your favorite RSS
-      Feed Reader to monitor updates.
+      <a href="/legal.rss">Subscribe to our RSS feed</a> to be notified when we
+      make changes to any of the above. Note that you may need to cut and paste
+      the RSS URL into your favorite RSS Feed Reader to monitor updates.
     </p>
   </div>
 </div>

--- a/pages/trust/index.html
+++ b/pages/trust/index.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Legal
+excerpt: View all Gruntwork legal docs.
+permalink: /trust/
+slug: trust
+---
+
+<div class="main page-trust">
+  <div class="section section-hero section-hero-with-button">
+    {% include_relative _hero.html %}
+  </div>
+  <div class="section section-dark">
+    <div class="container">
+      {% include_relative _legal-docs.html %}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Adds Trust page [WWW-59]

_I raised some questions in the Jira ticket around the wordings of RSS feed notification and where we link to this page on the website._

_Also, the links for the RSS feed, the DPA and Subprocessors page will not be routed correctly in this preview environment because the implementations of those pages are in separate PRs which are yet to be merged._

<img width="1710" alt="Screen Shot 2020-06-15 at 12 56 09 PM" src="https://user-images.githubusercontent.com/21035422/84695252-c7351c80-af07-11ea-95b6-e75777457e9b.png">

[View Page in Preview Env](https://deploy-preview-325--keen-clarke-470db9.netlify.app/trust/)

[WWW-59]: https://gruntwork.atlassian.net/browse/WWW-59