### PR TITLE
Go all in on the senior sales engineer approach.

### DIFF
--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -230,7 +230,7 @@
     <ul>
       <li><strong>DevOps experience.</strong> You've deployed software in prod, have solid experience with one or more of {AWS, GCP, Azure}, felt the pain, and understand why the Gruntwork product matters.</li>
       <li><strong>Technical skill.</strong> You can write code and build tools. You hate manual data entry so you write your own CLI tool to streamline it. You hate manually generating quotes, so you automate the CRM to do it.</li>
-      <li><strong>Ability to sell.</strong> You've had success selling technical products with both small startups and large enterprises. </li>
+      <li><strong>Sales skill.</strong> When it's clear we can add value to the customer, you're comfortable guiding the deal to a close. </li>
       <li><strong>Passionate about business.</strong> You love making a company grow, and delight in applying your scrappy techical skills and strategic acumen to make impact. </li>
       <li><strong>Moral grounding.</strong> You feel comfortable saying no when necessary so that we can all sleep better at night. In general, you do the right thing, for yourself, for Gruntwork, and for customers. </li>
     </ul>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -207,37 +207,32 @@
     <h2>Sales</h2>
 
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Sales Engineer</h3>
-    <h3 style="margin-top: 5px; margin-bottom: 5px;">Account Executive / Director of Sales</h3>
 
     <p>We're making for our first dedicated sales hire at Gruntwork. We've grown to millions of dollars in annual revenue
-       with zero outside investment/debt, near-zero marketing budget, and a small number of cloud engineers who handle
+       with zero outside investment/debt, near-zero marketing budget, and a small number of software engineers who handle
        all sales calls in addition to their core work. Now we're ready to take our sales to the next level!</p>
-    <p>As the first sales hire, you'll report directly to the founders and have considerable impact on the overall
-      growth of the company. In this role, it's critical that you do actual sales effectively (versus only managing others),
-      while at the same time helping us lay the groundwork for a future sales team, whether as a star individual contributor
-      or future sales manager (at Gruntwork, we value them equally).</p>
-    <p>Because our product is technical in nature, we're exploring two possible directions for our first sales hire:</p>
-    <ul>
-      <li><strong>Sales professionals with technical experience</strong> (Account Executive/Director of Sales)</li>
-      <li><strong>Technical professionals with sales experience</strong> (Senior Sales Engineer)</li>
-    </ul>
-    <p>We'd love to hear your vision for taking Grunwork sales to the next level!</p>
+    <p>Our product is used and purchased by software and DevOps engineers, so we are looking for a sales engineer
+      with senior-level experience and a special knack for sales. As the first sales engineer hire, you'll report directly
+      to the founders and have considerable impact on the overall growth of the company. Your growth path in this role could
+      be as either a star individual contributor or future team lead (at Gruntwork, we value IC and management roles equally).</p>
+    <p></p>
+  
     <h4>What You'll Work On</h4>
     <ul>
-      <li><strong>Manage deals.</strong> Engage with some of the largest enterprise companies in the world as well as cutting-edge new startups. Own the deal from initial inquiry through contract signature. </li>
-      <li><strong>Drive sales strategy at Gruntwork.</strong> Help us tailor our approach to different market segments, identify new strategic opportunities, build out a new partner program to drive more sales, and generally fill in the details of our sales strategy.</li>
-      <li><strong>Improve the sales pitch.</strong> Work with us to transition from an engineering-centric sales discussion to a sales-focused pitch that still resonates with our technical customers.</li>
-      <li><strong>Streamline our sales workflow.</strong> Help us strike the right balance between capturing key data in our CRM (currently Salesforce) and maintaining personal productivity and efficiency.</li>
+      <li><strong>Showcase the product.</strong> Show customers how the Gruntwork product works. Answer both their high-level stratgic questions and low-level technical questions. Where necessary, create new demos or implement solutions to directly solve customer problems.</li>
+      <li><strong>Improve the sales pitch.</strong> Observe what resonates with customers, and iteratively improve the effectiveness of our sales presentation.</li>
+      <li><strong>Streamline our sales workflow.</strong> Help us improve personal productivity by streamlining the way we track our deals, possibly by writing your own tooling.</li>
+      <li><strong>Manage deals.</strong> Own the deal from initial inquiry through contract signature. Engage with both large enterprises and startups.</li>
+      <li><strong>Drive sales strategy.</strong> Help us tailor our approach to different market segments, identify new strategic opportunities, build out a new partner program to drive more sales, and generally create more opportunities. Use your coding skills to automate where applicable.</li>
       <li><strong>Light marketing.</strong> Drive a limited set of low-hanging fruit opportunities to bring in more leads, backed by additional budget if needed.</li>
-      <li><strong>Lay the groundwork for a sales team.</strong> Help us build the foundation for a future multi-person sales team.</li>
     </ul>
     <h4>Your Ideal Background</h4>
     <ul>
-      <li><strong>Ability to sell.</strong> You've had success selling technical products from initial inquiry to signed contract with both small startups and large enterprises. </li>
-      <li><strong>Passionate about the art of sales.</strong> You have studied sales metholodologies and approaches, and can save us time by pattern-matching them to Gruntwork. </li>
-      <li><strong>Technical understanding.</strong> You expect to ramp up in our domain so that you have a core set of genuinely valuable technical information to offer customers, and clarity on when to defer to the engineers.</li>
+      <li><strong>DevOps experience.</strong> You've deployed software in prod, have solid experience with one or more of {AWS, GCP, Azure}, felt the pain, and understand why the Gruntwork product matters.</li>
+      <li><strong>Technical skill.</strong> You can write code and build tools. You hate manual data entry so you write your own CLI tool to streamline it. You hate manually generating quotes, so you automate the CRM to do it.</li>
+      <li><strong>Ability to sell.</strong> You've had success selling technical products with both small startups and large enterprises. </li>
+      <li><strong>Passionate about business.</strong> You love making a company grow, and delight in applying your scrappy techical skills and strategic acumen to make impact. </li>
       <li><strong>Moral grounding.</strong> You feel comfortable saying no when necessary so that we can all sleep better at night. In general, you do the right thing, for yourself, for Gruntwork, and for customers. </li>
-      <li><strong>Bonus: Technical skill.</strong> You can write code and build tools. You hate manual data entry so you write your own CLI tool to streamline it. You hate manually generating quotes, so you automate the CRM to do it. When customers point out gaps in the docs or product, you fill those gaps to help close the deal.</li>
     </ul>
     <h4>What time zones do we work in?</h4>
     <p>While Gruntwork <a href="/careers/#sane-working-hours">generally</a> hires anywhere between San Francisco and Berlin, candidates for this role must be within the GMT-7 to GMT-3 time zones, with a preference for being located in the USA or Canada. We expect you'll work primarily with customers and fellow Grunts in those time zones, with limited engagement with customers worldwide and Grunts in Europe. Working during reasonable hours is a priority for us.</p>


### PR DESCRIPTION
Our previous posting for the new sales hire took a wishy-washy position around whether we hire an account executive, sales engineer, or something else, looking to the candidate to help us decide. After getting enough experience talking to real candidates and thinking on this some more, I've concluded that we are essentially looking for a senior sales engineer (sometimes known as a solutions engineer) who can sell. I've updated the job posting accordingly.

Update: You can view a rendered version of the post at:
https://deploy-preview-388--keen-clarke-470db9.netlify.app/careers/#sales