### PR TITLE
Fix guides inconsistent paragraph height [WWW-101]

### DIFF
--- a/assets/css/guides.less
+++ b/assets/css/guides.less
@@ -3,83 +3,82 @@
 // ==================================================
 
 //Variables
-@guides-font-family: 'Open Sans', sans-serif;
+@guides-font-family: "Open Sans", sans-serif;
 @guides-font: #1e252f;
 @guides-primary-color: #06a6fd;
 
-
 //Mixins
 .guides-input-placeholder {
-	font-size: 14px;
-	font-style: normal;
-	opacity: 1 !important;
-	font-weight: 600;
-	letter-spacing: -0.23px;
-	color: #0000;
+  font-size: 14px;
+  font-style: normal;
+  opacity: 1 !important;
+  font-weight: 600;
+  letter-spacing: -0.23px;
+  color: #0000;
 }
 
 .remove-visibility {
-	display: none;
-	clear: both;
+  display: none;
+  clear: both;
 }
 
 .no-padding {
-	padding: 0 !important;
-	margin: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
 }
 
 .no-transform {
-	transform: none;
-	box-shadow: none;
-	outline: none !important;
+  transform: none;
+  box-shadow: none;
+  outline: none !important;
 }
 
 .active-button {
-	background-color: #fff !important;
-	position: relative;
-	border-radius: 8px !important;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-	cursor: pointer;
-	border: 1px solid #dedede !important;
-	outline-color: #fff;
+  background-color: #fff !important;
+  position: relative;
+  border-radius: 8px !important;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  border: 1px solid #dedede !important;
+  outline-color: #fff;
 }
 
 .guides-outline {
-	padding: 0;
+  padding: 0;
 
-	a {
-		color: #999999;
-	}
+  a {
+    color: #999999;
+  }
 
-	a:active,
-	a:hover {
-		text-decoration: none;
-		color: @guides-primary-color;
-	}
+  a:active,
+  a:hover {
+    text-decoration: none;
+    color: @guides-primary-color;
+  }
 
-	ul {
-		font-size: 16px;
-		font-weight: bold;
-		letter-spacing: -0.2px;
-	}
+  ul {
+    font-size: 16px;
+    font-weight: bold;
+    letter-spacing: -0.2px;
+  }
 }
 
 //Styles for listings page
 .col-md-2-5 {
-	position: relative;
-	min-height: 1px;
-	padding-right: 15px;
-	padding-left: 15px;
+  position: relative;
+  min-height: 1px;
+  padding-right: 15px;
+  padding-left: 15px;
 }
 
 @media (min-width: 768px) {
-	.col-md-2-5 {
-		float: left;
-	}
+  .col-md-2-5 {
+    float: left;
+  }
 
-	.col-md-2-5 {
-		width: 20.66666667%;
-	}
+  .col-md-2-5 {
+    width: 20.66666667%;
+  }
 }
 
 .guides-button {
@@ -92,873 +91,879 @@
 }
 
 #toc {
-	&.fixed {
-		width: inherit;
-		padding-right: 16px !important;
-	}
+  &.fixed {
+    width: inherit;
+    padding-right: 16px !important;
+  }
 
-	.guides-outline;
+  .guides-outline;
 
-	.section-nav,
-	.sectlevel1 {
-		@media (max-width: @screen-sm-max) {
-			.remove-visibility();
-		}
+  .section-nav,
+  .sectlevel1 {
+    @media (max-width: @screen-sm-max) {
+      .remove-visibility();
+    }
 
-		display: block;
-		z-index: 2;
-		padding: 1em;
-		overflow-y: auto;
-		max-height: 100vh;
-		overflow-wrap: break-word;
+    display: block;
+    z-index: 2;
+    padding: 1em;
+    overflow-y: auto;
+    max-height: 100vh;
+    overflow-wrap: break-word;
 
-		& li {
-			list-style-type: none;
-			&:hover {
-				cursor: pointer;
-			}
+    & li {
+      list-style-type: none;
+      &:hover {
+        cursor: pointer;
+      }
 
-			& ul {
-				display: none;
-			}
-		}
-	}
+      & ul {
+        display: none;
+      }
+    }
+  }
 
-	.sectlevel2 {
-		padding-left: 20px !important;
+  .sectlevel2 {
+    padding-left: 20px !important;
 
-		li {
-			line-height: 16px;
-			margin-bottom: 8px;
-		}
-	}
+    li {
+      line-height: 16px;
+      margin-bottom: 8px;
+    }
+  }
 
