### PR TITLE
Fix example to be list(string) as var declaration

### DIFF
--- a/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
+++ b/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
@@ -2601,8 +2601,8 @@ inputs = {
   iam_group_name_full_access            = "full-access"
   iam_group_name_read_only              = "read-only"
   iam_group_name_iam_user_self_mgmt     = "self-mgmt"
-  iam_group_names_ssh_grunt_sudo_users  = "ssh-grunt-sudo-users"
-  iam_group_names_ssh_grunt_users       = "ssh-grunt-users"
+  iam_group_names_ssh_grunt_sudo_users  = ["ssh-grunt-sudo-users"]
+  iam_group_names_ssh_grunt_users       = ["ssh-grunt-users"]
 
   # Create IAM groups that grant access to the other AWS accounts
   iam_groups_for_cross_account_access = [


### PR DESCRIPTION
[As pointed out by a customer](https://gruntwork-io.slack.com/archives/CAM4CM63C/p1610575381003700), these docs had an example that was using the `iam_group_names_ssh_grunt_sudo_users` and `iam_group_names_ssh_grunt_users` as `string` instead of `list(string)`.

This PR fixes that. Thanks to Nate! 👍 