### PR TITLE
Standardize 'apply now' buttons.

### DIFF
--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -83,9 +83,8 @@
         quickly and go deep when necessary.
       </li>
     </ul>
-    <p>
-      If the above describes you, email us at
-      <a href="mailto:careers@gruntwork.io">careers@gruntwork.io</a>.
+    <p>If the above describes you:<br>
+      <a href="mailto:careers@gruntwork.io?subject=Gruntwork Software Engineer Role" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa" style="margin-top:10px;" role="button">Apply Now</a>
     </p>
 
     <hr />
@@ -191,9 +190,8 @@
         quickly and go deep when necessary.
       </li>
     </ul>
-    <p>
-      If the above describes you, email us at
-      <a href="mailto:careers@gruntwork.io">careers@gruntwork.io</a>.
+    <p>If the above describes you:<br>
+      <a href="mailto:careers@gruntwork.io?subject=Gruntwork SRE Role" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa" style="margin-top:10px;" role="button">Apply Now</a>
     </p>
 
     <hr />
@@ -251,7 +249,10 @@
     <h4>What time zones do we work in?</h4>
     <p>While Gruntwork <a href="#sane-working-hours">generally</a> hires anywhere between San Francisco and Berlin, for this role, you'll be working with a team based in the USA/Canada (GMT-7 to GMT-3). We prefer to hire candidates located in the USA or Canada, but are open to hiring in any country within those time zones. Unfortunately, this role is not available outside the GMT-7 to GMT-3 time zones.</p>
 
-    <a href="https://apply.workable.com/gruntwork-io/j/03345F97D6/apply/" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"" role="button">Apply Now</a>
+    <h4>Start the conversation!</h4>
+    <p>If the above resonates with you:<br>
+      <a href="https://apply.workable.com/gruntwork-io/j/03345F97D6/apply/" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa" style="margin-top:10px;" role="button">Apply Now</a>
+    </p>
 
   </div>
 </div>


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4295964/86878105-143a8780-c09d-11ea-8bfd-85f79d8f1bd7.png)

After:

![image](https://user-images.githubusercontent.com/4295964/86878198-40560880-c09d-11ea-9afe-45ec9501ab69.png)

It's a small change, but makes the way to apply for all positions on the page consistent. Note that "Apply Now" for the SE and SRE roles goes to a mailto:careers@gruntwork.io?subject=xxx link.