### PR TITLE
WWW-87

### DIFF
--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -85,7 +85,7 @@
 - guid: 10011
   title: Update Terms of Service to clean up and professionalize terms
   description: We removed DevOps Bootcamps and Gruntwork Professional Services since we are no longer offering these services. While we have always required that you agree to an annual subscription, we’ve cleaned up a few legal provisions around billing practices and termination rights to make this crystal clear. We also clarified that the authorized users of your affiliated companies can use the services. In addition, we’ve put into writing our current policies and cleaned up a few legal positions around; <ul class="small">
-    <li>how we expect both you and us to behave when you use our website (see our <a href="/site-terms/" title="Site Terms">Site Terms</a>);</li>
+    <li>how we expect both you and us to behave when you use our website (see our <a href="/website-terms/" title="Website Terms">Site Terms</a>);</li>
     <li>how we use your data to help provide the services to you (see our updated <a href="/legal/privacy-policy/" title="Privacy Policy">Privacy Policy</a>);</li>
     <li>how we use your anonymized data to improve the services;</li>
     <li>what we do to keep your data private and secure (see our updated <a href="/legal/privacy-policy/" title="Privacy Policy">Privacy Policy</a> and, for our European Union customers, our recently added <a href="/legal/dpa/" title="Data Processing Agreement">Data Processing Agreement</a>);</li>

--- a/_data/website-terms.yml
+++ b/_data/website-terms.yml
@@ -112,10 +112,12 @@
       ans: |
         <p>We  will  respond  to  notices  of  alleged  copyright  infringement  that  comply  with  applicable  law.  If  you believe any materials accessible on or from the Gruntwork Sites infringe your copyright, you can request removal of those materials from the Gruntwork Sites by submitting written notification (a “DCMA Notice”) to our copyright agent (designated below) in accordance with the Online Copyright Infringement Liability Limitation Act of the Digital Millennium Copyright Act (17 U.S.C. § 512) (“DMCA”)</p>
         <p>Our designated Copyright Agent to receive DMCA Notices is:</p>
-        <p>Gruntwork, Inc.</p>
-        <p>Attn: Copyright Agent</p>
-        <p>221 E. Indianola Ave., Phoenix, AZ 85012</p>
-        <p>Email: abuse@gruntwork.io</p>
+        <div class='address-element'>
+          <p>Gruntwork, Inc.</p>
+          <p>Attn: Copyright Agent</p>
+          <p>221 E. Indianola Ave., Phoenix, AZ 85012</p>
+          <p>Email: abuse@gruntwork.io</p>
+        </div>
         <p>If you fail to comply with all of the requirements of Section 512(c)(3) of the DMCA, your DMCA Notice may not be effective.</p>
         <p>If you believe that material you posted on the site was removed or access to it was disabled by mistake or misidentification,  you  may  file  a  counter‑notification  with  us  by  submitting  written  notification  to  our Copyright Agent (identified above) pursuant to the DMCA.</p>
         <p>Gruntwork reserves the right to terminate the user accounts of repeat infringers.</p>

