### PR TITLE
Makes admonition for deploying ECS Deploy Runner Prominent [WWW-102]

### DIFF
--- a/_posts/2020-02-06-how-to-configure-a-production-grade-ci-cd-setup-for-apps-and-infrastructure-code.adoc
+++ b/_posts/2020-02-06-how-to-configure-a-production-grade-ci-cd-setup-for-apps-and-infrastructure-code.adoc
@@ -1133,6 +1133,7 @@ infrastructure-live
 
 === Deploy the ECS Deploy Runner
 
+[.exceptional]
 IMPORTANT: This guide is currently only compatible with ECS deploy runner version v0.23.x
 
 // TODO: update link to use service catalog so it is publicly visible

--- a/assets/css/guides.less
+++ b/assets/css/guides.less
@@ -1274,7 +1274,7 @@ body .guides .guides-section-white {
           font-weight: normal;
           left: 0;
           font-size: 16px;
-          margin-top: -9px;
+          margin-top: -12px;
         }
       }
 
@@ -1339,6 +1339,24 @@ body .guides .guides-section-white {
   .title:after {
     background-color: #ef5a73;
     border: 1px solid #ef5a73;
+  }
+}
+
+.admonitionblock.exceptional {
+  border-top: 9px solid #fd0606;
+  background-color: #ffe3e3;
+
+  tbody {
+    background-color: #ffe3e3;
+
+    .content{
+      font-size: 14px;
+    }
+
+    .title:after {
+      background-color: #fd0606;
+      border: 1px solid #fd0606;
+    }
   }
 }
 


### PR DESCRIPTION
<img width="1715" alt="Screen Shot 2020-08-24 at 7 04 55 PM" src="https://user-images.githubusercontent.com/21035422/91111185-18b30380-e63d-11ea-82f7-84a53298a5d6.png">


https://deploy-preview-356--keen-clarke-470db9.netlify.app/guides/automations/how-to-configure-a-production-grade-ci-cd-setup-for-apps-and-infrastructure-code/#deploy-a-vpc

[WWW-102]

[WWW-102]: https://gruntwork.atlassian.net/browse/WWW-102