### PR TITLE
Fix recaptcha icon display [WWW-103]

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -90,9 +90,10 @@
   });
 </script>
 
+{% if page.use_recaptcha %}
 <!-- recaptcha v3 by Google -->
-<script src="https://www.google.com/recaptcha/api.js?render={{ site.recaptchaApiKey }}"></script>
-
+<script src="https://www.google.com/recaptcha/api.js?render={{ site.recaptchaApiKey }}&style='bottomleft'"></script>
+{% endif %}
 <!-- Cookie Policy Notification -->
 <script src="{{ site.assets_base_url }}js/cookie.js" async></script>
 {% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -92,7 +92,7 @@
 
 {% if page.use_recaptcha %}
 <!-- recaptcha v3 by Google -->
-<script src="https://www.google.com/recaptcha/api.js?render={{ site.recaptchaApiKey }}&style='bottomleft'"></script>
+<script src="https://www.google.com/recaptcha/api.js?render={{ site.recaptchaApiKey }}"></script>
 {% endif %}
 <!-- Cookie Policy Notification -->
 <script src="{{ site.assets_base_url }}js/cookie.js" async></script>

--- a/assets/css/global.less
+++ b/assets/css/global.less
@@ -1595,7 +1595,7 @@ h6, .h6 { .heading-margin-variant(0.68; 0.52; @line-height-h6); }
 }
 .smaller{
   font-size: 0.8em;
-  
+
 }
 
 .big-price, .large-price, .medium-price, .small-price {
@@ -2931,4 +2931,16 @@ input[type=number]::-webkit-outer-spin-button {
   &::before {
     background: white;
   }
+}
+
+.grecaptcha-badge {
+  width: 70px !important;
+  overflow: hidden !important;
+  transition: all 0.3s ease !important;
+  left: 20px !important;
+  bottom: 20px !important;
+}
+
+.grecaptcha-badge:hover {
+  width: 256px !important;
 }

--- a/pages/contact/index.html
+++ b/pages/contact/index.html
@@ -5,6 +5,7 @@ permalink: /contact/
 slug: contact
 custom_js:
   - contact
+use_recaptcha: true
 ---
 
 <div class="main">


### PR DESCRIPTION
Due to Google's terms around displaying the Recaptcha Icon which I have referenced in the [issue here](https://gruntwork.atlassian.net/browse/WWW-103), I have chosen to display it in a different portion of the screen; bottom-left.

- The first pass resulted in this:
<img width="1685" alt="Screen Shot 2020-08-31 at 1 23 56 PM" src="https://user-images.githubusercontent.com/21035422/91758660-991dbb00-eb8d-11ea-90ca-518a9253c325.png">

The display on large screens is passable but on mobile; it really starts to overlap too much content and clog the display. This got me thinking that we should not be loading the script on all pages on the website anyway.

We should load Recaptcha only where needed and that also has the added benefit of narrowing the traffic which Recaptcha uses to score interactions and should therefore make it more accurate.

- Final Pass (Recaptcha loaded only on Contact page)
<img width="1679" alt="Screen Shot 2020-08-31 at 1 05 18 PM" src="https://user-images.githubusercontent.com/21035422/91759063-4690ce80-eb8e-11ea-940b-f27af1851bd1.png">

 
<img width="1669" alt="Screen Shot 2020-08-31 at 1 32 23 PM" src="https://user-images.githubusercontent.com/21035422/91759170-72ac4f80-eb8e-11ea-815e-94268c9d1616.png">


