### PR TITLE
Add senior product designer role

### DIFF
--- a/pages/careers/_human-friendly.html
+++ b/pages/careers/_human-friendly.html
@@ -11,11 +11,39 @@
     </ul>
     <p>In short, <strong>we want to work on interesting problems, with interesting people, while leading interesting lives.</strong></p>
     <h3>How We Work</h3>
-    Check out <a href="https://blog.gruntwork.io/how-we-built-a-distributed-self-funded-family-friendly-profitable-startup-93635feb5ace" target="_blank">How
+    <p>Check out <a href="https://blog.gruntwork.io/how-we-built-a-distributed-self-funded-family-friendly-profitable-startup-93635feb5ace" target="_blank">How
     we built a distributed, self-funded, family-friendly, profitable startup</a> and
     <a href="https://blog.gruntwork.io/how-we-got-to-1-million-in-annual-recurring-revenue-with-0-in-fundraising-340ed2b4e158" target="_blank">How
-    we got to $1 million in annual recurring revenue with $0 in fundraising</a> for all the details on what we do,
-    how we fund it, how we hire, and how we work.
+    we got to $1 million in annual recurring revenue with $0 in fundraising</a> for all the details on what we do, how we fund it, how we hire, and how we work.</p>
+
+    <h3>Benefits</h3>
+    <p>Our benefits reflect our values. We believe compensation should be fair, transparent, and generous.</p>
+    <ul>
+      <li><strong>Above-Market Salary.</strong> We compute your salary <a href="https://blog.gruntwork.io/how-we-hire-at-gruntwork-42193d583e24">formulaically</a>, using as inputs the average salary for your job title in New York City, the Gruntwork multiplier (currently 1.45) and the cost of living in your home city relative to New York City as reported by numbeo.com. We aim to systematically pay above market.</li>
+      <li><strong>Profit-Sharing Bonus.</strong> We set aside a pot of money at the end of each year based on profits and distribute bonuses according to a formula that uses as inputs your level within the company and the length of your tenure at the company.</li>
+      <li><strong>Performance Bonus.</strong> We give performance-based bonuses of $5,000 - $15,000 as often as once a quarter, depending on your performance.</li>
+      <li><strong>Progressive Equity.</strong> We grant <a href="https://medium.com/detour-dot-com/introducing-progressive-equity-f424a51ee3a4">progressive equity</a> to all new Grunts.</li>
+      <li><strong>Medical Insurance.</strong> We offer high-quality plans, including some with no deductible through JustWorks.com. We cover 80% of your health insurance costs and 55% of those of your family.</li>
+      <li><strong>Dental Insurance.</strong> We offer high-quality plans and pay for 100% of the cost.</li>
+      <li><strong>Vision Insurance.</strong> We offer high-quality plans and pay for 100% of the cost.</li>
+      <li><strong>FSA and HSAs.</strong> We don't contribute to these accounts, but we do offer them as an option.</li>
+      <li><strong>401(k).</strong> We contribute 3% of your salary to your 401(k), regardless of how much you contribute yourself.</li>
+      <li><strong>Disability insurance.</strong> If you get disabled, we have a policy that will pay out a portion of your salary.</li>
+      <li><strong>Hardware budget.</strong> We'll buy you a brand new 16" Apple MacBook Pro upon joining. It will be owned by you, not the company.</li>
+      <li><strong>Personal Budget.</strong> We'll give you a personal budget of $500/month to spend on improving your health, productivity, or knowledge.</li>
+      <li><strong>Minimum Vacation.</strong> We require that you take at least 4 weeks of vacation per year.</li>
+    </ul>
+
+    <p><em>The above benefits reflect our offering package for Grunts based in the USA. For Grunts based in other countries, we make every effort to offer an equivalent total package specific to that country.</em></p>
+
+    <h3>100% Remote</h3>
+    <p>Gruntwork is a remote-first company.</p>
+
+    <h3>Sane Working Hours</h3>
+    <p>Although we're a distributed team, we only hire candidates between the time zones of GMT-7 (San Francisco) and GMT+2 (Berlin). This means you'll never be separated by more than 9 hours from your colleagues and never pressured to work at crazy hours just to get your work done.</p>
+    <p>We also plan project teams based on geography so that most of your collaboration will be with team members in a similar time zone.</p>
+
+
   </div>
 </div>
 

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -12,7 +12,9 @@
     <hr />
 
     <a target="software-engineer"></a>
-    <h3>Software Engineer</h3>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Software Engineer</h3>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Software Engineer</h3>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Principal Software Engineer</h3>
     <h4>What You'll Work On</h4>
     <ul>
       <li>
@@ -89,7 +91,10 @@
     <hr />
 
     <a target="site-reliability-engineer-sre"></a>
-    <h3>Site Reliability Engineer (SRE)</h3>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Site Reliability Engineer (SRE)</h3>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Site Reliability Engineer (SRE)</h3>
+    <h3 style="margin-top: 5px;">Principal Site Reliability Engineer (SRE)</h3>
+
     <p>
       Be an SRE without being on call! Help Gruntwork develop its internal SRE
       practices as well as offer SRE as a product to enable our hundreds of
@@ -189,29 +194,6 @@
     <p>
       If the above describes you, email us at
       <a href="mailto:careers@gruntwork.io">careers@gruntwork.io</a>.
