### PR TITLE
[APT-1178] vulnerability disclosure policy

### DIFF
--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -175,3 +175,10 @@
   category: terms-of-service
   link: https://github.com/gruntwork-io/gruntwork-io.github.io/commit/d750788700f3f6e27ac4afd7da0cefd837386b1a
   date: 2022-02-24
+
+- guid: 10021
+  title: Added Our Vulnerability Disclosure Policy
+  description: As a reflection of our ongoing commitment to security, and in the interest of full transparency, we’ve created a Vulnerability Disclosure Policy. This establishes a formal commitment to our customers, as well as procedures through which any security concerns may be reported to Gruntwork.
+  category: vulnerability-disclosure-policy
+  link: https://github.com/gruntwork-io/gruntwork-io.github.io/commit/2d765b5
+  date: 2022-05-02

--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -58,16 +58,10 @@
     - title: Careers
       url: /careers/
 
-    - title: Terms of Service
-      url: /terms/
+    - title: Security
+      url: /security/
 
-    - title: Privacy Policy
-      url: /legal/privacy-policy/
-
-    - title: Cookie Policy
-      url: /legal/cookie-policy/
-
-    - title: All Legal Docs
+    - title: Legal
       url: /legal
 
 - title: Connect

--- a/_layouts/policy.html
+++ b/_layouts/policy.html
@@ -1,0 +1,21 @@
+---
+layout: default
+---
+
+<div class="main">
+  <div class="section">
+    <div class="container">
+      <div class="row">
+        <div class="col-xs-12">
+          <h1>{{ page.title }}</h1>
+          <p><em>Last Updated: {{ page.modified_date }}</em></p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          {{content}}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/pages/feed/index.html
+++ b/pages/feed/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Legal Feed
-excerpt: Gruntwork Legal and Privacy Updates.
+title: Contract & Policy Changelog
+excerpt: A history of all updates to Gruntwork contracts and policies.
 permalink: /legal/feed/
 redirect_from: /feed/
 slug: feed
@@ -13,7 +13,6 @@ slug: feed
   </div>
   <div class="section section-dark">
     <div class="container">
-        <p><a href="/legal">Back to Legal</a></p>
         {% include_relative _changes.html %}
     </div>
   </div>

--- a/pages/security/_commitment.html
+++ b/pages/security/_commitment.html
@@ -1,0 +1,3 @@
+<h3>Our Commitment</h3>
+<p>At Gruntwork, we understand the critical importance of security, both with respect to our customers’ information, as well as the infrastrucuture our customers build using our IaC library. Gruntwork is firmly committed to ensuring the security of its customers and users by protecting their information.</p>
+<p>See below for a list of our security policies, or subscribe to our <a href="/legal/feed">RSS feed</a> or <a href="http://eepurl.com/cdOjYX" target="_blank">security mailing list</a> to stay up to date on policy changes and security news.</p>

--- a/pages/security/_hero.html
+++ b/pages/security/_hero.html
@@ -1,0 +1,15 @@
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12">
+      <h1>{{ page.title }}</h1>
+      <p class="lead">
+        {{ page.excerpt }}
+      </p>
+      <p>
+        <a class="btn btn-primary-hollow btn-sm d-inline-block" href="mailto:security@gruntwork.io"
+          >Report a Security Concern</a
+        >
+      </p>
+    </div>
+  </div>
+</div>

