### PR TITLE
Legal Section Bug Fixes [WWW-79 WWW-80 WWW-81]

### DIFF
--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -1,18 +1,25 @@
-- id: 10000
+- guid: 10000
   title: We now have an RSS feed for all Gruntwork legal and privacy updates!
   description: Going forward, all updates to the Gruntwork terms of service, privacy policy, open source policy, and other policies relating to data processing will be posted here on our our RSS feed
   category: privacy-policy
   link: https://gruntwork.io/
   date: April 22, 2020
 
-- id: 10001
-  title: Updated Privacy Policy and Cookie Policy.
-  description: As part of our ongoing efforts to achieve GDPR compliance, we have updated our privacy policy to better comply with GDPR and CCPA regulations and reflect our latest data collection practices. We’ve also updated our cookie policy to better comply with GDPR and CCPA regulations.
-  category: privacy-policy, cookie-policy
-  link: https://gruntwork.io/legal/privacy-policy, https://gruntwork.io/legal/cookie-policy
+- guid: 10001
+  title: Updated Privacy Policy.
+  description: As part of our ongoing efforts to achieve GDPR compliance, we have updated our privacy policy to better comply with GDPR and CCPA regulations and reflect our latest data collection practices.
+  category: privacy-policy
+  link: https://gruntwork.io/legal/privacy-policy
   date: June 15, 2020
 
-- id: 10002
+- guid: 10002
+  title: Updated Cookie Policy.
+  description: As part of our ongoing efforts to achieve GDPR compliance, we have updated our cookie policy to better comply with GDPR and CCPA regulations and reflect our latest data collection practices.
+  category: cookie-policy
+  link: https://gruntwork.io/legal/cookie-policy
+  date: June 15, 2020
+
+- guid: 10003
   title: Added Data Processing Agreement and Data Subprocessor List.
   description: As part of our ongoing efforts to achieve GDPR compliance, we have publicly posted our Data Processing Agreement and Data Subprocessors List.
   category: subprocessors

--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -1,7 +1,7 @@
 - title: Products &amp; Services
   links:
     - title: Infrastructure Code Library
-      url: /infrastructure-as-code-library/  
+      url: /infrastructure-as-code-library/
 
     - title: Reference Architecture
       url: /reference-architecture/
@@ -13,7 +13,7 @@
       url: /support/
 
     - title: Repo Browser
-      url: /repos/          
+      url: /repos/
 
 - title: Learn
   links:
@@ -61,8 +61,8 @@
     - title: Cookie Policy
       url: /legal/cookie-policy/
 
-    - title: Trust
-      url: /trust
+    - title: All Legal Docs
+      url: /legal
 
 - title: Connect
   links:

--- a/assets/css/pages/legal.less
+++ b/assets/css/pages/legal.less
@@ -1,6 +1,7 @@
 .page-privacy-policy,
 .page-cookie-policy,
-.page-subprocessors {
+.page-subprocessors,
+.page-data-processing-agreement {
   .container > .row + .row {
     padding-top: 28px;
   }

--- a/legal.rss
+++ b/legal.rss
@@ -2,32 +2,28 @@
 layout: null
 ---
 <?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
 <channel>
- <title>Gruntwork Legal and Privacy Updates</title>
- <description>Read all the latest news on the Gruntwork terms of service, privacy policy, open source policy, and other policies relating to data processing.</description>
- <id>{{ site.url }}/legal.rss</id>
- <link>{{ site.url }}/legal.rss</link>
- <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
- <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
- <language>en</language>
- <copyright>{{ 'now' | date: "%Y" }} Gruntwork, Inc. All rights reserved</copyright>
- <generator>gruntwork.io</generator>
- <author>
-  <name>Gruntwork Legal</name>
-  <email>legal@gruntwork.io</email>
-  <link>{{ site.url }}</link>
- </author>
+  <atom:link href="{{ site.url }}/legal.rss" rel="self" type="application/rss+xml" />
+  <title>Gruntwork Legal and Privacy Updates</title>
+  <description>Read all the latest news on the Gruntwork terms of service, privacy policy, open source policy, and other policies relating to data processing.</description>
+  <link>{{ site.url }}/legal.rss</link>
+  <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+  <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+  <language>en</language>
+  <copyright>{{ 'now' | date: "%Y" }} Gruntwork, Inc. All rights reserved</copyright>
+  <generator>gruntwork.io</generator>
 
- {% for entry in site.data.legal reversed %}
- <item>
-  <title>{{ entry.title }}</title>
-  <description>{{ entry.description }}</description>
-  <link>{{ entry.link }}</link>
-  <pubDate>{{ entry.date }}</pubDate>
-  <category>{{ entry.category }}</category>
-  <id>{{ entry.id }}</id>
- </item>
- {% endfor %}
+  {% for entry in site.data.legal reversed %}
+  <item>
+    <title>{{ entry.title }}</title>
+    <description>{{ entry.description }}</description>
+    <link>{{ entry.link }}</link>
+    <pubDate>{{ entry.date | date_to_rfc822 }}</pubDate>
+    <category>{{ entry.category }}</category>
+    <author>legal@gruntwork.io (Gruntwork Legal)</author>
+    <guid isPermaLink="false">Feed item number {{ entry.guid }}</guid>
+  </item>
+  {% endfor %}
 </channel>
 </rss>

--- a/pages/trust/index.html
+++ b/pages/trust/index.html
@@ -2,11 +2,12 @@
 layout: default
 title: Legal
 excerpt: View all Gruntwork legal docs.
-permalink: /trust/
-slug: trust
+permalink: /legal/
+redirect_from: /trust/
+slug: legal
 ---
 
-<div class="main page-trust">
+<div class="main page-legal">
   <div class="section section-hero section-hero-with-button">
     {% include_relative _hero.html %}
   </div>


### PR DESCRIPTION
- Validates RSS Feed
- Fixes DPA page content spacing
- Renames "Trust" as "All Legal Docs"

[WWW-79]
[WWW-80]
[WWW-81]

<img width="1914" alt="Screen Shot 2020-06-24 at 6 13 13 PM" src="https://user-images.githubusercontent.com/21035422/85639708-d07c6280-b646-11ea-93f4-8b02ac326887.png">

<img width="1708" alt="Screen Shot 2020-06-24 at 5 57 17 PM" src="https://user-images.githubusercontent.com/21035422/85639135-01f42e80-b645-11ea-9a1e-5def74c831a0.png">


[WWW-79]: https://gruntwork.atlassian.net/browse/WWW-79

[WWW-80]: https://gruntwork.atlassian.net/browse/WWW-80
[WWW-81]: https://gruntwork.atlassian.net/browse/WWW-81