--- a/_data/website-terms.yml
+++ b/_data/website-terms.yml
@@ -1,0 +1,151 @@
+- question:
+  items:
+    - title:
+      ans: |
+        <p>These Terms and Conditions of Use (the “Site Terms”) govern your (“you” or “your”) access to, and use of, the Gruntwork, Inc. (“Gruntwork,” “we” or “us”) web site located at <a href="https://gruntwork.io/" title="Gruntwork web site">https://gruntwork.io/</a>, and all sub-domain sites (collectively, the “Gruntwork Sites”). The Gruntwork Sites are the property of Gruntwork.</p>
+        <p>BY ACCESSING, USING OR COPYING ANY MATERIALS FROM THE GRUNTWORK SITES, YOU ACKNOWLEDGE THAT  YOU  HAVE  READ,  UNDERSTOOD  AND  ACCEPT  THESE  SITE  TERMS  AND  THE  OTHER  POLICIES  AND AGREEMENTS  APPLICABLE  TO  THE  GRUNTWORK  SITES  AS  DESCRIBED  BELOW.  IF  YOU  DO  NOT  AGREE WITH (OR CANNOT COMPLY WITH) THESE SITE TERMS, POLICIES AND AGREEMENTS, YOU MAY NOT USE, AND MUST IMMEDIATELY CEASE USING, THE GRUNTWORK SITES.</p>
+
+- question: 1. The Policies and Agreements 
+  items: 
+    - title: 
+      ans: |
+        <p>Please review the Gruntwork Privacy Policy, available at <a href="/privacy-policy" title="Privacy policy">https://gruntwork.io/privacy-policy</a>,   to understand our practices with regard to how we use your personal data and the Gruntwork Cookie Policy, available  at <a href="/cookie-policy/" title="Cookie policy">https://www.gruntwork.io/cookie-policy/</a>,  to  understand  our  use  of  cookies  and  similar technologies (collectively, the “Policies”).</p>
+        <p>If you sign-up for any Gruntwork services that are available for purchase (“Gruntwork Services”), you will also  be  subject  to  the  Gruntwork  Terms  of  Service,  available  at <a href="/terms" title="Terms of service">https://gruntwork.io/terms</a>  (“Terms  of Service”), and/or a Gruntwork Subscription Agreement,  or similar agreement governing your use of the Gruntwork Services (“GSA”, and collectively with the Terms of Service, the “Customer Agreement(s)”). In the  event  of  a  conflict  between  these  Site  Terms  and  your  Customer  Agreement,  your  Customer Agreement controls.</p>
+
+- question: 2. Use of the Website 
+  items: 
+    - title: Content 
+      ans: |
+        <p>The Gruntwork Sites contain a variety of resources and information, including the following: product and service  descriptions,  user  interfaces,  text,  graphics,  video,  audio,  trademarks,  FAQs,  documents,  blogs, and software (collectively the “Site Content”); and areas to interact with the Gruntwork Sites and the user community such as community forums, chats, and other related interactive or social features (collectively, the “Community Services”).</p>
+    - title: Accounts 
+      ans: |
+        <p>To  access  portions  of  the  Gruntwork  Sites,  you  may  need  to  provide  login  details  or  other  personal information.  It is a condition of your use of the Gruntwork Sites, and you agree, that all information you provide is correct, current, and complete. You agree not to share your login information with any other person. You are solely responsible for all use (including any unauthorized use) of your login information. If  you  believe  there  has  been  unauthorized  access  to  your  account  by  a  third  party,  or  a  reasonable likelihood  of  unauthorized  access,  you  must  immediately  notify  Gruntwork  and  take  remedial  action. Gruntwork  has  the  absolute  right  to  disable  any  user  name  or  password,  at  any  time,  for  any  reason, including, if, in our sole discretion, we believe you have failed to comply with any provision of these Site Terms.</p>
+    - title: Posts 
+      ans: |
+        <p>You and other users of the Gruntwork Sites may be permitted to post, submit, contribute, publish, display, make  available  or  transmit  to  others  (hereinafter, "post")  contact  and  employer  information,  content, materials, reactions, responses, code, techniques, ideas, or product improvement suggestions (including input and output) (collectively, “User Content") on or through the Gruntwork Sites.</p>
+        <p>You  are  solely  responsible  for  any  User  Content  that  you  post,  including  its  legality,  accuracy  and appropriateness. Gruntwork is not responsible for (and has no liability with respect to) any User Content. You represent that you own or control all rights in and to your User Content and have the right to grant Gruntwork, its affiliates, and other users, the licenses granted in Section 5 (Intellectual Property) below. User  Content  you  post  must  not  include  third-party  intellectual  property  (such  as  trademarked  or copyrighted material) unless you are legally entitled to do so and must not link to any infringing content (such as pirated files or clips). You represent that your User Content does and will comply with these Site Terms, and you agree to defend, indemnify and hold Gruntwork and its affiliates and licensors harmless for any breach of that representation and warranty.</p>
+    - title: Code of Conduct
+      ans: |
+        <p>You agree to comply with the following code of conduct in your use of the Gruntwork Sites (in particular, any Community Services):</p>
+        <ul>
+          <li>Be  polite  and  respectful:  Respect  other  users.  Don’t  upset,  annoy,  threaten,  harass,  abuse  or embarrass other users through your posts.</li>
+          <li>Keep  it  clean:  Don’t  include  material  that  is  defamatory,  obscene,  indecent,  abusive,  offensive, harassing, violent, hateful, inflammatory or otherwise objectionable.</li>
+          <li>Keep discussions healthy and useful: lively discussions are welcomed in the community; however, please don’t argue around anything personal (including personal beliefs, behaviors, etc.) </li>
+          <li>Don’t mislead: Don’t provide instructions or advice that you know to be incorrect or misleading.</li>
+        </ul>
+    - title: What Is Not Allowed
+      ans: |
+        <p>You agree not to:</p>
+        <ul>
+          <li>Use the Gruntwork Sites for any unlawful or fraudulent activities.</li>
+          <li>Use the Gruntwork Sites for competitive analysis or to build competitive products.</li>
+          <li>Use  the  Gruntwork  Sites  to  publish,  post  or  store  other  people’s  or  entities’  private  or personal information without their express authorization.</li>
+          <li>Use  the  Gruntwork  Sites  to  send  unsolicited  communications,  promotions,  advertisements, or spam.</li>
+          <li>Probe,  scan,  or  test  the  vulnerability  of  any  Gruntwork  system  or  network  or  breach  or circumvent any security or authentication measure.</li>
+          <li>Access the Gruntwork Sites by any means other than by using the interfaces provided for your authorized use by Gruntwork (for example, “scraping”).</li>
+          <li>Attempt to disrupt or overwhelm our infrastructure by intentionally imposing unreasonable requests or burdens on our resources (e.g. using “bots” or other automated systems to send requests to our servers at a rate beyond what could be sent by a human user during the same period of time).</li>
+          <li>Interfere with or disrupt the access of any user, host or network, including, without limitation, by sending a virus, overloading, flooding, spamming, or mail-bombing the Gruntwork Sites.</li>
+          <li>Rent, lease, distribute, sublicense, or otherwise provide access to the Gruntwork Sites to an unauthorized third party.</li>
+          <li>Impersonate another person or entity or misrepresent an affiliation with a person or entity in a manner that does or is intended to mislead, confuse, or deceive others.</li>
+        </ul>
+    - title: Please Notify Us
+      ans: |
+        <p>If  you  become  aware  of  any  violation  of  these  Site  Terms  by  any  person,  including  other  users  or  third parties, you must immediately notify Gruntwork via e‑mail to <a href="mailto:abuse@gruntwork.io">abuse@gruntwork.io</a>.</p>
+    - title: Gruntwork Disclaimer
+      ans: |
+        <p>We may, but are under no obligation to, monitor or censor any User Content and we are not responsible for  the  accuracy,  completeness,  appropriateness  or  legality  of  anything  posted,  depicted  or  otherwise provided by users; and we disclaim any and all liability relating thereto.</p>
+
+- question: 3. Third-Party Services 
+  items: 
+    - title: 
+      ans: |
+        <p>From  time  to  time,  Gruntwork  may  offer  to  you  the  ability  to  access,  or  the  Gruntwork  Sites  may  be integrated   or   interact   with,   third   party   applications,   links,   websites,   and   services   (“Third-Party Applications”)  to  make  the  Gruntwork  Sites  available  to  you.  These  Third-Party  Applications  may  have their own terms and conditions of use and privacy policies. Your use of these Third-Party Applications will be governed by and subject to such terms and conditions and privacy policies. You understand and agree that Gruntwork does not endorse and is not responsible or liable for the behavior, features, or content of any Third Party Application or for any transaction you may enter into with the provider of any such Third-Party Applications, nor does Gruntwork warrant the compatibility or continuing compatibility of the Third-Party Applications with the Gruntwork Sites. </p>
+
+- question: 4. Third-Party Services 
+  items:
+    - title: 
+      ans: |
+        <p>You  can  purchase  Gruntwork  merchandise  at <a href="https://store.gruntwork.io/" title="Merchandise  Store">https://store.gruntwork.io/</a>  (“Merchandise  Store”).  When purchasing Gruntwork merchandise, payments are processed through a third-party payment processor.</p>
+        <p>All prices displayed in the Merchandise Store are quoted in U.S. Dollars, and are valid and effective only in  the  United  States.  Gruntwork  reserves  the  right  without  prior  notice  to  discontinue  or  change specifications  on  products  and  services  offered  in  the  Merchandise  Store  without  incurring  any obligations. All prices are stated exclusive of taxes. You shall be responsible for all taxes associated with your purchase or payment.</p>
+        <p>Though we don't offer refunds, you can return any product(s) within 30 days of your purchase in exchange for store credit to use the next time you shop with us.</p>
+        <p>Your shipping cost will be calculated and displayed before you enter your payment information.</p>
+
+- question: 5. Intellectual Property 
+  items:
+    - title: The Gruntwork Sites
+      ans: |
+        <p>The  Gruntwork  Sites  in  their  entirety,  including  the  Site  Content  and  Community  Services,  is  owned  by Gruntwork or our licensors and is protected by United States and international laws regarding copyrights, patents, trademarks, trade secrets and other intellectual property or proprietary rights. Gruntwork grants you a limited license to access and make personal use of the Gruntwork Sites only for legitimate business purposes related to your role as a current or prospective customer, developer or partner of Gruntwork, and not to download (other than page caching) or modify the Website, or any portion of it, except with express written consent of Gruntwork. This license does not include any resale or commercial use of the Gruntwork Sites or its contents; any derivative use of the Gruntwork Sites or its contents; any downloading or  copying  of  account  information;  or  any  use  of  data  mining,  robots,  or  similar  data  gathering  and extraction  tools.  The  Gruntwork  Sites  or  any  portion  of  the  Gruntwork  Sites  may  not  be  reproduced, duplicated, copied, sold, resold, visited, or otherwise exploited for any commercial purpose without the express written consent of Gruntwork. You may not frame or utilize framing techniques to enclose any trademark,  logo,  or  other  proprietary  information  (including  images,  text,  page  layout,  or  form)  of Gruntwork  without  our  express  written  consent.  You  may  not  use  any  meta  tags  or  any  other  “hidden text” utilizing Gruntwork’s name or trademarks without the express written consent of Gruntwork. Any unauthorized use terminates the permission or license granted by Gruntwork.</p>
+        <p>“Gruntwork,” “Grunty,” and all Gruntwork graphics, logos, page headers, button icons, scripts, and service names  are  trademarks,  registered  trademarks  or  trade  dress  of  Gruntwork  in  the  U.S.  and/or  other countries. Gruntwork’s trademarks and trade dress may not be used in connection with any product or service that is not Gruntwork’s in any manner that is likely to cause confusion among customers, or in any manner  that  disparages  or  discredits  Gruntwork.  All  other  trademarks  not  owned  by  Gruntwork  that appear on this Webite are the property of their respective owners, who may or may not be affiliated with or  connected  to  Gruntwork.  You  may  not  use  any  Gruntwork  logo  or  other  proprietary  graphic  or trademark as part of the link without express written permission.</p>
+    - title: User Content
+      ans: |
+        <p>You grant Gruntwork a worldwide, non-exclusive license to host, copy, process, transmit, and display User Content solely for the purpose of Gruntwork providing the Gruntwork Sites  in accordance with these Site Terms.</p>
+        <p>Any  User  Content  you  post  publicly,  including  through  the  Community  Forum  or  Community  Slack Workspace,  may  be  viewed  by  others.  You  grant  each  user  of  Gruntwork  a  nonexclusive,  worldwide, license to use, reproduce, display, and perform your publicly posted User Content, through the Gruntwork Site as permitted through Gruntwork’s functionality.</p>
+        <p>Subject  to  the  limited  licenses  granted  above,  the  user  retains  all  right,  title,  and  interest,  including  all related intellectual property rights, in and to the User Content.</p>
+    - title: Feedback and Suggestions
+      ans: |
+        <p>Gruntwork  shall  have  a  perpetual,  irrevocable,  royalty‑free,  fully‑paid,  sublicensable,  transferable, non‑exclusive, worldwide license to make, use, sell, offer for sale, import or otherwise use or commercially exploit  for  any  purpose,  any  feedback,  comments,  suggestions,  communications,  and  requests  for improvements or enhancements relating to the Gruntwork Sites.</p>
+        <p>Feedback shall not include submissions to a Gruntwork source code repository. The proprietary rights to such submissions shall be as described in the Gruntwork Terms of Service.</p>
+
+- question: 6. Disclaimer of Warranties 
+  items:
+    - title: 
+      ans: |
+        <p>GRUNTWORK  DISCLAIMS  ALL  WARRANTIES  WHATSOEVER  WITH  RESPECT  TO  THE  GRUNTWORK  SITES, EITHER EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, ALL IMPLIED WARRANTIES    OF    MERCHANTABILITY,    QUALITY,    FITNESS    FOR    A    PARTICULAR    PURPOSE,    NON-INFRINGEMENT AND WARRANTIES ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE. WITHOUT LIMITATION TO THE FOREGOING, GRUNTWORK PROVIDES NO WARRANTY OR UNDERTAKING, AND   MAKES   NO   REPRESENTATION   OF   ANY   KIND,   WHETHER   EXPRESS,   IMPLIED,   STATUTORY   OR OTHERWISE, THAT THE GRUNTWORK SITES WILL MEET YOUR REQUIREMENTS, MEET ANY PERFORMANCE OR    RELIABILITY    STANDARDS,    OR    BE    ERROR    FREE.    IN    ADDITION,    GRUNTWORK    MAKES    NO REPRESENTATION NOR DOES IT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY USER CONTENT, THIRD PARTY SERVICES, OR ANY OTHER PRODUCT OR SERVICE ADVERTISED, PROMOTED OR  OFFERED  BY  A  THIRD  PARTY  ON  OR  THROUGH  THE  GRUNTWORK  SITES,  AND  GRUNTWORK  IS  NOT RESPONSIBLE OR LIABLE FOR ANY TRANSACTION BETWEEN YOU AND THIRD PARTY PROVIDERS OF THE FOREGOING.  NO  ADVICE  OR  INFORMATION  WHETHER  ORAL  OR  IN  WRITING  OBTAINED  BY  YOU  FROM GRUNTWORK  SHALL  CREATE  ANY  WARRANTY  ON  BEHALF  OF  GRUNTWORK.  THIS  SECTION  APPLIES  TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW.</p>
+        <p>Gruntwork does not warrant that any aspect of the Gruntwork Sites is free of viruses or other destructive code.  You  are  responsible  for  implementing  sufficient  procedures  on  your  end  to  satisfy  your  specific requirements for anti‑virus protection and for maintaining data backups, etc.  GRUNTWORK WILL NOT BE LIABLE  FOR  ANY  LOSS  OR  DAMAGE  CAUSED  BY  VIRUSES  OR  OTHER  TECHNOLOGICALLY  HARMFUL MATERIAL THAT MAY INFECT YOUR COMPUTER EQUIPMENT, COMPUTER PROGRAMS, DATA OR OTHER PROPRIETARY MATERIAL DUE TO YOUR USE OF THE GRUNTWORK SITES.</p>
+
+- question: 7. Indemnification 
+  items:
+    - title: 
+      ans: |
+        <p>To the maximum extent permitted by applicable laws, you agree to defend, indemnify and hold us, our affiliates and licensors and their respective officers, directors, employees, contractors, agents, licensors and suppliers harmless from and against any claims, liabilities, damages, judgments, awards, losses, costs, expenses  or  fees  (including  reasonable  attorneys'  fees  and  other  costs  of  defense)  resulting  from  your violation of these Site Terms, your use of the Gruntwork Sites, or our use of User Content in accordance with  these  Site  Terms.  We  will  be  entitled,  at  our  sole  expense,  to  participate  in  the  defense  and settlement of the claim or action with counsel of our choosing.  You may not settle any claims without our prior written consent (which will not be unreasonably withheld).</p>
+
+- question: 8. Limited Liability 
+  items:
+    - title: 
+      ans: |
+        <p>Gruntwork's total liability to you under these Site Terms for damages, costs, and expenses will not exceed $5. Notwithstanding the foregoing, nothing in these Site Terms removes or limits Gruntwork’s liability for fraud, death or personal injury caused by its own gross negligence.</p>
+        <p>NOTWITHSTANDING ANYTHING STATED TO THE CONTRARY HEREIN, IN NO EVENT WILL GRUNTWORK OR ITS  AFFILIATES,  OR  THEIR  RESPECTIVE  OFFICERS,  SHAREHOLDERS,  DIRECTORS,  EMPLOYEES,  AGENTS, AFFILIATES,  SUCCESSORS  OR  ASSIGNS  BE  LIABLE  FOR  LOST  PROFITS  OR  SPECIAL,  INCIDENTAL,  OR CONSEQUENTIAL  DAMAGES,  WHETHER  IN  AN  ACTION  IN  CONTRACT  OR  TORT,  EVEN  IF  THE  COVERED PARTY  HAS  BEEN  ADVISED  BY  GRUNTWORK  OF  THE  POSSIBILITY  OF  SUCH  DAMAGES.  YOU  AND GRUNTWORK  AGREE  TO  THIS  LIMITATION  EVEN  IF  THE  REMEDY  FOR  ANY  BREACH  OF  THIS  CONTRACT FAILS OF ITS ESSENTIAL PURPOSE.</p>
+
+- question: 9. Copyright Infringement 
+  items:
+    - title: 
+      ans: |
+        <p>We  will  respond  to  notices  of  alleged  copyright  infringement  that  comply  with  applicable  law.  If  you believe any materials accessible on or from the Gruntwork Sites infringe your copyright, you can request removal of those materials from the Gruntwork Sites by submitting written notification (a “DCMA Notice”) to our copyright agent (designated below) in accordance with the Online Copyright Infringement Liability Limitation Act of the Digital Millennium Copyright Act (17 U.S.C. § 512) (“DMCA”)</p>
+        <p>Our designated Copyright Agent to receive DMCA Notices is:</p>
+        <p>Gruntwork, Inc.</p>
+        <p>Attn: Copyright Agent</p>
+        <p>221 E. Indianola Ave., Phoenix, AZ 85012</p>
+        <p>Email: abuse@gruntwork.io</p>
+        <p>If you fail to comply with all of the requirements of Section 512(c)(3) of the DMCA, your DMCA Notice may not be effective.</p>
+        <p>If you believe that material you posted on the site was removed or access to it was disabled by mistake or misidentification,  you  may  file  a  counter‑notification  with  us  by  submitting  written  notification  to  our Copyright Agent (identified above) pursuant to the DMCA.</p>
+        <p>Gruntwork reserves the right to terminate the user accounts of repeat infringers.</p>
+
+- question: 10. Governing Law and Jurisdiction 
+  items:
+    - title: 
+      ans: |
+        <p>These Site Terms will be governed by and construed in accordance with the laws of the state of Arizona. The Parties agree that any disputes in which the aggregate total claim for relief sought on behalf of one or more parties exceeds $1,000 will be brought and maintained exclusively in the federal and state courts in Maricopa County, Arizona.</p>
+
+- question: 11. Updates 
+  items:
+    - title: 
+      ans: |
+        <p>We reserve the right to make changes to the Gruntwork Site, these Site Terms and the Policies from time-to-time.  We  will  post  the  revised  terms  to  the  Gruntwork  Sites  with  a  “last  updated”  date.  IF  YOU CONTINUE TO USE THE SERVICES AFTER THE REVISIONS TAKE EFFECT, YOU AGREE TO BE BOUND BY THE REVISED TERMS. You agree that we shall not be liable to you or to any third party for any modification of the Site Terms.</p>
+
+- question: 12. Termination 
+  items:
+    - title: 
+      ans: |
+        <p>You can stop accessing or using the Gruntwork Sites at any time and without notice to us. Similarly, we may terminate your access to the Gruntwork Sites or stop offering all or part of the Gruntwork Sites at any time without notice. Such termination will not relieve either Party of any obligations under these Site Terms which are expressly or by implication intended to survive termination.</p>
+- question: 13. Miscellaneous 
+  items:
+    - title: 
+      ans: |
+        <p>These Site Terms, the Policies, and your Customer Agreement constitutes the entire agreement between you  and  us  with  respect  to  the  Gruntwork  Sites  and  supersede  all  prior  and  contemporaneous understandings  and  agreements  with  respect  to  the  Gruntwork  Sites.  The  failure  to  exercise  any  right provided in these Site Terms by a Party will not be a waiver of prior or subsequent rights by such Party. If any  provision  of  these  Site  Terms  is  held  by  a  court  of  competent  jurisdiction  to  be  invalid,  void,  or unenforceable, the remaining provisions will nevertheless continue in full force and effect, and the Parties will, in good faith, attempt to modify the invalid provision so it becomes a valid provision.</p>
+        <p>You  agree  to  receive  electronically  all  communications,  agreements,  and  notices  that  we  provide  in connection with the Gruntwork Sites (“Communications”), including by email or by posting them to our Gruntwork Sites. You agree that all Communications that we provide to you electronically satisfy any legal requirement that such Communications be in writing.</p>
+
+- question: 14. Contact Us 
+  items:
+    - title: 
+      ans: |
+        <p>If you have any questions about these Site Terms, please contact us at <a href="mailto:legal@gruntwork.io">legal@gruntwork.io</a></p>

--- a/assets/css/pages/legal.less
+++ b/assets/css/pages/legal.less
@@ -7,7 +7,7 @@
     padding-top: 28px;
   }
   .address-element{
-    margin-left: 15px;
+    margin-left: 30px;
     margin-bottom: 15px;
     p{
       margin-bottom: 0;

--- a/assets/css/pages/legal.less
+++ b/assets/css/pages/legal.less
@@ -1,8 +1,16 @@
 .page-privacy-policy,
 .page-cookie-policy,
+.page-website-terms,
 .page-subprocessors,
 .page-data-processing-agreement {
   .container > .row + .row {
     padding-top: 28px;
+  }
+  .address-element{
+    margin-left: 15px;
+    margin-bottom: 15px;
+    p{
+      margin-bottom: 0;
+    }
   }
 }

--- a/pages/legal/_legal-docs.html
+++ b/pages/legal/_legal-docs.html
@@ -17,6 +17,9 @@
       <li>
         <a href="/legal/subprocessors">Data Subprocessor List</a>
       </li>
+      <li>
+        <a href="/legal/website-terms">Website Terms</a>
+      </li>
     </ul>
 
     <h3>Gruntwork Legal Updates</h3>

--- a/pages/legal/website-terms/index.html
+++ b/pages/legal/website-terms/index.html
@@ -1,0 +1,35 @@
+---
+layout: default
+title: Website Terms
+modified_date: August 10, 2020
+permalink: /legal/website-terms/
+redirect_from: /website-terms/
+slug: website-terms
+---
+
+<div class="main page-website-terms">
+    <div class="section">
+        <div class="container">
+            <div class="row">
+            <div class="col-xs-12">
+                <h1>{{ page.title }}</h1>
+                <p><em>Last Updated: {{ page.modified_date }}</em></p>
+            </div>
+            </div>
+            <div class="row">
+            <div class="col-xs-12">
+                {% for answer in site.data.website-terms %} {% if answer.question !=
+                nil %}
+                <h2>{{ answer.question }}</h2>
+                {% endif %} {% for step in answer.items %} {% if step.title != nil %}
+                <h3>{{ step.title }}</h3>
+                {% endif %}
+                <div>
+                {{ step.ans }}
+                </div>
+                {% endfor %} {% endfor %}
+            </div>
+            </div>
+        </div>
+        </div>
+</div>


### PR DESCRIPTION
Hello @josh-padnick 

Create a new page gruntwork.io/legal/website-terms in the style of https://gruntwork.io/legal/cookie-policy/ or https://gruntwork.io/legal/privacy-policy/ populated with the attached Word Doc. 
✅ Done

Note that the Word Doc uses numbered sections. Please be sure to retain those numbers, but otherwise the formatting should be consistent with other legal pages on the site 
✅ Done

Add mention of the page to https://gruntwork.io/legal
✅ Done

Please be sure to test all changes on both desktop, tablet, and mobile as usual! 
✅ Done

Update all pages – especially /terms in WWW-83: Update Terms of Service to latest versionDONE / DEPLOYED – that refer to older links like /site-terms. Note that /terms refers to a different set of content than /site-terms. The URL /site-terms or /legal/site-terms or /website-terms or /legal/website-terms is specifically for the content on this page.
✅ Done (there were no old links inside /terms, I’ve found only one inside the legal feed and it’s changed)

Jakub /Altalogy

Jira Item: [WWW-87]

[WWW-87]: https://gruntwork.atlassian.net/browse/WWW-87