### PR TITLE
Fix /sha endpoint

### DIFF
--- a/pages/sha/index.html
+++ b/pages/sha/index.html
@@ -1,5 +1,6 @@
 ---
 layout: none
-permalink: /sha
+permalink: /sha/
 ---
+
 {{ site.github.build_revision }}


### PR DESCRIPTION
This PR hopes to fix the `/sha` endpoint. I suspect that the reason it's currently not working is that in production we won't serve files that aren't called `index.html`. If the trailing slash is missing from the `/sha` permalink definition then Jekyll will generate the file as `/sha.html`.