### PR TITLE
Add sales role. Connect SRE role to Workable. Add menu of open positions at top of career pages.

### DIFF
--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -11,7 +11,7 @@
 
     <ul>
       <li><a href="#software-engineer">Software Engineering</a></li>
-      <li><a href="#site-reliability-engineer-sre">Site Reliability Engineering (SRE)</a></li>
+      <li><a href="#sre">Site Reliability Engineering (SRE)</a></li>
       <li><a href="#sales">Sales</a></li>
     </ul>
 
@@ -97,7 +97,7 @@
 
     <hr />
 
-    <a target="site-reliability-engineer-sre"></a>
+    <a target="sre"></a>
     <h2>Site Reliability Engineering (SRE)</h2>
 
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Site Reliability Engineer (SRE)</h3>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -194,5 +194,46 @@
       <a href="https://apply.workable.com/gruntwork-io/j/21BC80A6E4/apply/" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa" style="margin-top:10px;" role="button">Apply Now</a>
     </p>
 
+    <hr />
+
+    <a target="director-of-sales"></a>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Sales Engineer</h3>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Sales Engineer</h3>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Salesperson</h3>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Director of Sales</h3>
+
+    <p>We're looking for a Director of Sales who can own the sales function at Gruntwork. To date, we've asked a small number
+      of DevOps engineers to handle sales calls in addition to their core work. As our company and lead volume have grown,
+      our team wants to stay focused on core product development projects, leaving sales without the attention it deserves.
+      Now we're looking to make our first dedicated sales hire and eventually build up a multi-member sales team at Gruntwork.
+    </p>
+    <p>As the Director of Sales, we'll look to you to create a sales strategy, handle all incoming leads from initial inquiry
+      to signed contract, refine our pitch, measure our success, and lay the groundwork for building up a future sales team.
+      You'll be supported by our current world-class engineers as they transition from "engineer sales person" to "sales engineer."
+      You'll work closely with and report directly to the founders.
+    </p>
+    <h4>What You'll Work On</h4>
+    <ul>
+      <li>
+      <li><strong>Lead sales strategy at Gruntwork.</strong> Gruntwork has become a multi-million dollar company with no outside investment, no debt, and a few humble engineers leading the way on sales. How do we transition from an engineer-led sales process to a more effective one led by sales? How do we measure our success? You'll lead the charge to answer those questions and implement the strategy.</li>
+      <li><strong>Design the sales pitch.</strong> Our sales presentation today involves Gruntwork engineers speaking to customer engineers with no slide deck needed. Customer love the detail and first-hand technical knowledge, but our engineers need the ability to focus on building our product. You'll help us craft an updated sales pitch for a target market (software engineers and DevOps engineers) that is averse to the classic Powerpoint and hungry for the technical details.</li>
+      <li><strong>Streamline our sales workflow.</strong> We are a company of engineers so a part of us dies when we see manual data entry taking up time unnecessarily. We'll look to you to design a streamlined sales workflow that captures key data and enables key metrics using either our existing CRM (Salesforce), or to make the case for a new CRM.</li>
+      <li><strong>Manage deals.</strong> We receive a growing number of leads each month and are struggling to keep up. As our first dedicated sales hire, you'll roll up your sleeves and respond to leads, lead sales calls, and close the deals. You'll engage with some of the largest enterprise companies in the world — and throughout the world — as well as cutting-edge new startups.</li>
+      <li><strong>Light marketing.</strong> You'll primarily focus on converting qualified leads into signed contracts, but there may be low-hanging fruit opportunities to bring in more leads. We'll look to you to identify and coordinate those opportunities, backed by additional budget if needed.</li>
+      <li><strong>Grow a sales team.</strong> You'll lay the groundwork for building up a multi-person sales team. Once we can make the case that hiring another person in sales will be a positive return on investment, we'll look to you to recruit, train, and manage the growing team.</li>
+    </ul>
+    <h4>Your Ideal Background</h4>
+    <ul>
+      <li><strong>Ability to sell.</strong> We can trust you to own all new opportunities ranging from small to company-changing. You should have confidence in your ability to effectively convert qualified leads to a signed contract. You should have prior experience closing deals end-to-end with both small startups and large enterprises.
+      <li><strong>Ability to lead and strategize.</strong> Your past results either prove you can successfully own strategy and leadership for our sales team, or this opportunity represents a natural next step in your career.
+      <li><strong>Moral grounding.</strong> A core principle at Gruntwork is doing the right thing. We expect all Grunts to be honest and never compromise their integrity. We understand there's a natural pressure to close the deal, but we only sell products to customers when we genuinely believe they will be of value. You should feel comfortable saying no when necessary so that we can all sleep better at night.
+      <li><strong>Technical skill.</strong> While you don't have to be a software engineer, you should be able to build a reasonable mental model of what Gruntwork does and field a common set of customer technical questions. We'll look for indicators that you've done that before.
+      <li><strong>Bonus: Consulting skill.</strong> Gruntwork helps customers deploy production-grade cloud infrastructure in record time, and sometimes general questions come up that call upon us to become temporary consultants. Or when speaking with large enterprises, you can speak thoughtfully at the level of broad industry trends.
+      <li><strong>Bonus: Software/DevOps background.</strong> If you happen to have a background in software engineering or DevOps, you may well be a uniquely good fit for this role!</li>
+    </ul>
+    <p>If the above describes you:<br>
+      <a href="https://apply.workable.com/gruntwork-io/j/52C1960D89/apply/" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa" style="margin-top:10px;" role="button">Apply Now</a>
+    </p>
+
   </div>
 </div>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -17,8 +17,8 @@
 
     <hr />
 
