### PR TITLE
Update CIS guides - IAM password policy

### DIFF
--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -190,7 +190,7 @@ In the subsequent sections, we'll review the recommendations and discuss how to 
 [[configure_authentication]]
 ==== Configure authentication
 One of main areas of concern in the IAM section relates to authentication. The Benchmark has recommendations for IAM
-users and the root user account, password complexity, and multi-factor authentication. There is more than one way to
+users and the root user account, password policy, and multi-factor authentication. There is more than one way to
 authenticate to AWS, and the method you choose determines how to implement these recommendations in your code.
 
 ===== Federated authentication using SAML
@@ -393,7 +393,7 @@ them by other IAM policies.
 Attach a policy like this one to every group in your account.
 
 ==== Password policy
-The IAM password policy is perhaps the most straightforward and explicit set of recommendations (1.8-1.9) in the entire
+The IAM password policy is perhaps the most straightforward and explicit set of recommendations (1.8-1.9 and 1.12) in the entire
 Benchmark. You can invoke link:https://www.terraform.io/docs/providers/aws/r/iam_account_password_policy.html[the
 Terraform `aws_iam_account_password_policy` resource] to implement the recommended policy.
 
@@ -403,10 +403,6 @@ For example:
 ----
 resource "aws_iam_account_password_policy" "aws_foundations_benchmark_policy" {
   minimum_password_length        = 14
-  require_numbers                = true
-  require_symbols                = true
-  require_lowercase_characters   = true
-  require_uppercase_characters   = true
   allow_users_to_change_password = true
   hard_expiry                    = true
   max_password_age               = 90
@@ -908,7 +904,7 @@ variable "aws_region" {
 variable "minimum_password_length" {
   description = "Minimum length to require for user passwords."
   type        = number
-  default     = 20
+  default     = 14
 }
 ----
 

--- a/_posts/2021-01-06-how-to-update-to-cis-13.adoc
+++ b/_posts/2021-01-06-how-to-update-to-cis-13.adoc
@@ -151,7 +151,7 @@ compatible with CIS AWS v1.3.0:
 |1.20, 2.1.1, 2.1.2
 
 |terraform-aws-cis-service-catalog
-|https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.10.0[v0.10.0]
+|https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases/tag/v0.11.1[v0.11.1]
 |3.10, 3.11, 4.15, 5.1
 
 |terraform-aws-service-catalog

--- a/_posts/2021-01-06-how-to-update-to-cis-13.adoc
+++ b/_posts/2021-01-06-how-to-update-to-cis-13.adoc
@@ -70,6 +70,14 @@ between versions 1.2.0 and 1.3.0:
 - 4.15: Ensure a log metric filter and alarm exists for AWS Organizations changes
 - 5.1: Ensure no network ACLs allow ingress from 0.0.0.0/0 to remote server administration ports
 
+==== Deleted recommendations
+Version 1.3.0 removed some recommendations, but they only affect the IAM password policy:
+
+- 1.5: Ensure IAM password policy requires at least one uppercase letter
+- 1.6: Ensure IAM password policy require at least one lowercase letter 
+- 1.7: Ensure IAM password policy require at least one symbol
+- 1.8: Ensure IAM password policy require at least one number
+
 ==== New Gruntwork modules vs. existing modules
 To achieve compliance with the newly added 10 recommendations listed above, we created four new modules in the
 Gruntwork's Infrastructure as Code Library, and updated a bunch of existing modules. Namely: recommendations 1.19, 1.21,


### PR DESCRIPTION
CIS v1.3 has fewer password restrictions; the CIS Service Catalog is now updated with them: https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/pull/79

This PR updates the guides to mention this change.