### PR TITLE
Update sales post to focus on account executive / director of sales.

### DIFF
--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -206,33 +206,27 @@
 
     <h2>Sales</h2>
 
-    <h3 style="margin-top: 5px; margin-bottom: 5px;">Senior Sales Engineer</h3>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Account Executive<br>Director of Sales</h3>
 
-    <p>We're making for our first dedicated sales hire at Gruntwork. We've grown to millions of dollars in annual revenue
-       with zero outside investment/debt, near-zero marketing budget, and a small number of software engineers who handle
-       all sales calls in addition to their core work. Now we're ready to take our sales to the next level!</p>
-    <p>Our product is used and purchased by software and DevOps engineers, so we are looking for a sales engineer
-      with senior-level experience and a special knack for sales. As the first sales engineer hire, you'll report directly
-      to the founders and have considerable impact on the overall growth of the company. Your growth path in this role could
-      be as either a star individual contributor or future team lead (at Gruntwork, we value IC and management roles equally).</p>
+    <p>We're making for our first dedicated sales hire at Gruntwork. We've grown to millions of dollars in annual revenue with zero outside investment/debt, near-zero marketing budget, and a small number of software engineers who handle all sales calls in addition to their core work. Now we're ready to take our sales to the next level!</p>
+    <p>Our product is used and purchased by software and DevOps engineers, so we are looking for a sales professional with proven experience selling technical products together with sales engineers. As the first sales hire, you'll report directly to the founders and have considerable impact on the overall growth of the company. Your growth path in this role could be as either a star individual contributor or team lead (at Gruntwork, we value IC and management roles equally).</p>
     <p></p>
   
     <h4>What You'll Work On</h4>
     <ul>
-      <li><strong>Showcase the product.</strong> Show customers how the Gruntwork product works. Answer both their high-level stratgic questions and low-level technical questions. Where necessary, create new demos or implement solutions to directly solve customer problems.</li>
-      <li><strong>Improve the sales pitch.</strong> Observe what resonates with customers, and iteratively improve the effectiveness of our sales presentation.</li>
-      <li><strong>Streamline our sales workflow.</strong> Help us improve personal productivity by streamlining the way we track our deals, possibly by writing your own tooling.</li>
-      <li><strong>Manage deals.</strong> Own the deal from initial inquiry through contract signature. Engage with both large enterprises and startups.</li>
-      <li><strong>Drive sales strategy.</strong> Help us tailor our approach to different market segments, identify new strategic opportunities, build out a new partner program to drive more sales, and generally create more opportunities. Use your coding skills to automate where applicable.</li>
-      <li><strong>Light marketing.</strong> Drive a limited set of low-hanging fruit opportunities to bring in more leads, backed by additional budget if needed.</li>
+      <li><strong>Improve our sales process.</strong> Identify what can be improved about our current sales process, prioritize the changes, and lead the implementation in collaboration with the rest of the team.</li>
+      <li><strong>Streamline our sales workflow.</strong> Lay the groundwork for higher personal productivity by streamlining the way we track our deals and helping us adopt best-practices sales tooling.</li>
+      <li><strong>Manage deals.</strong> Own the deal from initial inquiry through contract signature. Engage with both large enterprises and startups.</li>
+      <li><strong>Showcase the product.</strong> Show customers how the Gruntwork product works. Answer both their high-level strategic questions and common technical questions. When necessary, bring in a member of our engineering team as a sales engineer.</li>
+      <li><strong>Business development.</strong> Identify partnership opportunities, prioritize them, and lead their implementation.</li>
     </ul>
     <h4>Your Ideal Background</h4>
     <ul>