-    <h2>Software Engineering</h2>
     <a target="software-engineer"></a>
+    <h2>Software Engineering</h2>
 
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Software Engineer</h3>
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Software Engineer</h3>
@@ -97,8 +97,8 @@
 
     <hr />
 
-    <h2>Site Reliability Engineering (SRE)</h2>
     <a target="site-reliability-engineer-sre"></a>
+    <h2>Site Reliability Engineering (SRE)</h2>
 
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Site Reliability Engineer (SRE)</h3>
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Site Reliability Engineer (SRE)</h3>
@@ -206,9 +206,9 @@
 
     <hr />
 
-    <h2>Sales</h2>
     <a target="sales"></a>
-    
+    <h2>Sales</h2>
+
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Sales Engineer</h3>
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Sales Engineer</h3>
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Salesperson</h3>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -191,8 +191,8 @@
       </li>
     </ul>
     <p>If the above describes you:<br>
-      <a href="mailto:careers@gruntwork.io?subject=Gruntwork SRE Role" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa" style="margin-top:10px;" role="button">Apply Now</a>
+      <a href="https://apply.workable.com/gruntwork-io/j/21BC80A6E4/apply/" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa" style="margin-top:10px;" role="button">Apply Now</a>
     </p>
-    
+
   </div>
 </div>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -214,7 +214,6 @@
     </p>
     <h4>What You'll Work On</h4>
     <ul>
-      <li>
       <li><strong>Lead sales strategy at Gruntwork.</strong> Gruntwork has become a multi-million dollar company with no outside investment, no debt, and a few humble engineers leading the way on sales. How do we transition from an engineer-led sales process to a more effective one led by sales? How do we measure our success? You'll lead the charge to answer those questions and implement the strategy.</li>
       <li><strong>Design the sales pitch.</strong> Our sales presentation today involves Gruntwork engineers speaking to customer engineers with no slide deck needed. Customer love the detail and first-hand technical knowledge, but our engineers need the ability to focus on building our product. You'll help us craft an updated sales pitch for a target market (software engineers and DevOps engineers) that is averse to the classic Powerpoint and hungry for the technical details.</li>
       <li><strong>Streamline our sales workflow.</strong> We are a company of engineers so a part of us dies when we see manual data entry taking up time unnecessarily. We'll look to you to design a streamlined sales workflow that captures key data and enables key metrics using either our existing CRM (Salesforce), or to make the case for a new CRM.</li>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -9,9 +9,17 @@
       looking for:
     </p>
 
+    <ul>
+      <li><a href="#software-engineer">Software Engineering</a></li>
+      <li><a href="#site-reliability-engineer-sre">Site Reliability Engineering (SRE)</a></li>
+      <li><a href="#sales">Sales</a></li>
+    </ul>
+
     <hr />
 
+    <h2>Software Engineering</h2>
     <a target="software-engineer"></a>
+
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Software Engineer</h3>
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Software Engineer</h3>
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Principal Software Engineer</h3>
@@ -89,7 +97,9 @@
 
     <hr />
 
+    <h2>Site Reliability Engineering (SRE)</h2>
     <a target="site-reliability-engineer-sre"></a>
+
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Site Reliability Engineer (SRE)</h3>
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Site Reliability Engineer (SRE)</h3>
     <h3 style="margin-top: 5px;">Principal Site Reliability Engineer (SRE)</h3>
@@ -196,7 +206,9 @@
 
     <hr />
 
-    <a target="director-of-sales"></a>
+    <h2>Sales</h2>
+    <a target="sales"></a>
+    
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Sales Engineer</h3>
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Sales Engineer</h3>
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Salesperson</h3>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -10,14 +10,13 @@
     </p>
 
     <ul>