-    </p>
-
-    <hr />
-
-    <h3>Senior Software Engineer<br />Senior Site Reliability Engineer</h3>
-    <p>
-      Just like our <a href="#software-engineer">Software Engineer</a> and
-      <a href="#site-reliability-engineer-sre">Site Reliability Engineer</a>
-      positions, but with the added expectation that you take more ownership,
-      get (complex) things done, and communicate even more effectively.
-    </p>
-
-    <hr />
-
-    <h3>
-      Principal Software Engineer<br />Principal Site Reliability Engineer
-    </h3>
-    <p>
-      Just like our <a href="#software-engineer">Software Engineer</a> and
-      <a href="#site-reliability-engineer-sre">Site Reliability Engineer</a>
-      positions, but with the added expectation that you can take full ownership
-      of a complex project, get (highly complex) things done, and communicate
-      even more effectively.
     </p>
 
     <hr />

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -213,5 +213,63 @@
       of a complex project, get (highly complex) things done, and communicate
       even more effectively.
     </p>
+
+    <hr />
+
+    <a target="senior-product-designer"></a>
+    <h3>Senior Product Designer</h3>
+
+    <p>Help us make Gruntwork delightful!</p>
+
+    <h4>What's Gruntwork?</h4>
+    <p>We give software teams a complete, world-class cloud infrastructure that lets them go to prod in days. Typically,
+       the process of launching prod infrastructure in the cloud is awful. It takes months of tedious work, hundreds of
+       thousands of dollars, and often results in poorly maintained code and anti-patterns in the end. We call our company
+       "Gruntwork" because we take away this Gruntwork for our clients so that they can focus on the parts of their software
+       that are unique to them.</p>
+    <p>We are 100% remote, ~15 people, profitable, growing (even during COVID!) and fully bootstrapped with no debt and
+       no investors. Our small company works with both startups and name companies like Toyota, Adobe, and the US House
+      of Representatives. We also <a href="#gruntwork-is-a-human-friendly-company">care a lot about humans.</a></p>
+
+    <h4>What's the opportunity?</h4>
+    <ul>
+      <li>
+        <strong>Product Design.</strong> We're building a SaaS platform that will become the primary customer experience of our product. Today, customers access our product as private GitHub repos plus a patchwork of links to training and documentation. Working with you, we envision a portal where customers login to discover and use all the elements of our existing product, brand it to themselves, and ultimately offer a UI-based way to learn, deploy and manage infrastructure in the cloud, all backed by infrastructure as code under the hood.
+      </li>
+      <li>
+        <strong>Branding and Marketing Website.</strong> We have an improved understanding of our business that we'd like to reflect in a new public marketing website. We'll look to you lead the design effort here.
+      </li>
+      <li>
+        <strong>Design system.</strong> You'll be our first full-time designer so you will set the design direction for the entire company across all areas of design, working directly with the founders and closely with engineers.
+      </li>
+    </ul>
+
+    <p>Although you'll be the only professional designer on the team, our company cares deeply about design so you'll have many eager collaborators when it comes time to brainstorm.</p>
+
+    <h4>What skills are we looking for?</h4>
+
+    <ul>
+      <li>
+        <strong>Product sensibility.</strong> When we present our product vision, we'll look to you to offer opinions, insights, and methodologies to help us translate that vision into a fantastic product.
+      </li>
+      <li>
+        <strong>Design skill.</strong> At the end of the day, the designs you create should look great and be easy to use. Our hope is that you can make our users smile.
+      </li>
+      <li>
+        <strong>Domain expertise.</strong> We don't expect you to have a complete vision for our product on day 1, but we're looking for someone who either already understands our domain (DevOps, CI/CD, Infrastructure as Code, AWS), or who feels comfortable ramping up on it.
+      </li>
+      <li>
+        <strong>Bonus: HTML/CSS.</strong> If you can roll up your sleeves and review our engineers' work in HTML/CSS, you can help us make sure the final product is true to your vision.
+      </li>
+      <li>
+        <strong>Bonus: Engineering Background.</strong> If you happen to have an engineering background such as previous experience coding an app or a computer science degree, that may give you additional insight into how our product might especially delight users.
+      </li>
+    </ul>
+
+    <h4>What time zones do we work in?</h4>
+    <p>While Gruntwork <a href="#sane-working-hours">generally</a> hires anywhere between San Francisco and Berlin, for this role, you'll be working with a team based in the USA/Canada (GMT-7 to GMT-3). We prefer to hire candidates located in the USA or Canada, but are open to hiring in any country within those time zones. Unfortunately, this role is not available outside the GMT-7 to GMT-3 time zones.</p>
+
+    <a href="https://apply.workable.com/gruntwork-io/j/03345F97D6/apply/" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"" role="button">Apply Now</a>
+
   </div>
 </div>


### PR DESCRIPTION
- Update careers page to list benefits, discuss remote-first nature, and sane working hours
- Add senior product designer role
- Consolidate X / Senior X / Principal X titles

**Preview: See https://5f04ea1976b1d1000979908f--keen-clarke-470db9.netlify.app/careers/**

Also, note that I have the designer role applying to Workable because I initially ran into some issues with applicants applying to Breezy directly. Note that we have not made a decision to move off of Workable, so all other jobs should either apply via careers@gruntwork.io or to Breezy.