--- a/pages/security/_policies.html
+++ b/pages/security/_policies.html
@@ -1,0 +1,16 @@
+<div class="row row-page-header">
+  <div class="col-xs-12">
+    <h3>Security Policies</h3>
+    <ul style="margin-left: -20px;">
+      <li>
+        <a href="/security/vulnerability-disclosure-policy">Vulnerability Disclosure Policy</a>
+      </li>
+    </ul>
+    <h3>Security Updates</h3>
+    <ul>
+      <li><strong>Subscribe to our security mailing list.</strong> All Gruntwork subscribers receive notifications related to security releases, vulnerabilities, disclosures, and related security news via our mailing list. <a href="http://eepurl.com/cdOjYX" target="_blank">Subscribe to our security mailing list</a> to receive these updates.</li>
+      <li><strong>Get policy updates programmatically.</strong> Subscribe to our <a href="/legal.rss">policy RSS feed</a> to be notified when we release updates to our security policies. Note that you may need to cut and paste the RSS URL into your favorite RSS Feed Reader to monitor updates.<br/></li>
+      <li><strong>View recent policy updates.</strong> <a href="/legal/feed">View changes to our legal and security policies.</a> This is a human-friendly rendering of our RSS feed.</li>
+    </ul>
+  </div>
+</div>

--- a/pages/security/_report-a-vulnerability.html
+++ b/pages/security/_report-a-vulnerability.html
@@ -1,0 +1,6 @@
+<h3>Report a Vulnerability</h3>
+<p>We accept vulnerability reports via <a href="mailto:security@gruntwork.io">security@gruntwork.io</a>. Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.</p>
+
+<p>We do not support PGP-encrypted emails. For particularly sensitive information, please reach out to <a href="support@gruntwork.io">support@gruntwork.io</a> to discuss before sending over.</p>
+
+<p>For more information, please see our <a href="/security/vulnerability-disclosure-policy/">Vulnerability Disclosure Policy.</p>

--- a/pages/security/index.html
+++ b/pages/security/index.html
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Security
+excerpt: Understand our ongoing commitment to security.
+permalink: /security/
+slug: security
+footer_heading: Talk with our team of DevOps experts now!
+---
+
+<div class="main page-support">
+  <div class="section section-hero section-hero-with-button">
+    {% include_relative _hero.html %}
+  </div>
+  <div class="section section-dark">
+    <div class="container">
+      {% include_relative _commitment.html %}
+    </div>
+    <div class="container">
+      {% include_relative _policies.html %}
+    </div>
+    <div class="container">
+      {% include_relative _report-a-vulnerability.html %}
+    </div>
+  </div>
+</div>