-      <li><a href="#software-engineer">Software Engineering</a></li>
-      <li><a href="#sre">Site Reliability Engineering (SRE)</a></li>
+      <li><a href="#software-engineering">Software Engineering</a></li>
+      <li><a href="#site-reliability-engineering-sre">Site Reliability Engineering (SRE)</a></li>
       <li><a href="#sales">Sales</a></li>
     </ul>
 
     <hr />
 
-    <a target="software-engineer"></a>
     <h2>Software Engineering</h2>
 
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Software Engineer</h3>
@@ -97,7 +96,6 @@
 
     <hr />
 
-    <a target="sre"></a>
     <h2>Site Reliability Engineering (SRE)</h2>
 
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Site Reliability Engineer (SRE)</h3>
@@ -206,7 +204,6 @@
 
     <hr />
 
-    <a target="sales"></a>
     <h2>Sales</h2>
 
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Sales Engineer</h3>
@@ -235,13 +232,14 @@
     </ul>
     <h4>Your Ideal Background</h4>
     <ul>
-      <li><strong>Ability to sell.</strong> We can trust you to own all new opportunities ranging from small to company-changing. You should have confidence in your ability to effectively convert qualified leads to a signed contract. You should have prior experience closing deals end-to-end with both small startups and large enterprises.
-      <li><strong>Ability to lead and strategize.</strong> Your past results either prove you can successfully own strategy and leadership for our sales team, or this opportunity represents a natural next step in your career.
-      <li><strong>Moral grounding.</strong> A core principle at Gruntwork is doing the right thing. We expect all Grunts to be honest and never compromise their integrity. We understand there's a natural pressure to close the deal, but we only sell products to customers when we genuinely believe they will be of value. You should feel comfortable saying no when necessary so that we can all sleep better at night.
-      <li><strong>Technical skill.</strong> While you don't have to be a software engineer, you should be able to build a reasonable mental model of what Gruntwork does and field a common set of customer technical questions. We'll look for indicators that you've done that before.
-      <li><strong>Bonus: Consulting skill.</strong> Gruntwork helps customers deploy production-grade cloud infrastructure in record time, and sometimes general questions come up that call upon us to become temporary consultants. Or when speaking with large enterprises, you can speak thoughtfully at the level of broad industry trends.
-      <li><strong>Bonus: Software/DevOps background.</strong> If you happen to have a background in software engineering or DevOps, you may well be a uniquely good fit for this role!</li>
+      <li><strong>Ability to sell.</strong> We can trust you to own all new opportunities ranging from small to company-changing. You should have confidence in your ability to effectively convert qualified leads to a signed contract. You should have prior experience closing deals end-to-end with both small startups and large enterprises.</li>
+      <li><strong>Ability to lead and strategize.</strong> Your past results either prove you can successfully own strategy and leadership for our sales team, or this opportunity represents a natural next step in your career.</li>
+      <li><strong>Moral grounding.</strong> A core principle at Gruntwork is doing the right thing. We expect all Grunts to be honest and never compromise their integrity. We understand there's a natural pressure to close the deal, but we only sell products to customers when we genuinely believe they will be of value. You should feel comfortable saying no when necessary so that we can all sleep better at night.</li>
+      <li><strong>Technical skill.</strong> You should be able to build a reasonable mental model of what Gruntwork does and field a common set of customer technical questions. We'll look for indicators that you've done that before, or better yet that you have a technical background in software engineering or DevOps.</li>
+      <li><strong>Bonus: Consulting skill.</strong> Gruntwork helps customers deploy production-grade cloud infrastructure in record time, and sometimes general questions come up that call upon us to become temporary consultants. Or when speaking with large enterprises, you can speak thoughtfully at the level of broad industry trends.</li>
     </ul>
+    <h4>What time zones do we work in?</h4>
+    <p>While Gruntwork <a href="/careers/#sane-working-hours">generally</a> hires anywhere between San Francisco and Berlin, candidates for this role must be within the GMT-7 to GMT-3 time zones, with a preference for being located in the USA or Canada. We expect you'll work primarily with customers and fellow Grunts in those time zones, with limited engagement with customers worldwide and Grunts in Europe. Working during reasonable hours is a priority for us.</p>
     <p>If the above describes you:<br>
       <a href="https://apply.workable.com/gruntwork-io/j/52C1960D89/apply/" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa" style="margin-top:10px;" role="button">Apply Now</a>
     </p>


### PR DESCRIPTION
- Add the sales role!
- Update the SRE role to direct applications to Workable
- Add a menu of available positions at the top of the career page