### PR TITLE
[WWW-86] Update GCP Price to "Contact Us"

### DIFF
--- a/pages/pricing/_aws-pricing.html
+++ b/pages/pricing/_aws-pricing.html
@@ -23,7 +23,7 @@
                   data-toggle="tooltip">Support for AWS</span></li>
         <li><span class="help-text light"
                   title="Gain access to 300,000+ lines of reusable, battle-tested, production-ready infrastructure code."
-                  data-toggle="tooltip">40 Subscriber-Only modules</span></li>
+                  data-toggle="tooltip">150+ Subscriber-Only Modules</span></li>
         <li><span class="help-text light"
                   title="A user is a human or machine that accesses the Gruntwork code repos, training materials, or support services. For more than 20 users, see Gruntwork Enterprise."
                   data-toggle="tooltip">Up to 20 Users</span></li>

--- a/pages/pricing/_gcp-pricing.html
+++ b/pages/pricing/_gcp-pricing.html
@@ -4,19 +4,17 @@
       <h3 class="h2 no-anchor margin-top-none" style="margin-bottom: 8px;">Gruntwork for GCP</h3>
       <p class="description">
         Support for prod-grade infra on GCP.<br>Ideal for individual teams.
-        <span class="badge badge-secondary" id="gcp-new">New</span>
       </p>
     </div>
     <hr>
     <div class="flex flex-middle flex-column text-center">
       <div data-mh="plans-pricing-top" style="height:150px; position:relative;">
-        <p class="big-price"><span>$</span>500</p>
-        <p class="help-block" style="margin-top:-9px;">per month</p>
+        <p class="h1 enterprise-h1">Contact Us</p>
+        <p class="help-block"></p>
       </div>
       <div data-mh="plans-pricing-bottom" style="height:100px">
-        <p><a id="pricing-cta-gcp" class="btn btn-info pricing-ctas" href="{{ site.data.pricing.subscriptions.gcp.checkout_url }}">Select</a></p>
+        <p><a class="btn btn-primary" href="/contact/">Contact Us</a></p>
         <p class="text-muted small"><em>Annual contract.<br>Billed monthly or annually.</em></p>
-        <p id="gcp-special-pricing">Special Introductory Price!</p>
       </div>
     </div>
     <hr>
@@ -27,7 +25,7 @@
                   data-toggle="tooltip">Support for GCP</span></li>
         <li><span class="help-text light"
                   title="Gain access to 50,000+ lines of reusable, battle-tested, production-ready infrastructure code available exclusively to subscribers."
-                  data-toggle="tooltip">2 Subscriber-Only modules</span></li>
+                  data-toggle="tooltip">13 Open Source Modules</span></li>
         <li><span class="help-text light"
                   title="A user is a human or machine that accesses the Gruntwork code repos, training materials, or support services. For more than 20 users, see Gruntwork Enterprise."
                   data-toggle="tooltip">Up to 20 Users</span></li>


### PR DESCRIPTION
Remove the GCP price and replace with “Contact Us” ✔ Done

Remove the ability to “Select” GCP and replace with “Contact Us” ✔ Done

Remove the “New” label under Gruntwork for GCP. ✔ Done

Remove “Special Introductory Price!” ✔ Done

Under AWS, change the “What’s included” list to mention:

150+ Subscriber-Only Modules ✔ Done

Under GCP, change the “What’s included” list to the following:

Support for GCP ✔ Done

13 Open Source Modules ✔ Done

Up to 20 Users ✔ Done

DevOps Training Library & Docs ✔ Done

Community Support ✔ Done

Jira Item: [WWW-86]

[WWW-86]: https://gruntwork.atlassian.net/browse/WWW-86