### PR TITLE
Lighten the domain expertise requirement

### DIFF
--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -232,7 +232,7 @@
         <strong>Design skill.</strong> At the end of the day, the designs you create should look great and be easy to use. Help us make Gruntwork customers smile. :)
       </li>
       <li>
-        <strong>Domain expertise.</strong> We don't expect you to have a complete vision for our product on day 1, but to design products in our space, you must be able to thoroughly ramp up on our domain (DevOps, software delivery, cloud software, CI / CD, infrastructure as code).
+        <strong>Domain expertise.</strong> We don't expect you to have a complete technical vision for our product, but to design products in our space, you must build an understanding of our domain (DevOps, software delivery, cloud software, CI / CD, infrastructure as code).
       </li>
       <li>
         <strong>Bonus: HTML/CSS.</strong> If you can occasionally roll up your sleeves and work directly in HTML/CSS, you can help us make sure the final product is true to your vision.


### PR DESCRIPTION
@brikis98 and I are actively debating whether domain expertise or product sensibility is the more important quality in our new designer hire. We hope to test this in a trial project, but to avoid designers with limited prior experience in our domain from applying, I'm lightening the domain expertise requirement. Note that we still list "software background" as a bonus, so the core message that we're especially interested in those who already understand our domain is still here.