### PR TITLE
Remove links to our -public repos

### DIFF
--- a/_data/library.yml
+++ b/_data/library.yml
@@ -99,6 +99,7 @@
     - title: Python
       image: icon-python.png
   private_beta: true
+  docs_url: "https://gruntwork.io/repos/terraform-aws-eks"
   subscriber_url: "https://github.com/gruntwork-io/terraform-aws-eks"
   type: Subscriber-Only
   description: |
@@ -175,6 +176,7 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
+  docs_url: "https://gruntwork.io/repos/module-load-balancer"
   subscriber_url: "https://github.com/gruntwork-io/module-load-balancer"
   type: Subscriber-Only
   description: |
@@ -197,6 +199,7 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
+  docs_url: "https://gruntwork.io/repos/package-lambda"
   subscriber_url: "https://github.com/gruntwork-io/package-lambda"
   type: Subscriber-Only
   description: |
@@ -225,6 +228,7 @@
       image: icon-terraform.png
     - title: Go
       image: icon-go.png
+  docs_url: "https://gruntwork.io/repos/package-sam"
   subscriber_url: "https://github.com/gruntwork-io/package-sam"
   type: Subscriber-Only
   description: |
@@ -471,6 +475,7 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
+  docs_url: "https://gruntwork.io/repos/package-static-assets"
   subscriber_url: "https://github.com/gruntwork-io/package-static-assets"
   type: Subscriber-Only
   description: |
@@ -492,6 +497,7 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
+  docs_url: "https://gruntwork.io/repos/package-mongodb"
   subscriber_url: "https://github.com/gruntwork-io/package-mongodb"
   type: Subscriber-Only
   description: |
@@ -522,6 +528,7 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
+  docs_url: "https://gruntwork.io/repos/package-kafka"
   subscriber_url: "https://github.com/gruntwork-io/package-kafka"
   type: Subscriber-Only
   description: |
@@ -559,6 +566,7 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
+  docs_url: "https://gruntwork.io/repos/package-zookeeper"
   subscriber_url: "https://github.com/gruntwork-io/package-zookeeper"
   type: Subscriber-Only
   description: |
@@ -594,6 +602,7 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
+  docs_url: "https://gruntwork.io/repos/package-elk"
   subscriber_url: "https://github.com/gruntwork-io/package-elk"
   type: Subscriber-Only
   description: |
@@ -631,6 +640,7 @@
       image: icon-bash.png
     - title: Go
       image: icon-go.png
+  docs_url: "https://gruntwork.io/repos/package-openvpn"
   subscriber_url: "https://github.com/gruntwork-io/package-openvpn"
   type: Subscriber-Only
   description: |
@@ -657,6 +667,7 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
+  docs_url: "https://gruntwork.io/repos/package-messaging"
   subscriber_url: "https://github.com/gruntwork-io/package-messaging"
   type: Subscriber-Only
   description: |
@@ -971,6 +982,7 @@
   icons:
     - title: Go
       image: icon-go.png
+  docs_url: "https://gruntwork.io/repos/gruntkms"
   subscriber_url: "https://github.com/gruntwork-io/gruntkms"
   type: Subscriber-Only
   description: |

--- a/_data/library.yml
+++ b/_data/library.yml
@@ -4,7 +4,7 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
-  docs_url: "https://github.com/gruntwork-io/module-vpc-public"
+  docs_url: "https://gruntwork.io/repos/module-vpc"
   subscriber_url: "https://github.com/gruntwork-io/module-vpc"
   type: Subscriber-Only
   description: |
@@ -43,7 +43,7 @@
       image: icon-bash.png
     - title: Python
       image: icon-python.png
-  docs_url: "https://github.com/gruntwork-io/module-aws-monitoring-public"
+  docs_url: "https://gruntwork.io/repos/module-aws-monitoring"
   subscriber_url: "https://github.com/gruntwork-io/module-aws-monitoring"
   type: Subscriber-Only
   description: |
@@ -67,7 +67,7 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
-  docs_url: "https://github.com/gruntwork-io/module-ecs-public"
+  docs_url: "https://gruntwork.io/repos/module-ecs"
   subscriber_url: "https://github.com/gruntwork-io/module-ecs"
   type: Subscriber-Only
   description: |
@@ -155,7 +155,7 @@
       image: icon-terraform.png
     - title: Python
       image: icon-python.png
-  docs_url: "https://github.com/gruntwork-io/module-asg-public"
+  docs_url: "https://gruntwork.io/repos/module-asg"
   subscriber_url: "https://github.com/gruntwork-io/module-asg"
   type: Subscriber-Only
   description: |
@@ -250,7 +250,7 @@
       image: icon-bash.png
     - title: Go
       image: icon-go.png
-  docs_url: "https://github.com/gruntwork-io/module-security-public"
+  docs_url: "https://gruntwork.io/repos/module-security"
   subscriber_url: "https://github.com/gruntwork-io/module-security"
   type: Subscriber-Only
   description: |