-      <li><strong>DevOps experience.</strong> You've deployed software in prod, have solid experience with one or more of {AWS, GCP, Azure}, felt the pain, and understand why the Gruntwork product matters.</li>
-      <li><strong>Technical skill.</strong> You can write code and build tools. You hate manual data entry so you write your own CLI tool to streamline it. You hate manually generating quotes, so you automate the CRM to do it.</li>
-      <li><strong>Sales skill.</strong> When it's clear we can add value to the customer, you're comfortable guiding the deal to a close. </li>
-      <li><strong>Passionate about business.</strong> You love making a company grow, and delight in applying your scrappy techical skills and strategic acumen to make impact. </li>
-      <li><strong>Moral grounding.</strong> You feel comfortable saying no when necessary so that we can all sleep better at night. In general, you do the right thing, for yourself, for Gruntwork, and for customers. </li>
+      <li><strong>Sales skill.</strong> You can effectively qualify leads, understand customer needs, demo our product, and close the deal with a range of customers from startups to large enterprises. You're disciplined with follow-ups and know how to spend your time to make the most impact.</li>
+      <li><strong>Technical skill.</strong> You're tech-savvy, can build a full mental model of our product, and can learn to demo a core part of it on your own without the assistance of sales engineers. At the same time, you have prior experience working with sales engineers and know when to bring them in.</li>
+      <li><strong>Sales strategy.</strong> You have done sales for enough tech companies to understand what elements must be present to make a successful sale. You can map that experience to our sales process to lay the groundwork for sales scale.</li>
+      <li><strong>Sales leadership.</strong> You know how to recruit other sales people to build your sales team. Once on the team, you can coach and manage them effectively.</li>
+      <li><strong>Moral grounding.</strong> You feel comfortable saying no when necessary so that we can all sleep better at night. In general, you do the right thing for customers, for Gruntwork, and for yourself.</li>
     </ul>
     <h4>What time zones do we work in?</h4>
     <p>While Gruntwork <a href="/careers/#sane-working-hours">generally</a> hires anywhere between San Francisco and Berlin, candidates for this role must be within the GMT-7 to GMT-3 time zones, with a preference for being located in the USA or Canada. We expect you'll work primarily with customers and fellow Grunts in those time zones, with limited engagement with customers worldwide and Grunts in Europe. Working during reasonable hours is a priority for us.</p>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -209,7 +209,7 @@
     <h3 style="margin-top: 5px; margin-bottom: 5px;">Account Executive<br>Director of Sales</h3>
 
     <p>We're making for our first dedicated sales hire at Gruntwork. We've grown to millions of dollars in annual revenue with zero outside investment/debt, near-zero marketing budget, and a small number of software engineers who handle all sales calls in addition to their core work. Now we're ready to take our sales to the next level!</p>
-    <p>Our product is used and purchased by software and DevOps engineers, so we are looking for a sales professional with proven experience selling technical products together with sales engineers. As the first sales hire, you'll report directly to the founders and have considerable impact on the overall growth of the company. Your growth path in this role could be as either a star individual contributor or team lead (at Gruntwork, we value IC and management roles equally).</p>
+    <p>Our product is used and purchased by software and DevOps engineers, so we are looking for a sales professional with proven experience selling products that enable software engineers. As the first sales hire, you'll report directly to the founders and have considerable impact on the overall growth of the company. Your growth path in this role could be as either a star individual contributor or team lead (at Gruntwork, we value IC and management roles equally).</p>
     <p></p>
   
     <h4>What You'll Work On</h4>
@@ -222,8 +222,9 @@
     </ul>
     <h4>Your Ideal Background</h4>
     <ul>
-      <li><strong>Sales skill.</strong> You can effectively qualify leads, understand customer needs, demo our product, and close the deal with a range of customers from startups to large enterprises. You're disciplined with follow-ups and know how to spend your time to make the most impact.</li>
+      <li><strong>Experience in tech.</strong> You understand the cloud, are familiar with core elements of at least one major cloud provider, and have experience selling to software engineers. You don't have to be an engineer yourself, but ideally you have some kind of background in engineering or coding from earlier in your career.</li>
       <li><strong>Technical skill.</strong> You're tech-savvy, can build a full mental model of our product, and can learn to demo a core part of it on your own without the assistance of sales engineers. At the same time, you have prior experience working with sales engineers and know when to bring them in.</li>
+      <li><strong>Sales skill.</strong> You can effectively qualify leads, understand customer needs, demo our product, and close the deal with a range of customers from startups to large enterprises. You're disciplined with follow-ups and know how to spend your time to make the most impact.</li>
       <li><strong>Sales strategy.</strong> You have done sales for enough tech companies to understand what elements must be present to make a successful sale. You can map that experience to our sales process to lay the groundwork for sales scale.</li>
       <li><strong>Sales leadership.</strong> You know how to recruit other sales people to build your sales team. Once on the team, you can coach and manage them effectively.</li>
       <li><strong>Moral grounding.</strong> You feel comfortable saying no when necessary so that we can all sleep better at night. In general, you do the right thing for customers, for Gruntwork, and for yourself.</li>


### PR DESCRIPTION
Based on internal discussions, we're now focusing our sales recruiting on an account executive / director of sales, I've updated our [recruiting dimensions](https://www.notion.so/gruntwork/Dimensions-433fcd25a17045f5a4e669770c86087a) accordingly, and this job post reflects our latest understanding.

Note that I've also updated the [Workable job profile](https://apply.workable.com/gruntwork/j/52C1960D89/).