-	a.selected, a:hover, a:active{
-		color: @guides-primary-color;
-		text-decoration: none;
+  a.selected,
+  a:hover,
+  a:active {
+    color: @guides-primary-color;
+    text-decoration: none;
 
-		&:before {
-			content: "";
-			width: 6px;
-			height: 6px;
-			border-radius: 50%;
-			background: @guides-primary-color;
-			display: inline-block;
-			margin: 1px -3px;
-			position: relative;
-			left: -8px;
-		}
-	}
+    &:before {
+      content: "";
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: @guides-primary-color;
+      display: inline-block;
+      margin: 1px -3px;
+      position: relative;
+      left: -8px;
+    }
+  }
 }
 
 body .guides .guides-section-white {
-	font-family: @guides-font-family;
-	color: @guides-font;
+  font-family: @guides-font-family;
+  color: @guides-font;
 }
 
 .guide-listing {
-	.category-head {
-		font-size: 30px;
-		font-weight: 600;
-		line-height: normal;
-		letter-spacing: 0.84px;
-		color: @guides-font;
-		margin-top: 40px;
-		margin-bottom: 11px;
+  .category-head {
+    font-size: 30px;
+    font-weight: 600;
+    line-height: normal;
+    letter-spacing: 0.84px;
+    color: @guides-font;
+    margin-top: 40px;
+    margin-bottom: 11px;
 
-		&:first-of-type {
-			margin-top: 1em;
-		}
+    &:first-of-type {
+      margin-top: 1em;
+    }
 
-		&:hover>a.anchorjs-link {
-			text-decoration: none;
-			display: none;
-		}
-	}
+    &:hover > a.anchorjs-link {
+      text-decoration: none;
+      display: none;
+    }
+  }
 
-	.card {
-		color: @guides-font;
-		cursor: pointer;
-		min-height: 100px;
-		overflow: hidden;
-		position: relative;
+  .card {
+    color: @guides-font;
+    cursor: pointer;
+    min-height: 100px;
+    overflow: hidden;
+    position: relative;
 
-		& .card-title {
-			margin-top: 0;
-			margin-bottom: 2px;
-			font-size: 20px;
-			letter-spacing: 0.56px;
+    & .card-title {
+      margin-top: 0;
+      margin-bottom: 2px;
+      font-size: 20px;
+      letter-spacing: 0.56px;
 
-			&:hover>a.anchorjs-link {
-				color: #FFFFFF;
-				text-decoration: none;
-				display: none;
-			}
-		}
+      &:hover > a.anchorjs-link {
+        color: #ffffff;
+        text-decoration: none;
+        display: none;
+      }
+    }
 
-		a {
-			text-decoration: none;
-		}
+    a {
+      text-decoration: none;
+    }
 
-		& .card-body {
-			padding: 16px 30px 16px 10px;
-		}
+    & .card-body {
+      padding: 16px 30px 16px 10px;
+    }
 
-		& .img-inner {
-			position: absolute;
-			top: 50%;
-			-ms-transform: translateY(-50%);
-			transform: translateY(-50%);
-		}
+    & .img-inner {
+      position: absolute;
+      top: 50%;
+      -ms-transform: translateY(-50%);
+      transform: translateY(-50%);
+    }
 
-		img {
-			max-width: 100%;
-			display: block;
-			margin: auto auto;
-			padding: 11px 20px 11px 30px;
-			max-height: 85px;
-		}
+    img {
+      max-width: 100%;
+      display: block;
+      margin: auto auto;
+      padding: 11px 20px 11px 30px;
+      max-height: 85px;
+    }
 
-		& p {
-			font-size: 13px;
-			font-weight: inherit;
-			line-height: 1.5;
-			letter-spacing: 0.34px;
-			margin: 0;
-		}
+    & p {
+      font-size: 13px;
+      font-weight: inherit;
+      line-height: 1.5;
+      letter-spacing: 0.34px;
+      margin: 0;
+    }
 
-		& h6,
-		& h5,
-		& h4,
-		& h3,
-		& h2,
-		& a {
-			color: @guides-font;
-		}
+    & h6,
+    & h5,
+    & h4,
+    & h3,
+    & h2,
+    & a {
+      color: @guides-font;
+    }
 
-		& code {
-			color: #c7254e !important;
-		}
-	}
+    & code {
+      color: #c7254e !important;
+    }
+  }
 
-	.guide-card {
-		margin-bottom: 10px;
-		border: solid 1px #dedede;
-		border-radius: 8px;
-		transition: 0.2s all ease;
-	}
+  .guide-card {
+    margin-bottom: 10px;
+    border: solid 1px #dedede;
+    border-radius: 8px;
+    transition: 0.2s all ease;
+  }
 
-	.float-right {
-		float: right;
-	}
+  .float-right {
+    float: right;
+  }
 
-	.card-shadow:hover {
-		-webkit-box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
-		/* Safari, Android, iOS */
-		-moz-box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
-		/* Firefox */
-		box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
-		border: none;
-		transform: scale(1.10) translateZ(0);
-	}
+  .card-shadow:hover {
+    -webkit-box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
+    /* Safari, Android, iOS */
+    -moz-box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
+    /* Firefox */
+    box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
+    border: none;
+    transform: scale(1.1) translateZ(0);
+  }
 }
 
 //Hero
 .guides .section-hero {
-	&:extend(.section-bg-blue);
-	background: url('../img/bg-header-squares.png') center bottom no-repeat, linear-gradient(@brand-primary, #06A2FF);
+  &:extend(.section-bg-blue);
+  background: url("../img/bg-header-squares.png") center bottom no-repeat,
+    linear-gradient(@brand-primary, #06a2ff);
 
-	.container {
-		margin-bottom: 20px;
-	}
+  .container {
+    margin-bottom: 20px;
+  }
 
-	h1 {
-		font-size: 40px;
-		letter-spacing: 1.13px;
-		margin-bottom: 11px;
-	}
+  h1 {
+    font-size: 40px;
+    letter-spacing: 1.13px;
+    margin-bottom: 11px;
+  }
 
-	p {
-		font-size: 20px;
-		font-weight: inherit;
-		line-height: 1.5;
-		letter-spacing: 0.56px;
-	}
+  p {
+    font-size: 20px;
+    font-weight: inherit;
+    line-height: 1.5;
+    letter-spacing: 0.56px;
+  }
 }
 
 .section-hero-blue {
-	height: 409px;
-	color: #fff;
-	background: url('../img/bg-header-squares.png') center bottom no-repeat, linear-gradient(#7cd7ff, #07a7fc, #57a1ea);
+  height: 409px;
+  color: #fff;
+  background: url("../img/bg-header-squares.png") center bottom no-repeat,
+    linear-gradient(#7cd7ff, #07a7fc, #57a1ea);
 
-	& label {
-		margin-bottom: 29px;
-		font-size: 35px;
-		line-height: normal;
-		letter-spacing: 0.98px;
-		text-align: center;
-		color: #ffffff;
-	}
+  & label {
+    margin-bottom: 29px;
+    font-size: 35px;
+    line-height: normal;
+    letter-spacing: 0.98px;
+    text-align: center;
+    color: #ffffff;
+  }
 
-	& img {
-		margin: -1%;
-		position: relative;
-		height: 231px;
-		width: 112px;
-		margin-bottom: 23px;
-	}
+  & img {
+    margin: -1%;
+    position: relative;
+    height: 231px;
+    width: 112px;
+    margin-bottom: 23px;
+  }
 
-	& a {
-		margin-bottom: 49px;
-		color: #08a9fb;
-		font-size: 14px;
-		background-color: white;
-	}
+  & a {
+    margin-bottom: 49px;
+    color: #08a9fb;
+    font-size: 14px;
+    background-color: white;
+  }
 
-	& a:active,
-	a:hover {
-		color: #08a9fb;
-		cursor: pointer;
-		.no-transform();
-	}
+  & a:active,
+  a:hover {
+    color: #08a9fb;
+    cursor: pointer;
+    .no-transform();
+  }
 }
 
 //Search styles
 .searchrow {
-	margin-top: 20px;
-	padding: 0;
+  margin-top: 20px;
+  padding: 0;
 
-	.input-group {
-		width: 100%;
-		padding-right: 19px;
-		z-index: 0;
-	}
+  .input-group {
+    width: 100%;
+    padding-right: 19px;
+    z-index: 0;
+  }
 
-	button {
-		border-bottom-left-radius: 8px;
-		border-top-left-radius: 8px;
-		min-height: 56px;
-		height: 56px;
+  button {
+    border-bottom-left-radius: 8px;
+    border-top-left-radius: 8px;
+    min-height: 56px;
+    height: 56px;
 
-		&:hover,
-		&:focus {
-			.no-transform();
-		}
-	}
+    &:hover,
+    &:focus {
+      .no-transform();
+    }
+  }
 
-	input {
-		background: #f5f9fa;
-		border-top-right-radius: 8px;
-		border-bottom-right-radius: 8px;
-		min-height: 56px;
-		height: 56px;
-		border: none;
-		color: @guides-font;
-		.no-transform();
+  input {
+    background: #f5f9fa;
+    border-top-right-radius: 8px;
+    border-bottom-right-radius: 8px;
+    min-height: 56px;
+    height: 56px;
+    border: none;
+    color: @guides-font;
+    .no-transform();
 
-		&:active,
-		&:focus {
-			.no-transform();
-		}
-	}
+    &:active,
+    &:focus {
+      .no-transform();
+    }
+  }
 }
 
 .guides-input-box::-webkit-input-placeholder {
-	.guides-input-placeholder;
+  .guides-input-placeholder;
 }
 
 .guides-input-box::-moz-placeholder {
-	.guides-input-placeholder;
+  .guides-input-placeholder;
 }
 
 .guides-input-box::-ms-placeholder {
-	.guides-input-placeholder;
+  .guides-input-placeholder;
 }
 
 .guides-input-box::placeholder {
-	.guides-input-placeholder;
+  .guides-input-placeholder;
 }
 
 //Cloud filter styles
 .cloud-filter {
-	.center();
-	margin-bottom: 11px;
+  .center();
+  margin-bottom: 11px;
 
-	.filter {
-		width: 109px;
-		height: 76px;
-		cursor: pointer;
-		float: left;
-		border-radius: 8px;
-		border: none;
-		background-color: #f5f9fa;
-		text-align: center;
+  .filter {
+    width: 109px;
+    height: 76px;
+    cursor: pointer;
+    float: left;
+    border-radius: 8px;
+    border: none;
+    background-color: #f5f9fa;
+    text-align: center;
 
-		&:hover,
-		&:active {
-			.active-button();
-		}
+    &:hover,
+    &:active {
+      .active-button();
+    }
 
-		img {
-			vertical-align: middle;
-			max-height: 55px;
-			padding: 8px;
-		}
+    img {
+      vertical-align: middle;
+      max-height: 55px;
+      padding: 8px;
+    }
 
-		.helper {
-			display: inline-block;
-			height: 100%;
-			vertical-align: middle;
-		}
+    .helper {
+      display: inline-block;
+      height: 100%;
+      vertical-align: middle;
+    }
 
-		&:nth-last-of-type(2) {
-			border-radius: 0;
-		}
+    &:nth-last-of-type(2) {
+      border-radius: 0;
+    }
 
-		&:last-child {
-			border-top-left-radius: 0;
-			border-bottom-left-radius: 0;
-		}
+    &:last-child {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
 
-		&:first-child {
-			border-top-right-radius: 0;
-			border-bottom-right-radius: 0;
-		}
-	}
+    &:first-child {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
 }
 
-//No azure filter 
+//No azure filter
 .no-azure-results {
-	display: none;
+  display: none;
 
-	h2 {
-		color: @guides-font;
-		font-size: 30px;
-		line-height: normal;
-		letter-spacing: 0.84px;
-		margin-bottom: 8px;
-		margin-top: 91px;
+  h2 {
+    color: @guides-font;
+    font-size: 30px;
+    line-height: normal;
+    letter-spacing: 0.84px;
+    margin-bottom: 8px;
+    margin-top: 91px;
 
-		&:hover>a.anchorjs-link {
-			color: #FFFFFF;
-			text-decoration: none;
-			display: none;
-		}
-	}
+    &:hover > a.anchorjs-link {
+      color: #ffffff;
+      text-decoration: none;
+      display: none;
+    }
+  }
 
-	p {
-		font-size: 20px;
-		opacity: 0.7;
-		line-height: 1.5;
-		letter-spacing: 0.56px;
-		color: #000000;
-		margin-bottom: 24px;
-	}
+  p {
+    font-size: 20px;
+    opacity: 0.7;
+    line-height: 1.5;
+    letter-spacing: 0.56px;
+    color: #000000;
+    margin-bottom: 24px;
+  }
 
-	.btn {
-		border-radius: 23.5px;
-		background-image: linear-gradient(to bottom, #5bcde7, #569cea);
-		color: white;
+  .btn {
+    border-radius: 23.5px;
+    background-image: linear-gradient(to bottom, #5bcde7, #569cea);
+    color: white;
 
-		&:hover,
-		&:active {
-			outline: none;
-			transform: none;
-			box-shadow: none;
-			border-radius: 23.5px;
-			background-image: linear-gradient(to bottom, #5bcde7, #569cea);
-		}
-	}
+    &:hover,
+    &:active {
+      outline: none;
+      transform: none;
+      box-shadow: none;
+      border-radius: 23.5px;
+      background-image: linear-gradient(to bottom, #5bcde7, #569cea);
+    }
+  }
 }
 
 //Filter styles
 #tags-filter {
-	display: flex;
-	justify-content: flex-end;
+  display: flex;
+  justify-content: flex-end;
 
-	button {
-		border-radius: 8px;
-		background: rgba(0, 185, 248, 0.2);
-		padding: 0 15px;
-		box-shadow: none;
-		border: none;
-		font-size: 18px;
-		font-weight: 600;
-		letter-spacing: 0.51px;
-		text-align: center;
-		color: @guides-primary-color;
+  button {
+    border-radius: 8px;
+    background: rgba(0, 185, 248, 0.2);
+    padding: 0 15px;
+    box-shadow: none;
+    border: none;
+    font-size: 18px;
+    font-weight: 600;
+    letter-spacing: 0.51px;
+    text-align: center;
+    color: @guides-primary-color;
 
-		&:hover,
-		&:focus,
-		&:active {
-			.no-transform;
-			background: rgba(0, 185, 248, 0.1);
-			color: @guides-primary-color;
-		}
-	}
+    &:hover,
+    &:focus,
+    &:active {
+      .no-transform;
+      background: rgba(0, 185, 248, 0.1);
+      color: @guides-primary-color;
+    }
+  }
 }
 
 .filter-options {
-	padding: 0;
-	margin: 16px;
+  padding: 0;
+  margin: 16px;
 
-	.card {
-		padding: 30px 109px;
-		border-radius: 8px;
-		background-color: #f5f9fa;
-		min-height: 193px;
-		max-height: 193px;
+  .card {
+    padding: 30px 109px;
+    border-radius: 8px;
+    background-color: #f5f9fa;
+    min-height: 193px;
+    max-height: 193px;
 
-		.tags {
-			display: flex;
-			flex-wrap: wrap;
-			flex-direction: column;
-			max-height: 133px;
-		}
+    .tags {
+      display: flex;
+      flex-wrap: wrap;
+      flex-direction: column;
+      max-height: 133px;
+    }
 
-		.checkbox {
-			padding-left: 20px;
-			position: relative;
-			display: block;
-			margin-bottom: 0;
+    .checkbox {
+      padding-left: 20px;
+      position: relative;
+      display: block;
+      margin-bottom: 0;
 
-			input {
-				opacity: 0;
-				position: absolute;
-				z-index: 1;
-				cursor: pointer;
-				margin-left: -20px;
+      input {
+        opacity: 0;
+        position: absolute;
+        z-index: 1;
+        cursor: pointer;
+        margin-left: -20px;
 
-				&:checked {
-					+label {
-						&::before {
-							border: 2px solid @guides-primary-color;
-						}
+        &:checked {
+          + label {
+            &::before {
+              border: 2px solid @guides-primary-color;
+            }
 
-						&::after {
-							content: '';
-							display: inline-block;
-							position: absolute;
-							width: 13px;
-							height: 13px;
-							left: 2px;
-							top: 4px;
-							margin-left: -20px;
-							border: 2px solid @guides-primary-color;
-							border-radius: 2px;
-							background-color: @guides-primary-color;
-						}
-					}
-				}
-			}
+            &::after {
+              content: "";
+              display: inline-block;
+              position: absolute;
+              width: 13px;
+              height: 13px;
+              left: 2px;
+              top: 4px;
+              margin-left: -20px;
+              border: 2px solid @guides-primary-color;
+              border-radius: 2px;
+              background-color: @guides-primary-color;
+            }
+          }
+        }
+      }
 
-			label {
-				display: inline-block;
-				position: relative;
-				padding-left: 10px;
+      label {
+        display: inline-block;
+        position: relative;
+        padding-left: 10px;
 
-				&::before {
-					content: '';
-					display: inline-block;
-					position: absolute;
-					width: 18px;
-					height: 18px;
-					border-radius: 2px;
-					border: 2px solid #939596;
-					background-color: #fff;
-				}
-			}
-		}
+        &::before {
+          content: "";
+          display: inline-block;
+          position: absolute;
+          width: 18px;
+          height: 18px;
+          border-radius: 2px;
+          border: 2px solid #939596;
+          background-color: #fff;
+        }
+      }
+    }
 
-		.checkbox+.checkbox {
-			margin-top: 10px !important;
-		}
+    .checkbox + .checkbox {
+      margin-top: 10px !important;
+    }
 
-		.checkbox {
-			input {
-				&:checked {
-					+label {
-						&::before {
-							background-color: @guides-primary-color;
-						}
+    .checkbox {
+      input {
+        &:checked {
+          + label {
+            &::before {
+              background-color: @guides-primary-color;
+            }
 
-						&::after {
-							content: '';
-							position: absolute;
-							width: 10px;
-							height: 7px;
-							background: @guides-primary-color;
-							left: 4px;
-							border: 2px solid #fff;
-							border-top: none;
-							border-right: none;
-							-webkit-transform: rotate(-45deg);
-							-moz-transform: rotate(-45deg);
-							-o-transform: rotate(-45deg);
-							-ms-transform: rotate(-45deg);
-							transform: rotate(-45deg);
-						}
-					}
-				}
-			}
+            &::after {
+              content: "";
+              position: absolute;
+              width: 10px;
+              height: 7px;
+              background: @guides-primary-color;
+              left: 4px;
+              border: 2px solid #fff;
+              border-top: none;
+              border-right: none;
+              -webkit-transform: rotate(-45deg);
+              -moz-transform: rotate(-45deg);
+              -o-transform: rotate(-45deg);
+              -ms-transform: rotate(-45deg);
+              transform: rotate(-45deg);
+            }
+          }
+        }
+      }
 
-			label {
-				&::before {
-					border-radius: 2px;
-				}
-			}
-		}
+      label {
+        &::before {
+          border-radius: 2px;
+        }
+      }
+    }
 
-		p {
-			letter-spacing: -0.2px;
-			color: #8f9fa7;
-			text-transform: uppercase;
-			font-size: 14px;
-			font-weight: bold;
-			margin-bottom: 2px;
-		}
+    p {
+      letter-spacing: -0.2px;
+      color: #8f9fa7;
+      text-transform: uppercase;
+      font-size: 14px;
+      font-weight: bold;
+      margin-bottom: 2px;
+    }
 
-		label {
-			font-size: 16px;
-			font-weight: 600;
-			letter-spacing: -0.23px;
-			color: #939596;
-			text-transform: capitalize;
-			line-height: 1.3em;
-		}
-	}
+    label {
+      font-size: 16px;
+      font-weight: 600;
+      letter-spacing: -0.23px;
+      color: #939596;
+      text-transform: capitalize;
+      line-height: 1.3em;
+    }
+  }
 }
 
 .fixed {
-	position: fixed;
-	top: 0;
+  position: fixed;
+  top: 0;
 }
 
 .bottom {
-	position: absolute;
-	bottom: 0;
-	top: auto;
+  position: absolute;
+  bottom: 0;
+  top: auto;
 }
 
 .row.equal {
-	display: flex;
-	display: -webkit-flex;
-	flex-wrap: wrap;
+  display: flex;
+  display: -webkit-flex;
+  flex-wrap: wrap;
 }
 
 #toc .sectlevel1 .expanded {
-	& ul {
-		display: block;
-		font-size: 14px;
-		font-weight: normal;
-	}
+  & ul {
+    display: block;
+    font-size: 14px;
+    font-weight: normal;
+  }
 }
 
 .no-results-space:after {
-	margin-bottom: 40%;
+  margin-bottom: 40%;
 }
 
 @media (max-width: @screen-md-max) {
-	.guides .section-hero {
-		padding-top: 0;
-	}
+  .guides .section-hero {
+    padding-top: 0;
+  }
 
-	.filter-options .card {
-		padding: 20px 40px;
-	}
+  .filter-options .card {
+    padding: 20px 40px;
+  }
 
-	.categories {
-		display: none !important;
-	}
-	
-	.guide-listing .card-shadow {
-		&:hover, &:active {
-			transform: scale(1.05) translateZ(0);
-		}
+  .categories {
+    display: none !important;
+  }
 
-		.card img {
-			padding: 11px;
-		}
-	}
+  .guide-listing .card-shadow {
+    &:hover,
+    &:active {
+      transform: scale(1.05) translateZ(0);
+    }
 
-	.breadcrumb {
-		margin-bottom: 0;
-	}
+    .card img {
+      padding: 11px;
+    }
+  }
+
+  .breadcrumb {
+    margin-bottom: 0;
+  }
 }
 
 @media only screen and (max-width: @screen-xs-max) {
-	.guides .section-hero {
-		h1 {
-			font-size: 29px;
-		}
+  .guides .section-hero {
+    h1 {
+      font-size: 29px;
+    }
 
-		p {
-			font-size: 14px;
-		}
-	}
+    p {
+      font-size: 14px;
+    }
+  }
 
-	.post-detail {
-		h1 {
-			font-size: 29px;
-		}
-		.post-title {
-			padding: 0 !important;
-		}
-	}
+  .post-detail {
+    h1 {
+      font-size: 29px;
+    }
+    .post-title {
+      padding: 0 !important;
+    }
+  }
 
-	.post-content {
-		h2 {
-			margin: 0 !important;
-			font-size: 28px !important;
-		}
-		h3 {
-			font-size: 22px !important;
-		}
-	}
+  .post-content {
+    h2 {
+      margin: 0 !important;
+      font-size: 28px !important;
+    }
+    h3 {
+      font-size: 22px !important;
+    }
+  }
 
-	.searchrow, .filter-options {
-		display: none !important;
-	}
+  .searchrow,
+  .filter-options {
+    display: none !important;
+  }
 
-	.cloud-filter .filter {
-		height: 60px;
-		width: 90px;
-	}
+  .cloud-filter .filter {
+    height: 60px;
+    width: 90px;
+  }
 
-	#listings {
-		display: flex;
-		justify-content: center;
-	}
+  #listings {
+    display: flex;
+    justify-content: center;
+  }
 
-	.guide-listing {
-		.category-head {
-			font-size: 20px;
-		}
+  .guide-listing {
+    .category-head {
+      font-size: 20px;
+    }
 
-		.card .card-title {
-			font-size: 16px;
-		}
-	}
+    .card .card-title {
+      font-size: 16px;
+    }
+  }
 
-	.card-shadow:hover {
-		-webkit-box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
-		/* Safari, Android, iOS */
-		-moz-box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
-		/* Firefox */
-		box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
-		border: none;
-	}
+  .card-shadow:hover {
+    -webkit-box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
+    /* Safari, Android, iOS */
+    -moz-box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
+    /* Firefox */
+    box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.1);
+    border: none;
+  }
 
-	.guides-newsletter {
-		padding: 0!important;
+  .guides-newsletter {
+    padding: 0 !important;
 
-		label {
-			font-size: 22px !important;
-		}
+    label {
+      font-size: 22px !important;
+    }
 
-		p{
-			font-size: 16px;
-		}
-	}
+    p {
+      font-size: 16px;
+    }
+  }
 
-	.section-hero-blue {
-		label {
-			font-size: 25px;
-		}
-	}
+  .section-hero-blue {
+    label {
+      font-size: 25px;
+    }
+  }
 
-	p {
-		font-size: 18px;
-	}
+  p {
+    font-size: 18px;
+  }
 }
 
 .guides-newsletter,
 .no-results {
-	padding: 5em 6em;
-	font-size: 16px;
-	color: @guides-font;
-	display: inline-block;
+  padding: 5em 6em;
+  font-size: 16px;
+  color: @guides-font;
+  display: inline-block;
 
-	.modal-box {
-		padding-bottom: 3em;
-	}
+  .modal-box {
+    padding-bottom: 3em;
+  }
 
-	& .guides-input-box {
-		background-color: #f5f9fa;
-		border: none;
-		border-top-left-radius: 20px;
-		border-bottom-left-radius: 20px;
-		font-size: 16px;
-		color: black;
-		height: 42px;
-		z-index: 1;
-		overflow: hidden;
-		padding-right: 16px;
-		box-shadow: none;
-		width: 60%;
+  & .guides-input-box {
+    background-color: #f5f9fa;
+    border: none;
+    border-top-left-radius: 20px;
+    border-bottom-left-radius: 20px;
+    font-size: 16px;
+    color: black;
+    height: 42px;
+    z-index: 1;
+    overflow: hidden;
+    padding-right: 16px;
+    box-shadow: none;
+    width: 60%;
 
-		&:hover,
-		&:active,
-		&:focus {
-			border: 1px solid #07a7fc;
-			z-index: 1 !important;
-			padding: 12px;
-			.no-transform();
-		}
-	}
+    &:hover,
+    &:active,
+    &:focus {
+      border: 1px solid #07a7fc;
+      z-index: 1 !important;
+      padding: 12px;
+      .no-transform();
+    }
+  }
 
-	& label {
-		font-size: 28px;
-		line-height: 40px;
-		letter-spacing: 0.79px;
-		font-weight: 600;
-		color: @guides-font;
-	}
+  & label {
+    font-size: 28px;
+    line-height: 40px;
+    letter-spacing: 0.79px;
+    font-weight: 600;
+    color: @guides-font;
+  }
 
-	& img {
-		margin-bottom: 2%;
-	}
+  & img {
+    margin-bottom: 2%;
+  }
 
-	& .btn {
-		text-decoration: none;
-		margin-top: -3px;
-		margin-left: -13px;
-		position: relative;
-		z-index: 2;
-		color: #fff;
-		background-image: linear-gradient(to bottom, #5bcde7, #569cea);
-	}
+  & .btn {
+    text-decoration: none;
+    margin-top: -3px;
+    margin-left: -13px;
+    position: relative;
+    z-index: 2;
+    color: #fff;
+    background-image: linear-gradient(to bottom, #5bcde7, #569cea);
+  }
 
-	& .btn:hover,
-	.btn:focus {
-		.no-transform();
-	}
+  & .btn:hover,
+  .btn:focus {
+    .no-transform();
+  }
 }
 
 //Newsletter styles
 #newsletter-success {
-	@media (min-width: 768px) {
-		.modal-dialog {
-			margin: 30px auto;
-			width: auto;
-		}
-	}
+  @media (min-width: 768px) {
+    .modal-dialog {
+      margin: 30px auto;
+      width: auto;
+    }
+  }
 
-	& label {
-		font-size: 28px;
-		color: @guides-font;
-		font-weight: 600;
-		line-height: 1.43;
-		letter-spacing: 0.79px;
-		color: #1e252f;
-		margin-bottom: 10px;
-	}
+  & label {
+    font-size: 28px;
+    color: @guides-font;
+    font-weight: 600;
+    line-height: 1.43;
+    letter-spacing: 0.79px;
+    color: #1e252f;
+    margin-bottom: 10px;
+  }
 
-	p {
-		color: @guides-font;
-		font-size: 16px;
-		line-height: 22px;
-		letter-spacing: 0.45px;
-	}
+  p {
+    color: @guides-font;
+    font-size: 16px;
+    line-height: 22px;
+    letter-spacing: 0.45px;
+  }
 
-	& .modal-content {
-		background: #fff;
-		max-width: 468px;
-		height: 320px;
-		border-radius: 8px;
+  & .modal-content {
+    background: #fff;
+    max-width: 468px;
+    height: 320px;
+    border-radius: 8px;
 
-		.modal-body {
-			padding: 50px 39px;
+    .modal-body {
+      padding: 50px 39px;
 
-			.img {
-				margin-bottom: 19px;
-			}
-		}
-	}
+      .img {
+        margin-bottom: 19px;
+      }
+    }
+  }
 
-	& .btn {
-		width: 131px;
-		height: 47px;
-		border-radius: 23.5px;
-		background-color: @guides-primary-color;
-		color: #ffffff;
-		margin-top: 20px;
+  & .btn {
+    width: 131px;
+    height: 47px;
+    border-radius: 23.5px;
+    background-color: @guides-primary-color;
+    color: #ffffff;
+    margin-top: 20px;
 
-		&:hover,
-		&:focus {
-			background: @guides-primary-color;
-			outline: none;
-			.no-transform();
-		}
-	}
+    &:hover,
+    &:focus {
+      background: @guides-primary-color;
+      outline: none;
+      .no-transform();
+    }
+  }
 }
 
 .guides-cta-card {
-	@media (max-width: @screen-md-min) {
-		.remove-visibility();
-	}
+  @media (max-width: @screen-md-min) {
+    .remove-visibility();
+  }
 
-	background-color: white;
-	color: black;
-	box-shadow: 3px 4px #c5c2c2;
-	border-radius: 5px;
-	padding: 0 24px 0;
-	margin-top: 10px;
+  background-color: white;
+  color: black;
+  box-shadow: 3px 4px #c5c2c2;
+  border-radius: 5px;
+  padding: 0 24px 0;
+  margin-top: 10px;
 
-	& p {
-		color: black;
-		font-size: 14px;
-		margin-top: -20%;
-	}
+  & p {
+    color: black;
+    font-size: 14px;
+    margin-top: -20%;
+  }
 
-	& .deploy {
-		margin-top: 6%;
-		width: 100%;
-		border-radius: 6px;
-		font-size: 14px;
-		background-color: @guides-primary-color;
-		color: white !important;
-	}
+  & .deploy {
+    margin-top: 6%;
+    width: 100%;
+    border-radius: 6px;
+    font-size: 14px;
+    background-color: @guides-primary-color;
+    color: white !important;
+  }
 
-	& .dismiss-cta {
-		color: @guides-primary-color;
+  & .dismiss-cta {
+    color: @guides-primary-color;
 
-		&:hover,
-		&:focus {
-			text-decoration: none;
-			.no-transform;
-		}
-	}
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      .no-transform;
+    }
+  }
 
-	& img {
-		max-width: 100%;
-	}
+  & img {
+    max-width: 100%;
+  }
 }
 
 .guides-section-white {
-	background-color: #fff;
-	position: relative;
-	color: @guides-font;
-	padding: 20px 25px 0 25px;
-	font-family: @guides-font-family;
-	min-height: 400px;
+  background-color: #fff;
+  position: relative;
+  color: @guides-font;
+  padding: 20px 25px 0 25px;
+  font-family: @guides-font-family;
+  min-height: 400px;
 
-	.container-fluid {
-		max-width: 1200px;
-	}
+  .container-fluid {
+    max-width: 1200px;
+  }
 }
 
 .img-center {
-	max-width: 184px;
-	max-height: 184px;
-	padding: 15px;
-	display: block;
-	margin: 0 auto;
+  max-width: 184px;
+  max-height: 184px;
+  padding: 15px;
+  display: block;
+  margin: 0 auto;
 }
 
 // Post Detail styles
 .post-bg {
-	background-color: #f6f8fa;
+  background-color: #f6f8fa;
 }
 
 .post-detail {
@@ -993,14 +998,19 @@ body .guides .guides-section-white {
       font-size: 14px;
       letter-spacing: 0.39px;
     }
-    h1, h2, h3, h4, h5, h6 {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
       color: @guides-font;
     }
   }
- 
+
   .breadcrumb {
-		font-size: 14px;
-		margin-bottom: 0;
+    font-size: 14px;
+    margin-bottom: 0;
     letter-spacing: -0.2px;
     background-color: white;
     > a {
@@ -1025,18 +1035,16 @@ body .guides .guides-section-white {
   }
 }
 
-
 // Post Detail styles
 .post-content {
   padding: 0 0 50px 0;
   color: @guides-font;
-  line-height: 1.38;
+  line-height: 1.7;
 
   // Limit width so typography remains readable on wide screens: https://ux.stackexchange.com/a/108803/4869
   max-width: 760px;
   margin: 0 auto;
 
-  
   .imageblock > .title {
     font-size: 12px;
     margin: 5px 0 15px 0;
@@ -1045,10 +1053,11 @@ body .guides .guides-section-white {
   }
 
   .sect2 {
-    .paragraph, dd {
+    .paragraph,
+    dd {
       margin-bottom: 10px;
     }
-    dl{
+    dl {
       margin: 0;
     }
     .listingblock {
@@ -1059,31 +1068,36 @@ body .guides .guides-section-white {
         color: rgba(0, 0, 0, 0.54);
         text-align: left;
       }
-	}
-		
-	& .hdlist1 {
-		a {
-			text-decoration: none;
-			color: @guides-font;
-		}
-	}
+    }
 
-    & .dlist, & .ulist {
+    & .hdlist1 {
+      a {
+        text-decoration: none;
+        color: @guides-font;
+      }
+    }
+
+    & .dlist,
+    & .ulist {
       padding: 0;
       margin: 20px 0;
 
       dt {
         margin-top: 15px;
       }
-	}
+    }
 
-    pre.highlight > code, pre:not(.highlight) {
+    pre.highlight > code,
+    pre:not(.highlight) {
       padding: 15px;
       background: rgba(245, 245, 245, 0.3);
       border: 1px solid #efefef;
     }
 
-    .token.operator, .token.entity, .token.url, .token.variable {
+    .token.operator,
+    .token.entity,
+    .token.url,
+    .token.variable {
       background: transparent !important;
     }
   }
@@ -1092,13 +1106,14 @@ body .guides .guides-section-white {
     & .hdlist1 a {
       color: #3cb8fd !important;
       font-style: italic;
-  
+
       &:before {
         content: "\2192 \0020";
       }
     }
   }
-  p, li {
+  p,
+  li {
     font-size: 16px;
     letter-spacing: 0.45px;
     margin: 0;
@@ -1111,7 +1126,8 @@ body .guides .guides-section-white {
     }
   }
 
-  & p > a, p > em > a {
+  & p > a,
+  p > em > a {
     color: @guides-primary-color;
     text-decoration: none;
     font-weight: bold;
@@ -1126,7 +1142,8 @@ body .guides .guides-section-white {
     }
   }
 
-  pre, pre[class*="language-"] {
+  pre,
+  pre[class*="language-"] {
     padding: 0;
     border: none;
     font-size: 14px;
@@ -1147,19 +1164,26 @@ body .guides .guides-section-white {
     letter-spacing: 0.79px;
     margin: 40px 0 18px 0;
   }
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     color: @guides-font;
     a:link {
-      color:@guides-font;
-      font-size: .9em !important;
+      color: @guides-font;
+      font-size: 0.9em !important;
       margin-left: -0.8em !important;
       padding-right: 0.1em !important;
       .no-transform();
     }
   }
-  h1, h5, h6  {
-    &:hover > a.anchorjs-link{
-      color: #FFFFFF;
+  h1,
+  h5,
+  h6 {
+    &:hover > a.anchorjs-link {
+      color: #ffffff;
       text-decoration: none;
       display: none;
     }
@@ -1177,7 +1201,7 @@ body .guides .guides-section-white {
         padding: 7px 0;
       }
     }
-    tbody{
+    tbody {
       background-color: #f5f9fa;
       tr {
         border-bottom: 15px solid #fff;
@@ -1188,7 +1212,9 @@ body .guides .guides-section-white {
             letter-spacing: 0.34px;
             padding: 10px;
           }
-          &:nth-child(even) {background-color: #fafcfc;}
+          &:nth-child(even) {
+            background-color: #fafcfc;
+          }
         }
       }
     }
@@ -1199,132 +1225,132 @@ body .guides .guides-section-white {
 }
 
 .badge {
-	background: rgba(0, 185, 248, 0.1);
-	padding: 6px 10px;
-	border-radius: 4px;
-	color: @guides-primary-color;
-	font-size: 12px;
-	letter-spacing: 0.34px;
-	font-weight: bold;
-	text-align: center;
+  background: rgba(0, 185, 248, 0.1);
+  padding: 6px 10px;
+  border-radius: 4px;
+  color: @guides-primary-color;
+  font-size: 12px;
+  letter-spacing: 0.34px;
+  font-weight: bold;
+  text-align: center;
 }
 
 .admonitionblock-content {
-	position: relative;
-	padding: 19px;
-	border-top: 9px solid @guides-primary-color;
-	background-color: #f5f9fa;
-	text-align: center;
-	margin: 40px 0;
+  position: relative;
+  padding: 19px;
+  border-top: 9px solid @guides-primary-color;
+  background-color: #f5f9fa;
+  text-align: center;
+  margin: 40px 0;
 
-	.title {
-		font-weight: bold;
-		margin-bottom: 0 !important;
-	}
+  .title {
+    font-weight: bold;
+    margin-bottom: 0 !important;
+  }
 
-	table {
-		text-align: center;
-		margin-left: auto;
-		margin-right: auto;
+  table {
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
 
-		& tbody tr {
-			border-bottom: none !important;
+    & tbody tr {
+      border-bottom: none !important;
 
-			& .icon .title {
-				margin-right: 40px;
-				position: relative;
-				font-size: 0;
-				text-align: center;
+      & .icon .title {
+        margin-right: 40px;
+        position: relative;
+        font-size: 0;
+        text-align: center;
 
-				&:after {
-					display: block;
-					position: absolute;
-					color: #fff;
-					content: "!";
-					border-radius: 50%;
-					width: 21px;
-					height: 21px;
-					line-height: 21px;
-					font-weight: normal;
-					left: 0;
-					font-size: 16px;
-					margin-top: -9px;
-				}
+        &:after {
+          display: block;
+          position: absolute;
+          color: #fff;
+          content: "!";
+          border-radius: 50%;
+          width: 21px;
+          height: 21px;
+          line-height: 21px;
+          font-weight: normal;
+          left: 0;
+          font-size: 16px;
+          margin-top: -9px;
+        }
       }
-      
+
       a {
         color: #07a7fc;
         text-decoration: none;
         font-weight: 600;
       }
 
-			& td,
-			td p {
-				text-align: initial;
-				font-size: 12px;
-				line-height: normal;
-				letter-spacing: 0.34px;
-				color: @guides-font;
-				padding: 0;
+      & td,
+      td p {
+        text-align: initial;
+        font-size: 12px;
+        line-height: normal;
+        letter-spacing: 0.34px;
+        color: @guides-font;
+        padding: 0;
 
-				.js-subscribe-cta {
-					color: #07a7fc;
-					text-decoration: none;
-					font-weight: 600;
-					&:hover {
-						cursor: pointer;
-						text-decoration: underline;
-					}
-				}
+        .js-subscribe-cta {
+          color: #07a7fc;
+          text-decoration: none;
+          font-weight: 600;
+          &:hover {
+            cursor: pointer;
+            text-decoration: underline;
+          }
+        }
 
-				.title {
-					margin-bottom: 12px;
-				}
+        .title {
+          margin-bottom: 12px;
+        }
 
-				code {
-					background: #e5ecee !important;
-					color: @guides-font;
-					font-family: AndaleMono;
-					font-weight: normal;
-					font-size: 12px;
-				}
+        code {
+          background: #e5ecee !important;
+          color: @guides-font;
+          font-family: AndaleMono;
+          font-weight: normal;
+          font-size: 12px;
+        }
 
-				&:nth-child(even) {
-					background-color: inherit !important;
-				}
-			}
-		}
-	}
+        &:nth-child(even) {
+          background-color: inherit !important;
+        }
+      }
+    }
+  }
 }
 
 .admonitionblock.important,
 .admonitionblock.note {
-	.admonitionblock-content;
+  .admonitionblock-content;
 
-	.title:after {
-		background-color: #06a6fd;
-		border: 1px solid #06a6fd;
-	}
+  .title:after {
+    background-color: #06a6fd;
+    border: 1px solid #06a6fd;
+  }
 }
 
 .admonitionblock.error {
-	.admonitionblock-content;
+  .admonitionblock-content;
 
-	.title:after {
-		background-color: #ef5a73;
-		border: 1px solid #ef5a73;
-	}
+  .title:after {
+    background-color: #ef5a73;
+    border: 1px solid #ef5a73;
+  }
 }
 
 .center {
-	display: flex;
-	justify-content: center;
+  display: flex;
+  justify-content: center;
 }
 
 .white-section {
-	background-color: #fff;
-	padding: 20px 25px 0 25px;
-	min-height: 200px;
+  background-color: #fff;
+  padding: 20px 25px 0 25px;
+  min-height: 200px;
 }
 
 //comment styles
@@ -1351,7 +1377,7 @@ body .guides .guides-section-white {
     background-color: @guides-primary-color;
     margin: 20px 8px 0 0;
     text-align: center;
-    padding: 2px; 
+    padding: 2px;
   }
   .share-buttons {
     ul {
@@ -1359,7 +1385,7 @@ body .guides .guides-section-white {
       display: flex;
       list-style-type: none;
       li {
-      display: inline;
+        display: inline;
         a {
           text-decoration: none;
         }
@@ -1372,15 +1398,15 @@ body .guides .guides-section-white {
       background-color: black;
     }
     .timeline {
-      .comment-header  {
+      .comment-header {
         background-color: #fff;
         border-bottom: none;
-			}
-		}
-	}
+      }
+    }
+  }
 }
 
-.timeline-comment.current-user .comment-header{
+.timeline-comment.current-user .comment-header {
   background-color: black;
 }
 
@@ -1418,10 +1444,12 @@ body .guides .guides-section-white {
     }
     .modal-body {
       padding: 1px 60px;
-      h2,h3,p {
+      h2,
+      h3,
+      p {
         color: #1e252f;
       }
-      h2{
+      h2 {
         margin: 30px 0;
         font-size: 28px;
       }
@@ -1458,7 +1486,7 @@ body .guides .guides-section-white {
             transform: rotate(45deg);
             -o-transform: rotate(45deg);
             -ms-transform: rotate(45deg);
-            -webkit-transform: rotate(45deg)
+            -webkit-transform: rotate(45deg);
           }
         }
       }
@@ -1480,7 +1508,8 @@ body .guides .guides-section-white {
         font-weight: 600;
         margin-bottom: 10px;
       }
-      .btn-link, .btn-primary {
+      .btn-link,
+      .btn-primary {
         &:hover {
           .no-transform();
         }


### PR DESCRIPTION
* The "files changed" section shows a lot of changes on the `guides.less` file but those were all formatting changes with the exception of changing the line-height property on `post-content` class to 1.7.

#### Before
![image-20200727-170411](https://user-images.githubusercontent.com/21035422/89317369-7c4ba180-d63a-11ea-8d6f-5d2abcdfcf3b.png)


#### After
<img width="874" alt="Screen Shot 2020-08-04 at 10 11 41 AM" src="https://user-images.githubusercontent.com/21035422/89317673-f3813580-d63a-11ea-84cf-181e5c2ac2ef.png">



[WWW-101]

[WWW-101]: https://gruntwork.atlassian.net/browse/WWW-101