### PR TITLE
Change Slack notifications channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,11 +71,13 @@ references:
       failure_message: ":red_circle: $CIRCLE_JOB has failed on master! Build triggered by: $CIRCLE_USERNAME. You have one hour to fix or revert!!"
       success_message: ":tada: stage (static) has been successfully deployed at version $CIRCLE_SHA1 to https://www.dogfood-stage.com"
       only_for_branches: "master"
+      channel: "C01J73HUKEF" # #team-platform-notifications
 
   notify_slack_prod: &notify_slack_prod
     slack/status:
       failure_message: ":red_circle: $CIRCLE_JOB has failed on master! Build triggered by: $CIRCLE_USERNAME. You have one hour to fix or revert!!"
       success_message: ":tada: prod (static) has been successfully deployed at version $CIRCLE_TAG to https://gruntwork.io"
+      channel: "C01J73HUKEF" # #team-platform-notifications
 
 #######################################################################################################################
 # The build jobs available, all consisting of lists of references to the references section above


### PR DESCRIPTION
This PR updates the slack notifications for the CI builds to be directed to a notifications channel rather than sending them to our main slack channel