--- a/pages/vulnerability-disclosure-policy/index.md
+++ b/pages/vulnerability-disclosure-policy/index.md
@@ -1,0 +1,82 @@
+---
+layout: policy
+title: Vulnerability Disclosure Policy
+modified_date: May 2, 2022
+permalink: /security/vulnerability-disclosure-policy/
+redirect_from: /vulnerability-disclosure-policy/
+slug: vulnerability-disclosure-policy-2
+---
+
+## Introduction
+
+Gruntwork is committed to recognizing and encouraging responsible disclosure of security vulnerabilities. This policy is intended to give security researchers, external to Gruntwork, clear guidelines for conducting security research and to convey our preferences in how to submit discovered vulnerabilities to us.
+
+Among other things, this policy describes **what systems and types of research** are covered under this policy, **how to send us** vulnerability reports, and **how long** we ask security researchers to wait before publicly disclosing vulnerabilities.
+
+We encourage you to contact us via email at [security@gruntwork.io](mailto:security@gruntwork.io) to report potential vulnerabilities in our systems.
+
+## Authorization
+
+If you make a good faith effort to comply with this policy during your security research, we will consider your research to be "authorized" under the Computer Fraud and Abuse Act, the Digital Millennium Copyright Act, and any applicable anti-hacking laws such as Cal. Penal Code 502(c) and Gruntwork will not recommend or pursue legal action related to your research. Should legal action be initiated by a third party against you for activities that were conducted in accordance with this policy, we will make this authorization known.
+
+Please note however that if your security research involves the products, services, or systems of a third party, that third party is not bound by our commitment not to pursue legal action. You should review the disclosure policies of any relevant third parties before beginning your research.
+
+## Guidelines
+
+Under this policy, “research” means activities in which you do the following:
+
+- Notify us as soon as possible after you discover a real or potential security issue.
+- Make every effort to avoid privacy violations, degradation of user experience, disruption to production systems, and destruction or manipulation of data;
+- Only use exploits to the extent necessary to confirm a vulnerability’s presence and do not use an exploit to compromise or exfiltrate data, establish persistent command line access, or use the exploit to pivot to other systems;
+- Provide us a reasonable amount of time to resolve the issue before you disclose it publicly; and
+- Do not submit a high volume of low-quality reports.
+
+Once you’ve established that a vulnerability exists or encounter any sensitive data (including personally identifiable information, financial information, or proprietary information or trade secrets of any party), **you must stop your test, notify us immediately at [security@gruntwork.io](mailto:security@gruntwork.io), and not disclose this data to anyone else**.
+
+## Test methods
+
+The following test methods are not authorized:
+
+- Network denial of service (DoS or DDoS) tests or other tests that impair access to or damage a system or data; and
+- Physical testing (e.g. office access, open doors, tailgating), social engineering attacks against Gruntwork employees (e.g., phishing, vishing), or any other non-technical vulnerability testing.
+
+## Scope
+
+This policy applies to the following systems and services:
+
+- Source code at [https://github.com/gruntwork-io](https://github.com/gruntwork-io)
+- [Gruntwork.io](http://gruntwork.io) website
+- Gruntwork portal ([app.gruntwork.io](https://app.gruntwork.io))
+
+**Any service not expressly listed above, such as any connected services, are excluded from scope** and are not authorized for testing. Additionally, vulnerabilities found in systems from our vendors fall outside of this policy’s scope and should be reported directly to the vendor according to their disclosure policy (if any). If you aren’t sure whether a system is in scope or not, contact us at [security@gruntwork.io](mailto:security@gruntwork.io) before starting your research.
+
+Though we develop and maintain other internet-accessible systems or services, we ask that *active research and testing* only be conducted on the systems and services covered by the scope of this document. If there is a particular system not in scope that you think merits testing, please contact us to discuss it first. We may increase the scope of this policy over time.
+
+## Reporting a vulnerability
+
+**We accept vulnerability reports via [security@gruntwork.io](mailto:security@gruntwork.io)**. Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+
+We do not support PGP-encrypted emails. For particularly sensitive information, please reach out to [support@gruntwork.io](mailto:support@gruntwork.io) to discuss before sending over.
+
+NOTE: *Currently, Gruntwork does not have an official bug bounty program, however we are grateful for efforts to help make our products more secure. Therefore, if you make a security disclosure, we may pay up to $500 cash, depending on the impact of the vulnerability. Please note that by submitting a vulnerability, you acknowledge that payment is completely at the discretion of Gruntwork.*
+
+## What we would like to see from you
+
+In order to help us triage and prioritize submissions, we recommend that your report include the following:
+
+- A description of the location the vulnerability was discovered and the potential impact of exploitation, and
+- A detailed description of the steps needed to reproduce the vulnerability (proof of concept scripts or screenshots are helpful).
+
+If possible, we prefer that reports are submitted in English.
+
+## What you can expect from us
+
+We appreciate the contributions of security researchers and commit to the following:
+
+- If you share contact information, we will acknowledge receipt of your report within 3 business days.
+- We will notify you when the reported vulnerability is remediated, and you may be invited to confirm that the solution adequately addresses the vulnerability.
+- We may, in our sole discretion, offer to recognize your contribution by providing a reward or public acknowledgement of your efforts.
+
+## Questions
+
+Questions regarding this policy may be sent to [security@gruntwork.io](mailto:security@gruntwork.io). We also invite you to contact us with suggestions for improving this policy.


### PR DESCRIPTION
This adds our Vulnerability Disclosure Policy linked under a new Security page. This will require a follow-up commit to call out this new policy in our legal feed, and I understand we're also waiting for final sign of from legal, but I'd like feedback on the content and presentation in advance.

@tsmit291 Can you give this a glance for content?