### PR TITLE
[APT-324] Add dev portal sign in link to navbar and footer

### DIFF
--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -72,6 +72,9 @@
 
 - title: Connect
   links:
+    - title: Sign In
+      url: https://app.gruntwork.io
+
     - title: Blog
       url: "https://blog.gruntwork.io"
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -19,7 +19,7 @@
         >
       </div>
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-2">
-        <ul class="nav navbar-nav navbar-right">
+        <ul class="nav navbar-nav navbar-left">
           <li>
             <a
               href="/how-it-works/"
@@ -98,7 +98,7 @@
               </li>
             </ul>
           </li>
-          <li id="guides-nav-item">
+          <li>
             <a
               href="/guides/"
               ga-event-category="nav-{{ page.path | slugify }}"
@@ -106,6 +106,8 @@
               >Guides</a
             >
           </li>
+        </ul>
+        <ul class="nav navbar-nav navbar-right">
           <li>
             <a
               href="/pricing/"
@@ -121,11 +123,19 @@
           <li>
             <a
               href="/contact/"
-              class="contact-sales"
               ga-on="click"
               ga-event-category="nav-{{ page.path | slugify }}"
               ga-event-action="contact-sales"
               >Contact Sales</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://app.gruntwork.io"
+              ga-on="click"
+              ga-event-category="nav-{{ page.path | slugify }}"
+              ga-event-action="sign-in"
+              >Sign In</a
             >
           </li>
         </ul>

--- a/assets/css/global.less
+++ b/assets/css/global.less
@@ -459,16 +459,27 @@ a.caret-right{
   border: none;
 }
 
-.navbar > .container > .navbar-header .navbar-brand-beta {
+.navbar > .container {
   @media (min-width: @screen-md-min) {
-    margin-left: -1em;
+    width: 720px;
+    .navbar-header {
+      margin-right: 0;
+    }
   }
   @media (min-width: @screen-lg-min) {
-    margin-left: -1.5em;
+    width: 960px;
+    .navbar-header {
+      margin-right: 0;
+    }
   }
   @media (min-width: 1400px) {
-    margin-left: -4.5em;
+    width: 1280px;
+    .navbar-header {
+      margin-right: 3em;
+      transition: margin 0.2s ease-out;
+    }
   }
+  transition: width 0.2s ease-out;
 }
 
 .navbar-brand {
@@ -492,33 +503,14 @@ a.caret-right{
   padding: @padding-base-vertical @padding-base-horizontal;
   margin-top: ((@navbar-height - 42) / 2);
   margin-bottom: ((@navbar-height - 42) / 2);
-  margin-left: 20px;
+  margin: 20px;
   &:hover,
   &:focus {
     color: #fff;
   }
 }
 
-.navbar-nav > li > a.contact-sales {
-  @media (min-width: 1200px) {
-    margin-right: -5em;
-  }
-  @media (min-width: 1400px) {
-    margin-right: -9em;
-  }
-}
 
-#guides-nav-item {
-  @media (min-width: 992px) {
-    margin-right: 50px;
-  }
-  @media (min-width: 1200px) {
-    margin-right: 110px;
-  }
-  @media (min-width: 1400px) {
-    margin-right: 186px;
-  }
-}
 
 // Home page navbar styles
 .index-page .navbar-default,


### PR DESCRIPTION
This adds a sign in link to the nav bar and the connect section of
the footer, which lead to the Gruntwork Developer Portal.

The navbar was using a curious combination of negative margins on
specific list items in order to achieve its layout, which made it
challenging to add another item. This change refactors the layout
into right/left navbar sections which float accordingly, and a
container that adjusts for several screen sizes.