### PR TITLE
Change open source policy to Notion doc

### DIFF
--- a/pages/open-source-policy/index.html
+++ b/pages/open-source-policy/index.html
@@ -3,5 +3,5 @@ layout: default
 title: Gruntwork Open Source Policy
 permalink: /open-source-policy/
 redirect_to:
-  - https://docs.google.com/document/d/1f_ZOh_PtAte_v8Q0lBNaWZ6QQAuu0ZdgwPA_eh3ovdo
+  - https://www.notion.so/gruntwork/Gruntwork-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378
 ---


### PR DESCRIPTION
As per [this Slack thread](https://gruntwork-io.slack.com/archives/CLYE0JYS0/p1602859003208300?thread_ts=1602779219.187400&cid=CLYE0JYS0), we've moved our open source policy into a [page in Notion](https://www.notion.so/gruntwork/Gruntwork-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378). I shared this page publicly on the web via [this link](https://www.notion.so/gruntwork/Gruntwork-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) and in this PR, I'm updating our website to redirect to the public Notion page, so we have one place we're maintaining this policy.