@@ -346,7 +346,7 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
-  docs_url: "https://github.com/gruntwork-io/module-ci-public"
+  docs_url: "https://gruntwork.io/repos/module-ci"
   subscriber_url: "https://github.com/gruntwork-io/module-ci"
   type: Subscriber-Only
   description: |
@@ -387,11 +387,11 @@
       image: icon-terraform.png
     - title: Python
       image: icon-python.png
-  docs_url: "https://github.com/gruntwork-io/module-data-storage-public"
+  docs_url: "https://gruntwork.io/repos/module-data-storage"
   subscriber_url: "https://github.com/gruntwork-io/module-data-storage"
   type: Subscriber-Only
   description: |
-    Run MySQL, Postgres, MariaDB, or Amazon Aurora on Amazon’s Relational Database Service (RDS) or Amazon Redshift. 
+    Run MySQL, Postgres, MariaDB, or Amazon Aurora on Amazon’s Relational Database Service (RDS) or Amazon Redshift.
     Creates the database, sets up replicas, configures multi-zone automatic failover and automatic backup.
   submodules:
     - name: rds
@@ -422,7 +422,7 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
-  docs_url: "https://github.com/gruntwork-io/module-cache-public"
+  docs_url: "https://gruntwork.io/repos/module-cache"
   subscriber_url: "https://github.com/gruntwork-io/module-cache"
   type: Subscriber-Only
   description: |
@@ -444,7 +444,7 @@
       image: icon-terraform.png
     - title: Bash
       image: icon-bash.png
-  docs_url: "https://github.com/gruntwork-io/module-server-public"
+  docs_url: "https://gruntwork.io/repos/module-server"
   subscriber_url: "https://github.com/gruntwork-io/module-server"
   type: Subscriber-Only
   description: |
@@ -985,7 +985,7 @@
       image: icon-terraform.png
     - title: Go
       image: icon-go.png
-  docs_url: "https://github.com/gruntwork-io/module-security-public/tree/master/modules/ssh-grunt"
+  docs_url: "https://gruntwork.io/repos/module-security/modules/ssh-grunt/README.adoc"
   subscriber_url: "https://github.com/gruntwork-io/module-security/tree/master/modules/ssh-grunt"
   type: Subscriber-Only
   description: |
@@ -998,7 +998,7 @@
   icons:
     - title: Bash
       image: icon-bash.png
-  docs_url: "https://github.com/gruntwork-io/module-security-public/tree/master/modules/aws-auth"
+  docs_url: "https://gruntwork.io/repos/module-security/modules/aws-auth/README.md"
   subscriber_url: "https://github.com/gruntwork-io/module-security/tree/master/modules/aws-auth"
   type: Subscriber-Only
   description: |

--- a/_data/library.yml
+++ b/_data/library.yml
@@ -1088,7 +1088,8 @@
   icons:
     - title: Go
       image: icon-go.png
-  public_url: "https://github.com/gruntwork-io/gruntwork"
+  docs_url: "https://gruntwork.io/repos/gruntwork"
+  subscriber_url: "https://github.com/gruntwork-io/gruntwork"
   type: Subscriber-Only
   description: |
     A CLI tool to perform Gruntwork tasks, such as bootstrapping your GitHub and AWS accounts for the Reference

--- a/_data/library.yml
+++ b/_data/library.yml
@@ -4,8 +4,8 @@
   icons:
     - title: Terraform
       image: icon-terraform.png
-  docs_url: "https://gruntwork.io/repos/module-vpc"
-  subscriber_url: "https://github.com/gruntwork-io/module-vpc"
+  docs_url: "https://gruntwork.io/repos/terraform-aws-vpc"
+  subscriber_url: "https://github.com/gruntwork-io/terraform-aws-vpc"
   type: Subscriber-Only
   description: |
     Create a best-practices Virtual Private Cloud (VPC) on AWS. Includes multiple subnet tiers, network ACLs, security
@@ -43,8 +43,8 @@
       image: icon-bash.png
     - title: Python
       image: icon-python.png
-  docs_url: "https://gruntwork.io/repos/module-aws-monitoring"
-  subscriber_url: "https://github.com/gruntwork-io/module-aws-monitoring"
+  docs_url: "https://gruntwork.io/repos/terraform-aws-monitoring"
+  subscriber_url: "https://github.com/gruntwork-io/terraform-aws-monitoring"
   type: Subscriber-Only
   description: |
     Configure monitoring, log aggregation, and alerting using CloudWatch, SNS, and S3. Includes Slack integration.

--- a/jekyll-serve.sh
+++ b/jekyll-serve.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-bundle exec jekyll build --incremental
 bundle exec jekyll serve --livereload --drafts --host 0.0.0.0


### PR DESCRIPTION
As part of cleaning up the `-public` repos, we need to remove any inbound links to them. This PR updates the IaC Lib page to replace this links with links to our repo browser. As a bonus, I also add repo browser links to all our repos, and fix broken links on a few items.