### PR TITLE
Update LZ Production Guide.

### DIFF
--- a/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
+++ b/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
@@ -889,6 +889,15 @@ Terraform::
   Comprehensive Guide to Terraform], https://training.gruntwork.io/p/terraform[A Crash Course on Terraform], and
   link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library[How to use the Gruntwork Infrastructure as Code Library].
 
+Terragrunt::
+  This guide uses https://terragrunt.gruntwork.io/[Terragrunt] to configure the infrastructure as code. To get familiar
+  with Terragrunt, explore the https://terragrunt.gruntwork.io/docs/#features[features], read the https://terragrunt.gruntwork.io/docs/getting-started/quick-start/[guides],
+  or dive into the https://terragrunt.gruntwork.io/docs/[documentation].
+
+Code repository::
+  You will need to initialize an `infrastructure-live` repository to contain all of the Terragrunt configuration code for your
+  infrastructure. You may use the https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.41.4/examples/for-production/infrastructure-live[`for-production` example code] to start with.
+
 Keybase (optional)::
   As part of this guide, you will create IAM users, including, optionally, credentials for those IAM users. If you
   choose to create credentials, those credentials will be encrypted with a PGP key. You could provide the PGP keys
@@ -896,9 +905,181 @@ Keybase (optional)::
   create PGP keys for themselves, and then you can provide their Keybase usernames, and the PGP keys will be retrieved
   automatically.
 
+
+=== Prepare your `infrastructure-live` repository
+
+[NOTE]
+.Terragrunt not required
+====
+This guide uses https://github.com/gruntwork-io/terragrunt[Terragrunt] and its associated file and folder
+structure to deploy Terraform modules. Please note that *Terragrunt is NOT required for using Terraform modules from
+the Gruntwork Infrastructure as Code Library.* Check out link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library[How to use the Gruntwork Infrastructure as Code Library]
+for instructions on alternative options, such as
+link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library#deploy_using_plain_terraform[deploying with plain Terraform].
+====
+
+Now we're going to make some HCL files that store variables to be used across your modules. _You won't be able to fill
+everything out just yet._ Your AWS account IDs will be generated after applying the account-baseline-root to the root
+account. At that point you can update these files. Create them now to have them ready to use.
+
+----
+infrastructure-live
+  └ terragrunt.hcl
+  └ landingzone
+    └ account-baseline-root
+    └ account-baseline-app
+      └ main.tf
+      └ outputs.tf
+      └ variables.tf
+----
+
+The Terraform modules in the Service Catalog are missing some required blocks for Terraform to operate (e.g., the
+`provider` and `terraform` state backend blocks). This is by design, to allow the modules to be flexibly used in
+different contexts. We'll define a root `terragrunt.hcl` that injects these these required blocks.
+
+Create a `terragrunt.hcl` at the root of your infrastructure-live repo and insert the following contents. As you can
+see, it references `common`, `account`, and `region` hcl files which we'll create shortly.
+
+.infrastructure-live/terragrunt.hcl
+[source,hcl]
+----
+# -----------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# -----------------------------------------------------------------------------
+
+locals {
+  common_vars  = read_terragrunt_config("${get_terragrunt_dir()}/common.hcl")
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  name_prefix    = local.common_vars.locals.name_prefix
+  account_name   = local.account_vars.locals.account_name
+  account_id     = local.account_vars.locals.account_id
+  default_region = local.common_vars.locals.default_region
+  aws_region     = local.region_vars["aws_region"]
+}
+
+# -----------------------------------------------------------------------------
+# GENERATED PROVIDER BLOCK
+# -----------------------------------------------------------------------------
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region = "${local.aws_region}"
+  version = ">= 3.13.0"
+  # Only these AWS Account IDs may be operated on by this template
+  allowed_account_ids = ["${local.account_id}"]
+}
+EOF
+}
+
+# -----------------------------------------------------------------------------
+# GENERATED REMOTE STATE BLOCK
+# -----------------------------------------------------------------------------
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    encrypt        = true
+    bucket         = "${local.name_prefix}-${local.account_name}-${local.aws_region}-terraform-state"
+    key            = "${path_relative_to_include()}/terraform.tfstate"
+    region         = local.default_region
+    dynamodb_table = "terraform-locks"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# GLOBAL PARAMETERS
+# -----------------------------------------------------------------------------
+
+inputs = {
+  # Set commonly used inputs globally to keep child terragrunt.hcl files DRY
+  aws_account_id = local.account_id
+  aws_region     = local.aws_region
+  name_prefix    = local.name_prefix
+}
+----
+
+Also create a `common.hcl` file at the root of your `infrastructure-live` repo, with the following contents.
+
+.infrastructure-live/common.hcl
+[source,hcl]
+----
+locals {
+  # TODO: Enter a unique name prefix to set for all resources created in your accounts, e.g., your org name.
+  name_prefix = ""
+  # TODO: Enter the default AWS region, the same as where the terraform state S3 bucket is currently provisioned.
+  default_region = ""
+
+  # TODO: An accounts map to conveniently store all account IDs.
+  # Centrally define all the AWS account IDs. We use JSON so that it can be readily parsed outside of Terraform.
+  accounts = jsondecode(file("accounts.json"))
+}
+----
+
+This file references an `accounts.json`, which you should also create at the root of the repo. _You will fill out
+the account IDs after applying the account-baseline-root to the root account._
+
+.infrastructure-live/accounts.json
+[source,json]
+----
+{
+  "dev": "",
+  "logs": "",
+  "prod": "",
+  "security": "",
+  "shared": "",
+  "stage": ""
+}
+----
+
+In each account folder (e.g., `infrastructure-live/dev`, `infrastructure-live/shared`, etc.), add a file named
+`account.hcl` with the following contents. _Leave `account_id` blank until after the `account-baseline-root` has been
+applied to the root account._
+
+[source,hcl]
+----
+locals {
+  # TODO: Update with the actual information of each account
+  # The user friendly name of the AWS account. Usually matches the folder name.
+  account_name = ""
+  # The 12 digit ID number of your AWS account.
+  account_id = ""
+}
+----
+
+Now in each `infrastructure-live/<account_name>/_global/` folder, create a `region.hcl` file.
+
+[source,hcl]
+----
+# Modules in the account _global folder don't live in any specific AWS region, but you still have to send the API calls
+# to _some_ AWS region, so here we use the default region for those API calls.
+locals {
+  aws_region = read_terragrunt_config(find_in_parent_folders("common.hcl")).locals.default_region
+}
+----
+
+Do the same in each region folder (e.g., `infrastructure-live/dev/us-east-1/`). This `region.hcl` file is a bit different.
+
+[source,hcl]
+----
+locals {
+# TODO: Enter the region to use for all resources in this subfolder.
+  aws_region = ""
+}
+----
+
+
 === Create the root account
 
-The first step is to create your root account. This account will be the parent of all of your other AWS accounts and
+Now let's create your root AWS account. This account will be the parent of all of your other AWS accounts and
 the central place where you manage billing. You create this initial account manually, via a web browser:
 
 . Go to https://aws.amazon.com.
@@ -987,360 +1168,14 @@ Enable MFA::
 
 Next, we'll configure a security baseline for the root account that is responsible for creating all the child accounts.
 It will also configure AWS Organizations, IAM Roles, IAM Users, IAM Groups, IAM Password Policies, Amazon GuardDuty,
-AWS CloudTrail and AWS Config.
+AWS CloudTrail, and AWS Config.
 
 We'll be using the `account-baseline-root` module from https://github.com/gruntwork-io/terraform-aws-service-catalog[terraform-aws-service-catalog].
 
 [.exceptional]
 IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork subscriber# to access `terraform-aws-service-catalog`.
 
-First, create a _wrapper module_ called `account-baseline-root` in your `infrastructure-modules` repo under the `landingzone` subdirectory:
-
-----
-infrastructure-modules
-  └ landingzone
-    └ account-baseline-root
-      └ main.tf
-      └ outputs.tf
-      └ variables.tf
-----
-
-Inside of `main.tf`, configure your AWS provider and Terraform settings:
-
-.infrastructure-modules/landingzone/account-baseline-root/main.tf
-[source,hcl]
-----
-provider "aws" {
-  # The AWS region in which all resources will be created
-  region = var.aws_region
-
-  # Require a 3.x version of the AWS provider
-  version = "~> 3.23"
-
-  # Only these AWS Account IDs may be operated on by this template
-  allowed_account_ids = [var.aws_account_id]
-}
-
-terraform {
-  # The configuration for this backend will be filled in by Terragrunt or via a backend.hcl file. See
-  # https://www.terraform.io/docs/backends/config.html#partial-configuration
-  backend "s3" {}
-
-  # Only allow this Terraform version. Note that if you upgrade to a newer version, Terraform won't allow you to use an
-  # older version, so when you upgrade, you should upgrade everyone on your team and your CI servers all at once.
-  required_version = "= 0.12.29"
-}
-----
-
-Next, use the `account-baseline-root` module from the Gruntwork Infrastructure as Code Library:
-
-.infrastructure-modules/landingzone/account-baseline-root/main.tf
-[source,hcl]
-----
-module "root_baseline" {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/landingzone/account-baseline-root?ref=v0.39.0"
-
-  aws_account_id = var.aws_account_id
-  aws_region     = var.aws_region
-  name_prefix    = var.name_prefix
-
-  # If you're running the example against an account that doesn't have AWS Organization created, change the following value to true
-  create_organization = var.create_organization
-
-  # The child accounts to create
-  child_accounts = var.child_accounts
-
-  # IAM users to create in this account
-  users = var.users
-}
-----
-
-Create all the corresponding input variables for `account-baseline-root` in `variables.tf`:
-
-.infrastructure-modules/landingzone/account-baseline-root/variables.tf
-[source,hcl]
-----
-# ---------------------------------------------------------------------------------------------------------------------
-# MODULE PARAMETERS
-# These variables are expected to be passed in by the operator
-# ---------------------------------------------------------------------------------------------------------------------
-
-variable "name_prefix" {
-  description = "The name used to prefix AWS Config and Cloudtrail resources, including the S3 bucket names and SNS topics used for each."
-  type        = string
-}
-
-variable "aws_region" {
-  description = "The AWS Region to use as the global config recorder and seed region for AWS GuardDuty."
-  type        = string
-}
-
-variable "aws_account_id" {
-  description = "The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables."
-  type        = string
-}
-
-variable "child_accounts" {
-  description = "Map of child accounts to create. The map key is the name of the account and the value is an object containing account configuration variables. See the comments below for what keys and values this object should contain."
-
-  # Ideally, this would be a map of (string, object), but object does not support optional properties, and we want
-  # users to be able to specify, say, tags for some accounts, but not for others. We can't use a map(any) either, as that
-  # would require the values to all have the same type, and due to optional parameters, that wouldn't work either. So,
-  # we have to lamely fall back to any.
-  type = any
-
-  # Expected value for the `child_accounts` is a map of child accounts. The map key is the name of the account and
-  # the value is another map with one required key (email) and several optional keys:
-  #
-  # - email (required):
-  #   Email address for the account.
-  #
-  # - is_logs_account:
-  #   Set to `true` to mark this account as the "logs" account, which is the one to use to aggregate AWS Config and
-  #   CloudTrail data. This module will create an S3 bucket for AWS Config and an S3 bucket and KMS CMK for CloudTrail
-  #   in this child account, configure the root account to send all its AWS Config and CloudTrail data there, and return
-  #   the names of the buckets and ARN of the KMS CMK as output variables. When you apply account baselines to the
-  #   other child accounts (e.g., using the account-baseline-app or account-baseline-security modules), you'll want to
-  #   configure those accounts to send AWS Config and CloudTrail data to the same S3 buckets and use the same KMS CMK.
-  #   If is_logs_account is not set on any child account (not recommended!), then either you must disable AWS Config
-  #   and CloudTrail (via the enable_config and enable_cloudtrail variables) or configure this module to use S3 buckets
-  #   and a KMS CMK that ALREADY exist!
-  #
-  # - parent_id:
-  #   Parent Organizational Unit ID or Root ID for the account
-  #   Defaults to the Organization default Root ID.
-  #
-  # - role_name:
-  #   The name of an IAM role that Organizations automatically preconfigures in the new member account. This role trusts
-  #   the master account, allowing users in the master account to assume the role, as permitted by the master account
-  #   administrator. The role has administrator permissions in the new member account. Note that the Organizations API
-  #   provides no method for reading this information after account creation.
-  #   If no value is present and no ´default_role_name´ is provided, AWS automatically assigns a value.
-  #
-  # - iam_user_access_to_billing:
-  #   If set to ´ALLOW´, the new account enables IAM users to access account billing information if they have the required
-  #   permissions. If set to ´DENY´, then only the root user of the new account can access account billing information.
-  #   Defaults to ´default_iam_user_access_to_billing´.
-  #
-  #
-  # - enable_config_rules:
-  #   Set to `true` to enable org-level AWS Config Rules for this child account. This is only used if
-  #   var.config_create_account_rules is false (which is NOT recommened) to force org-level rules. If you do go with
-  #   org-level rules, you can only set enable_config_rules to true after deploying a Config Recorder in the child
-  #   account. That means you have to: (1) initially set enable_config_rules to false, (2) run 'apply' in this root
-  #   module to create the child account, (3) go to the child account and create a config recorder in it, e.g., by
-  #   running 'apply' on a security baseline in that account, (4) come back to this root module and set
-  #   enable_config_rules to true, (5) run 'apply' again. This is a brittle, error-prone, multi-step process, which is
-  #   why we recommend using account-level rules (the default) and avoiding it entirely!
-  #
-  # - tags:
-  #   Key-value mapping of resource tags.
-  #
-  #
-  # Example:
-  #
-  # child_accounts = {
-  #   logs = {
-  #     email                       = "root-accounts+logs@acme.com"
-  #     is_logs_account             = true
-  #   }
-  #   security = {
-  #     email                       = "root-accounts+security@acme.com"
-  #     role_name                   = "OrganizationAccountAccessRole"
-  #     iam_user_access_to_billing  = "DENY"
-  #     tags = {
-  #       Tag-Key = "tag-value"
-  #     }
-  #   }
-  #   shared-services = {
-  #     email                       = "root-accounts+shared-services@acme.com"
-  #   }
-  #   dev = {
-  #     email                       = "root-accounts+dev@acme.com"
-  #   }
-  #   stage = {
-  #     email                       = "root-accounts+stage@acme.com"
-  #   }
-  #   prod = {
-  #     email                       = "root-accounts+prod@acme.com"
-  #   }
-  # }
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# OPTIONAL MODULE PARAMETERS
-# These variables have defaults, but may be overridden by the operator.
-# ---------------------------------------------------------------------------------------------------------------------
-
-variable "create_organization" {
-  description = "Set to true to create/configure AWS Organizations for the first time in this account. If you already configured AWS Organizations in your account, set this to false; alternatively, you could set it to true and run 'terraform import' to import you existing Organization."
-  type        = bool
-  default     = false
-}
-
-variable "users" {
-  description = "A map of users to create. The keys are the user names and the values are an object with the optional keys 'groups' (a list of IAM groups to add the user to), 'tags' (a map of tags to apply to the user), 'pgp_key' (either a base-64 encoded PGP public key, or a keybase username in the form keybase:username, used to encrypt the user's credentials; required if create_login_profile or create_access_keys is true), 'create_login_profile' (if set to true, create a password to login to the AWS Web Console), 'create_access_keys' (if set to true, create access keys for the user), 'path' (the path), and 'permissions_boundary' (the ARN of the policy that is used to set the permissions boundary for the user)."
-
-  # Ideally, this would be a map of (string, object), but object does not support optional properties, and we want
-  # users to be able to specify, say, tags for some users, but not for others. We can't use a map(any) either, as that
-  # would require the values to all have the same type, and due to optional parameters, that wouldn't work either. So,
-  # we have to lamely fall back to any.
-  type = any
-
-  # Example:
-  # default = {
-  #   alice = {
-  #     groups = ["user-self-mgmt", "developers", "ssh-sudo-users"]
-  #   }
-  #
-  #   bob = {
-  #     path   = "/"
-  #     groups = ["user-self-mgmt", "ops", "admins"]
-  #     tags   = {
-  #       foo = "bar"
-  #     }
-  #   }
-  #
-  #   carol = {
-  #     groups               = ["user-self-mgmt", "developers", "ssh-users"]
-  #     pgp_key              = "keybase:carol_on_keybase"
-  #     create_login_profile = true
-  #     create_access_keys   = true
-  #   }
-  # }
-
-  default = {}
-}
-----
-
-Finally, add some useful outputs in `outputs.tf`:
-
-.infrastructure-modules/landingzone/account-baseline-root/outputs.tf
-[source,hcl]
-----
-# ---------------------------------------------------------------------------------------------------------------------
-# CONFIG OUTPUTS
-# ---------------------------------------------------------------------------------------------------------------------
-
-output "config_s3_bucket_name" {
-  description = "The name of the S3 bucket used by AWS Config to store configuration items."
-  value       = module.root_baseline.config_s3_bucket_name
-}
-
-output "config_s3_bucket_arn" {
-  description = "The ARN of the S3 bucket used by AWS Config to store configuration items."
-  value       = module.root_baseline.config_s3_bucket_arn
-}
-
-output "config_iam_role_arns" {
-  description = "The ARNs of the IAM role used by the config recorder."
-  value       = module.root_baseline.config_iam_role_arns
-}
-
-output "config_sns_topic_arns" {
-  description = "The ARNs of the SNS Topic used by the config notifications."
-  value       = module.root_baseline.config_sns_topic_arns
-}
-
-output "config_recorder_names" {
-  description = "The names of the configuration recorder."
-  value       = module.root_baseline.config_recorder_names
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# ORGANIZATIONS OUTPUTS
-# ---------------------------------------------------------------------------------------------------------------------
-
-output "organization_arn" {
-  description = "ARN of the organization."
-  value       = module.root_baseline.organization_arn
-}
-
-output "organization_id" {
-  description = "Identifier of the organization."
-  value       = module.root_baseline.organization_id
-}
-
-output "master_account_arn" {
-  description = "ARN of the master account."
-  value       = module.root_baseline.master_account_arn
-}
-
-output "master_account_id" {
-  description = "Identifier of the master account."
-  value       = module.root_baseline.master_account_id
-}
-
-output "master_account_email" {
-  description = "Email address of the master account."
-  value       = module.root_baseline.master_account_email
-}
-
-output "child_accounts" {
-  description = "A map of all accounts created by this module (NOT including the root account). The keys are the names of the accounts and the values are the attributes for the account as defined in the aws_organizations_account resource."
-  value       = module.root_baseline.child_accounts
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# CLOUDTRAIL OUTPUTS
-# ---------------------------------------------------------------------------------------------------------------------
-
-output "cloudtrail_trail_arn" {
-  description = "The ARN of the cloudtrail trail."
-  value       = module.root_baseline.cloudtrail_trail_arn
-}
-
-output "cloudtrail_s3_bucket_name" {
-  description = "The name of the S3 bucket where cloudtrail logs are delivered."
-  value       = module.root_baseline.cloudtrail_s3_bucket_name
-}
-
-output "cloudtrail_s3_bucket_arn" {
-  description = "The ARN of the S3 bucket where cloudtrail logs are delivered."
-  value       = module.root_baseline.cloudtrail_s3_bucket_arn
-}
-
-output "cloudtrail_kms_key_arn" {
-  description = "The ARN of the KMS key used by the S3 bucket to encrypt cloudtrail logs."
-  value       = module.root_baseline.cloudtrail_kms_key_arn
-}
-
-output "cloudtrail_kms_key_alias_name" {
-  description = "The alias of the KMS key used by the S3 bucket to encrypt cloudtrail logs."
-  value       = module.root_baseline.cloudtrail_kms_key_alias_name
-}
-
-output "cloudtrail_iam_role_name" {
-  description = "The name of the IAM role used by the cloudwatch log group."
-  value       = module.root_baseline.cloudtrail_iam_role_name
-}
-
-output "cloudtrail_iam_role_arn" {
-  description = "The ARN of the IAM role used by the cloudwatch log group."
-  value       = module.root_baseline.cloudtrail_iam_role_arn
-}
-----
-
-At this point, you'll want to test your code. See
-link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library#manual_tests_terraform[Manual tests for Terraform code] and
-link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library#automated_tests_terraform[Automated tests for Terraform code]
-for instructions.
-
-Once your code is tested and working, commit and release your changes:
-
-[source,bash]
-----
-git add landingzone/account-baseline-root
-git commit -m "Add root account baseline wrapper module"
-git tag -a "v0.3.0" -m "Created root account baseline module"
-git push --follow-tags
-----
-
-NOTE: This guide will use https://github.com/gruntwork-io/terragrunt[Terragrunt] and its associated file and folder
-structure to deploy Terraform modules. Please note that *Terragrunt is NOT required for using Terraform modules from
-the Gruntwork Infrastructure as Code Library.* Check out link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library[How to use the Gruntwork Infrastructure as Code Library]
-for instructions on alternative options, such as how to
-link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library#deploy_using_plain_terraform[deploying how to use plain terraform].
+==== Set up the inputs for `account-baseline` for the root account
 
 Next, create a `terragrunt.hcl` file in `infrastructure-live`. It should go under the file path `root/_global/account-baseline`:
 
@@ -1352,14 +1187,13 @@ infrastructure-live
         └ terragrunt.hcl
 ----
 
-Point the `source` URL in your `terragrunt.hcl` file to your `account-baseline` wrapper module in the `infrastructure-modules`
-repo, setting the `ref` param to the version you released earlier:
+Define the `terraform` block with the source pointing to the https://github.com/gruntwork-io/terraform-aws-service-catalog[terraform-aws-service-catalog account-baseline-root] module.
 
 .infrastructure-live/root/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
 terraform {
-  source = "git::git@github.com/<YOUR_ORG>/infrastructure-modules.git//landingzone/account-baseline-root?ref=v0.3.0"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/account-baseline-root?ref=v0.41.4"
 
   # This module deploys some resources (e.g., AWS Config) across all AWS regions, each of which needs its own provider,
   # which in Terraform means a separate process. To avoid all these processes thrashing the CPU, which leads to network
@@ -1371,22 +1205,16 @@ terraform {
 }
 ----
 
-[.exceptional]
-IMPORTANT: We **strongly** recommend setting Terraform parallelism to a low value (e.g., `-parallelism=2`), as shown above, with the `account-baseline-xxx` modules. This is because these modules deploy multi-region resources (e.g., GuardDuty, AWS Config, etc), and for each region, Terraform spins up a separate process, so if you don't limit the parallelism, it may peg all your CPU cores and lead to network connectivity errors.
 
-Set the variables for the `account-baseline-root` module in this environment in the `inputs = { ... }` block of `terragrunt.hcl`:
+[.exceptional]
+IMPORTANT: We **strongly** recommend setting Terraform parallelism to a low value (i.e., `-parallelism=2`), as shown above, with the `account-baseline-xxx` modules. This is because these modules deploy multi-region resources (e.g., GuardDuty, AWS Config, etc), and for each region, Terraform spins up a separate process, so if you don't limit the parallelism, it may peg all your CPU cores and lead to network connectivity errors.
+
+Set the variables for the `account-baseline-root` module in this environment in the `inputs = { ... }` block.
 
 .infrastructure-live/root/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
 inputs = {
-  # Fill in your region you want to use (only used for API calls) and the ID of your root AWS account
-  aws_region     = "us-east-2"
-  aws_account_id = "<ROOT_ACCOUNT_ID>"
-
-  # Prefix all resources with this name
-  name_prefix = "<COMPANY_NAME>-root"
-
   # If you've already created an AWS Organization in your root account, you'll be able to import it later in this guide
   create_organization = true
 
@@ -1401,8 +1229,8 @@ inputs = {
     security = {
       email = "root-accounts+security@acme.com"
     },
-    shared-services = {
-      email = "root-accounts+shared-services@acme.com"
+    shared = {
+      email = "root-accounts+shared@acme.com"
     },
     dev = {
       email = "root-accounts+dev@acme.com"
@@ -1460,7 +1288,7 @@ The example code above does the following:
 . **Create IAM groups**. By default, `account-baseline-root` will create a `full-access` IAM group (for admins) and a
   `billing` IAM group (for the finance team).
 
-. **Create IAM users**. For this example, we create `alice` and `bob`, and carol, adding `alice` to the `full-access`
+. **Create IAM users**. For this example, we create `alice` and `bob`, and `carol`, adding `alice` to the `full-access`
   IAM group and `carol` to the `billing` IAM group. _Note_: your own IAM user (the one you created manually) should be
   in the `users` list; we'll use the `import` command to put this user under Terraform management shortly.
 
@@ -1468,7 +1296,7 @@ The example code above does the following:
   back to how to handle the passwords shortly).
 
 Pull in the https://www.terraform.io/docs/backends/[backend] settings from a root `terragrunt.hcl` file that you
-`include` in each child `terragrunt.hcl`:
+`include` in each child `terragrunt.hcl`. The file you created earlier in `infrastructure-live/terragrunt.hcl` will be pulled.
 
 .infrastructure-live/root/_global/account-baseline/terragrunt.hcl
 [source,hcl]
@@ -1510,14 +1338,14 @@ You should get JSON output with information about your IAM user:
 }
 ----
 
-You're now almost ready to deploy the `account-baseline` module in the root account. But first, you may need to import
-some existing resources.
+You're now almost ready to deploy the `account-baseline` module in the root account. But first, let's import the IAM user
+and any other existing resources.
 
 
-=== Import existing resources from the root account
+=== Import existing resources from the root account into Terraform state
 
-Before applying the security baseline to the root account, we need to import any existing resources—including the IAM
-user you created manually earlier—into Terraform state, so that Terraform manages those existing resources instead of
+Before applying the `account-baseline-root` module to the root account, we need to import existing resources—including
+the IAM user you created manually earlier—into Terraform state, so that Terraform manages those resources instead of
 trying to create totally new ones. You can do this using the
 https://www.terraform.io/docs/import/index.html[`import` command], which uses the format:
 
@@ -1530,7 +1358,7 @@ Where `<ADDRESS>` is the https://www.terraform.io/docs/internals/resource-addres
 resource you're importing and `<ID>` is a resource-specific identifier (e.g., for `aws_instance`, it's the instance ID,
 whereas for `aws_lb`, it's the load balancer's name—check the docs for the resource to find out what to use).
 
-As a first example, let's import the IAM user you created manually in the root account. IAM users are managed using the
+Let's import the IAM user you created manually in the root account. IAM users are managed using the
 `aws_iam_user` resource, and the
 https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user#import[documentation for that
 resource] tells us to use the user's `name` as the `<ID>`; we'll assume for this example that your IAM user's name was
@@ -1685,14 +1513,14 @@ aws-vault exec root-iam-user -- terragrunt apply
 ----
 
 [.exceptional]
-IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 1024`.
+IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 10240`.
 
 Once `apply` completes, you should see output variables with all of your account IDs, the name of the AWS Config S3
 bucket, the name of the CloudTrail S3 bucket, and the ARN of the CloudTrail KMS key:
 
 [source,hcl]
 ----
-# (this output has been edited to be easier to read)
+# (This output has been truncated to be easier to read)
 child_accounts = {
   "dev" = {
     "email" = "root-accounts+dev@acme.com"
@@ -1714,8 +1542,8 @@ child_accounts = {
     "id" = "<SECURITY_ACCOUNT_ID>"
     # (...)
   }
-  "shared-services" = {
-    "email" = "root-accounts+shared-services@acme.com"
+  "shared" = {
+    "email" = "root-accounts+shared@acme.com"
     "id" = "<SHARED_SERVICES_ACCOUNT_ID>"
     # (...)
   }
@@ -1730,9 +1558,11 @@ cloudtrail_s3_bucket_name = "<CLOUDTRAIL_BUCKET_NAME>"
 config_s3_bucket_name     = "<CONFIG_BUCKET_NAME>"
 ----
 
-Take note of all of this data, as you'll need it again shortly!
+Now, you can update the `accounts.json` file with the account IDs from the Terraform output! Also `account.hcl` files
+located in each account folder (e.g., infrastructure-live/dev, infrastructure-live/shared, etc.), with the appropriate
+account ID shown in the Terraform output.
 
-One other useful output will be the encrypted passwords for any IAM users you created:
+One other useful output are the encrypted passwords for IAM users you created:
 
 [source,hcl]
 ----
@@ -1768,227 +1598,7 @@ those root users again.
 === Apply the security baseline to the logs account
 
 The next step is to configure the logs account, which is used to aggregate AWS Config and CloudTrail data from all the
-other accountss. To do this, create a new module called `account-baseline-app`  in your `infrastructure-modules` repo:
-
-----
-infrastructure-modules
-  └ landingzone
-    └ account-baseline-root
-    └ account-baseline-app
-      └ main.tf
-      └ outputs.tf
-      └ variables.tf
-----
-
-Inside of `main.tf`, configure your AWS provider and Terraform settings:
-
-.infrastructure-modules/landingzone/account-baseline-app/main.tf
-[source,hcl]
-----
-provider "aws" {
-  # The AWS region in which all resources will be created
-  region = var.aws_region
-
-  # Require a 2.x version of the AWS provider
-  version = "~> 2.6"
-
-  # Only these AWS Account IDs may be operated on by this template
-  allowed_account_ids = [var.aws_account_id]
-}
-
-terraform {
-  # The configuration for this backend will be filled in by Terragrunt or via a backend.hcl file. See
-  # https://www.terraform.io/docs/backends/config.html#partial-configuration
-  backend "s3" {}
-
-  # Only allow this Terraform version. Note that if you upgrade to a newer version, Terraform won't allow you to use an
-  # older version, so when you upgrade, you should upgrade everyone on your team and your CI servers all at once.
-  required_version = "= 0.12.29"
-}
-----
-
-Next, use the `account-baseline-app` module from the Gruntwork Infrastructure as Code Library:
-
-.infrastructure-modules/landingzone/account-baseline-app/main.tf
-[source,hcl]
-----
-module "security_baseline" {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/landingzone/account-baseline-app?ref=v0.39.0"
-
-  name_prefix    = var.name_prefix
-  aws_region     = var.aws_region
-  aws_account_id = var.aws_account_id
-
-  # We assume the S3 bucket for AWS Config has already been created by account-baseline-root
-  config_should_create_s3_bucket                   = false
-  config_s3_bucket_name                            = var.config_s3_bucket_name
-  config_central_account_id                        = var.config_central_account_id
-  config_aggregate_config_data_in_external_account = var.config_aggregate_config_data_in_external_account
-
-  # We assume the S3 bucket and KMS key for CloudTrail have already been created by account-baseline-root
-  cloudtrail_s3_bucket_already_exists = true
-  cloudtrail_s3_bucket_name           = var.cloudtrail_s3_bucket_name
-  cloudtrail_kms_key_arn              = var.cloudtrail_kms_key_arn
-
-  dev_permitted_services  = var.dev_permitted_services
-  auto_deploy_permissions = var.auto_deploy_permissions
-
-  allow_read_only_access_from_other_account_arns = var.allow_read_only_access_from_other_account_arns
-  allow_billing_access_from_other_account_arns   = var.allow_billing_access_from_other_account_arns
-  allow_logs_access_from_other_account_arns      = var.allow_logs_access_from_other_account_arns
-  allow_dev_access_from_other_account_arns       = var.allow_dev_access_from_other_account_arns
-  allow_full_access_from_other_account_arns      = var.allow_full_access_from_other_account_arns
-  allow_auto_deploy_from_other_account_arns      = var.allow_auto_deploy_from_other_account_arns
-}
-----
-
-Create all the corresponding input variables for `account-baseline-app` in `variables.tf`:
-
-.infrastructure-modules/landingzone/account-baseline-app/variables.tf
-[source,hcl]
-----
-# ---------------------------------------------------------------------------------------------------------------------
-# MODULE PARAMETERS
-# These variables are expected to be passed in by the operator
-# ---------------------------------------------------------------------------------------------------------------------
-
-variable "name_prefix" {
-  description = "The name used to prefix AWS Config and CloudTrail resources, including the S3 bucket names and SNS topics used for each."
-  type        = string
-}
-
-variable "aws_region" {
-  description = "The AWS Region to use as the global config recorder and seed region for GuardDuty."
-  type        = string
-}
-
-variable "aws_account_id" {
-  description = "The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables."
-  type        = string
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# OPTIONAL PARAMETERS
-# These variables have reasonable defaults that can be overridden for further customizations.
-# ---------------------------------------------------------------------------------------------------------------------
-
-variable "cloudtrail_s3_bucket_name" {
-  description = "The name of the S3 Bucket where CloudTrail logs will be stored. This could be a bucket in this AWS account (e.g., if this is the logs account) or the name of a bucket in another AWS account where logs should be sent (e.g., if this is the stage or prod account and you're specifying the name of a bucket in the logs account)."
-  type        = string
-}
-
-variable "config_s3_bucket_name" {
-  description = "The name of the S3 Bucket where Config items will be stored. This could be a bucket in this AWS account (e.g., if this is the logs account) or the name of a bucket in another AWS account where Config items should be sent (e.g., if this is the stage or prod account and you're specifying the name of a bucket in the logs account)."
-  type        = string
-}
-
-variable "config_aggregate_config_data_in_external_account" {
-  description = "Set to true to send the AWS Config data to another account (e.g., a logs account) for aggregation purposes. You must set the ID of that other account via the config_central_account_id variable. This redundant variable has to exist because Terraform does not allow computed data in count and for_each parameters and var.config_central_account_id may be computed if its the ID of a newly-created AWS account."
-  type        = bool
-}
-
-variable "config_central_account_id" {
-  description = "If the S3 bucket and SNS topics used for AWS Config live in a different AWS account, set this variable to the ID of that account (e.g., if this is the stage or prod account, set this to the ID of the logs account). If the S3 bucket and SNS topics live in this account (e.g., this is the logs account), set this variable to null. Only used if config_aggregate_config_data_in_external_account is true."
-  type        = string
-}
-
-variable "cloudtrail_kms_key_arn" {
-  description = "All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If that CMK already exists (e.g., if this is the stage or prod account and you want to use a CMK that already exists in the logs account), set this to the ARN of that CMK. Otherwise (e.g., if this is the logs account), set this to null, and a new CMK will be created."
-  type        = string
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# OPTIONAL CROSS ACCOUNT IAM ROLES PARAMETERS
-# These variables have defaults, but may be overridden by the operator.
-# ---------------------------------------------------------------------------------------------------------------------
-
-variable "dev_permitted_services" {
-  description = "A list of AWS services for which the developers from the accounts in var.allow_dev_access_from_other_account_arns will receive full permissions. See https://goo.gl/ZyoHlz to find the IAM Service name. For example, to grant developers access only to EC2 and Amazon Machine Learning, use the value [\"ec2\",\"machinelearning\"]. Do NOT add iam to the list of services, or that will grant Developers de facto admin access."
-  type        = list(string)
-  default     = []
-}
-
-variable "allow_read_only_access_from_other_account_arns" {
-  description = "A list of IAM ARNs from other AWS accounts that will be allowed read-only access to this account."
-  type        = list(string)
-  default     = []
-  # Example:
-  # default = [
-  #   "arn:aws:iam::123445678910:root"
-  # ]
-}
-
-variable "allow_billing_access_from_other_account_arns" {
-  description = "A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the billing info for this account."
-  type        = list(string)
-  default     = []
-  # Example:
-  # default = [
-  #   "arn:aws:iam::123445678910:root"
-  # ]
-}
-
-variable "allow_logs_access_from_other_account_arns" {
-  description = "A list of IAM ARNs from other AWS accounts that will be allowed read access to the logs in CloudTrail, AWS Config, and CloudWatch for this account. If var.cloudtrail_kms_key_arn is specified, will also be given permissions to decrypt with the KMS CMK that is used to encrypt CloudTrail logs."
-  type        = list(string)
-  default     = []
-  # Example:
-  # default = [
-  #   "arn:aws:iam::123445678910:root"
-  # ]
-}
-
-variable "allow_dev_access_from_other_account_arns" {
-  description = "A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to the services in this account specified in var.dev_permitted_services."
-  type        = list(string)
-  default     = []
-  # Example:
-  # default = [
-  #   "arn:aws:iam::123445678910:root"
-  # ]
-}
-
-variable "allow_full_access_from_other_account_arns" {
-  description = "A list of IAM ARNs from other AWS accounts that will be allowed full (read and write) access to this account."
-  type        = list(string)
-  default     = []
-  # Example:
-  # default = [
-  #   "arn:aws:iam::123445678910:root"
-  # ]
-}
-
-variable "allow_auto_deploy_from_other_account_arns" {
-  description = "A list of IAM ARNs from other AWS accounts that will be allowed to assume the auto deploy IAM role that has the permissions in var.auto_deploy_permissions."
-  type        = list(string)
-  default     = []
-  # Example:
-  # default = [
-  #   "arn:aws:iam::123445678910:role/jenkins"
-  # ]
-}
-
-variable "auto_deploy_permissions" {
-  description = "A list of IAM permissions (e.g. ec2:*) that will be added to an IAM Group for doing automated deployments. NOTE: If var.should_create_iam_group_auto_deploy is true, the list must have at least one element (e.g. '*')."
-  type        = list(string)
-  default     = []
-}
-----
-
-At this point, you'll want to test your code. See
-link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library#manual_tests_terraform[Manual tests for Terraform code] and
-link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library#automated_tests_terraform[Automated tests for Terraform code]
-for instructions.
-
-When you're done testing, commit and release your changes:
-
-[source,bash]
-----
-git add landingzone/account-baseline-app
-git commit -m "Add app account baseline wrapper module"
-git tag -a "v0.3.1" -m "Created app account baseline module"
-git push --follow-tags
-----
+other accounts.
 
 Create a `terragrunt.hcl` file in `infrastructure-live` under the file path `logs/_global/account-baseline`:
 
@@ -2001,14 +1611,13 @@ infrastructure-live
         └ terragrunt.hcl
 ----
 
-Point the `source` URL in your `terragrunt.hcl` file to your `account-baseline-app` wrapper module in the `infrastructure-modules`
-repo, setting the `ref` param to the version you released earlier:
+Point the `source` URL in your `terragrunt.hcl` file to the https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.41.4/modules/landingzone/account-baseline-app[account-baseline-app] service in the Service Catalog.
 
 .infrastructure-live/logs/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
 terraform {
-  source = "git::git@github.com/<YOUR_ORG>/infrastructure-modules.git//landingzone/account-baseline-app?ref=v0.3.1"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/landingzone/account-baseline-app?ref=v0.41.4"
 
   # This module deploys some resources (e.g., AWS Config) across all AWS regions, each of which needs its own provider,
   # which in Terraform means a separate process. To avoid all these processes thrashing the CPU, which leads to network
@@ -2023,32 +1632,61 @@ terraform {
 [.exceptional]
 IMPORTANT: We **strongly** recommend setting Terraform parallelism to a low value (e.g., `-parallelism=2`), as shown above, with the `account-baseline-xxx` modules. This is because these modules deploy multi-region resources (e.g., GuardDuty, AWS Config, etc), and for each region, Terraform spins up a separate process, so if you don't limit the parallelism, it may peg all your CPU cores and lead to network connectivity errors.
 
+Include all the settings from the root terragrunt.hcl file:
+
+.infrastructure-live/logs/_global/account-baseline/terragrunt.hcl
+[source,hcl]
+----
+include {
+  path = find_in_parent_folders()
+}
+----
+
 Set the variables for the `account-baseline-app` module in this environment in the `inputs = { ... }` block of `terragrunt.hcl`:
 
 .infrastructure-live/logs/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
+locals {
+  # A local for more convenient access to the accounts map.
+  accounts = local.common_vars.locals.accounts
+
+  # A local for convenient access to the security account root ARN.
+  security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
+}
+
 inputs = {
-  # Fill in your region you want to use (only used for API calls) and the ID of your logs AWS account
-  aws_region     = "us-east-2"
-  aws_account_id = "<LOGS_ACCOUNT_ID>"
-
-  # Prefix all resources with this name
-  name_prefix    = "<COMPANY_NAME>-logs"
-
-  # Use the S3 bucket and KMS key that were already created in this logs account by account-baseline-root
+  # Use the S3 bucket and KMS key that were already created in the logs account by account-baseline-root
   cloudtrail_s3_bucket_name = "<CLOUDTRAIL_BUCKET_NAME>"
   cloudtrail_kms_key_arn    = "<CLOUDTRAIL_KMS_KEY_ARN>"
 
-  # Use the S3 bucket that was already created in this logs account by account-baseline-root
+  # All of the other accounts send logs to this account.
+  cloudtrail_allow_kms_describe_key_to_external_aws_accounts = true
+  cloudtrail_external_aws_account_ids_with_write_access = [
+    for name, id in local.accounts :
+      id if name != "logs"
+  ]
+
+  # Use the S3 bucket that was already created in the logs account by account-baseline-root
   config_s3_bucket_name                            = "<CONFIG_BUCKET_NAME>"
   config_aggregate_config_data_in_external_account = false
-  config_central_account_id                        = null
+  config_central_account_id                        = local.accounts.logs
+  config_force_destroy                             = false
+
+  # This is the Logs account, so we create the S3 bucket and SNS topic for aggregating Config logs from all accounts.
+  config_should_create_s3_bucket = true
+  config_should_create_sns_topic = true
+
+  # All of the other accounts send logs to this account.
+  config_linked_accounts = [
+    for name, id in local.accounts :
+      id if name != "logs"
+  ]
 
   # Allow users in the security account to assume IAM roles in this account
-  allow_full_access_from_other_account_arns      = ["arn:aws:iam::<SECURITY_ACCOUNT_ID>:root"]
-  allow_read_only_access_from_other_account_arns = ["arn:aws:iam::<SECURITY_ACCOUNT_ID>:root"]
-  allow_logs_access_from_other_account_arns      = ["arn:aws:iam::<SECURITY_ACCOUNT_ID>:root"]
+  allow_full_access_from_other_account_arns      = [local.security_account_root_arn]
+  allow_read_only_access_from_other_account_arns = [local.security_account_root_arn]
+  allow_logs_access_from_other_account_arns      = [local.security_account_root_arn]
 }
 ----
 
@@ -2063,23 +1701,13 @@ The example above configures the logs account of an AWS Organization as follows:
 . **Allow access from the security account**: We configure IAM roles that IAM users in the security account will be
   able to assume to get access to the logs account.
 
-Configure your Terraform backend:
-
-.infrastructure-live/logs/_global/account-baseline/terragrunt.hcl
-[source,hcl]
-----
-include {
-  path = find_in_parent_folders()
-}
-----
-
 You're now going to use an IAM role to authenticate to the logs account. This IAM role is created automatically in each
 child account by `account-baseline-root` and has a default name of `OrganizationAccountAccessRole`. There are many ways
 to https://blog.gruntwork.io/a-comprehensive-guide-to-authenticating-to-aws-on-the-command-line-63656a686799[assume an IAM role on the CLI];
 for this guide, we're going to keep using `aws-vault`.
 
 Open up `~/.aws/config` and you should see a `profile` that was created automatically when you ran
-`aws-vault add root-iam-user`  earlier:
+`aws-vault add root-iam-user` earlier:
 
 [source,text]
 ----
@@ -2123,419 +1751,12 @@ aws-vault exec logs-from-root -- terragrunt apply
 ----
 
 [.exceptional]
-IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 1024`.
+IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 10240`.
 
 === Apply the security baseline to the security account
 
 Now that your logs accounts is fully configured, you need to apply the security baseline to the security account, which
 is where all your IAM users and groups will be defined and managed.
-
-Create a new module called `account-baseline-security` in your `infrastructure-modules` repo:
-
-----
-infrastructure-modules
-  └ landingzone
-    └ account-baseline-root
-    └ account-baseline-app
-    └ account-baseline-security
-      └ main.tf
-      └ outputs.tf
-      └ variables.tf
-----
-
-Inside of `main.tf`, configure your AWS provider and Terraform settings:
-
-.infrastructure-modules/landingzone/account-baseline-security/main.tf
-[source,hcl]
-----
-provider "aws" {
-  # The AWS region in which all resources will be created
-  region = var.aws_region
-
-  # Require a 2.x version of the AWS provider
-  version = "~> 2.6"
-
-  # Only these AWS Account IDs may be operated on by this template
-  allowed_account_ids = [var.aws_account_id]
-}
-
-terraform {
-  # The configuration for this backend will be filled in by Terragrunt or via a backend.hcl file. See
-  # https://www.terraform.io/docs/backends/config.html#partial-configuration
-  backend "s3" {}
-
-  # Only allow this Terraform version. Note that if you upgrade to a newer version, Terraform won't allow you to use an
-  # older version, so when you upgrade, you should upgrade everyone on your team and your CI servers all at once.
-  required_version = "= 0.12.29"
-}
-----
-
-Next, use the `account-baseline-security` module from the Gruntwork Infrastructure as Code Library:
-
-.infrastructure-modules/landingzone/account-baseline-security/main.tf
-[source,hcl]
-----
-module "security_baseline" {
-  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/landingzone/account-baseline-security?ref=v0.39.0"
-
-  name_prefix    = var.name_prefix
-  aws_region     = var.aws_region
-  aws_account_id = var.aws_account_id
-
-  # We assume the S3 bucket for AWS Config has already been created by account-baseline-root
-  config_should_create_s3_bucket                   = false
-  config_s3_bucket_name                            = var.config_s3_bucket_name
-  config_central_account_id                        = var.config_central_account_id
-  config_aggregate_config_data_in_external_account = true
-
-  # We assume the S3 bucket and KMS key for CloudTrail have already been created by account-baseline-root
-  cloudtrail_s3_bucket_already_exists = true
-  cloudtrail_s3_bucket_name           = var.cloudtrail_s3_bucket_name
-  cloudtrail_kms_key_arn              = var.cloudtrail_kms_key_arn
-
-  iam_groups_for_cross_account_access            = var.iam_groups_for_cross_account_access
-  cross_account_access_all_group_name            = var.cross_account_access_all_group_name
-  allow_ssh_grunt_access_from_other_account_arns = var.allow_ssh_grunt_access_from_other_account_arns
-
-  should_create_iam_group_full_access              = var.should_create_iam_group_full_access
-  should_create_iam_group_billing                  = var.should_create_iam_group_billing
-  should_create_iam_group_logs                     = var.should_create_iam_group_logs
-  should_create_iam_group_developers               = var.should_create_iam_group_developers
-  should_create_iam_group_read_only                = var.should_create_iam_group_read_only
-  should_create_iam_group_support                  = var.should_create_iam_group_support
-  should_create_iam_group_user_self_mgmt           = var.should_create_iam_group_user_self_mgmt
-  should_create_iam_group_iam_admin                = var.should_create_iam_group_iam_admin
-  should_create_iam_group_use_existing_iam_roles   = var.should_create_iam_group_use_existing_iam_roles
-  should_create_iam_group_auto_deploy              = var.should_create_iam_group_auto_deploy
-  should_create_iam_group_cross_account_access_all = var.should_create_iam_group_cross_account_access_all
-
-  iam_group_name_full_access            = var.iam_group_name_full_access
-  iam_group_name_billing                = var.iam_group_name_billing
-  iam_group_name_logs                   = var.iam_group_name_logs
-  iam_group_name_developers             = var.iam_group_name_developers
-  iam_group_name_read_only              = var.iam_group_name_read_only
-  iam_group_names_ssh_grunt_sudo_users  = var.iam_group_names_ssh_grunt_sudo_users
-  iam_group_names_ssh_grunt_users       = var.iam_group_names_ssh_grunt_users
-  iam_group_name_use_existing_iam_roles = var.iam_group_name_use_existing_iam_roles
-  iam_group_name_auto_deploy            = var.iam_group_name_auto_deploy
-  iam_group_name_support                = var.iam_group_name_support
-  iam_group_name_iam_user_self_mgmt     = var.iam_group_name_iam_user_self_mgmt
-  iam_group_name_iam_admin              = var.iam_group_name_iam_admin
-
-  users = var.users
-}
-----
-
-Create all the corresponding input variables for `account-baseline-security` in `variables.tf`:
-
-.infrastructure-modules/landingzone/account-baseline-security/variables.tf
-[source,hcl]
-----
-# ---------------------------------------------------------------------------------------------------------------------
-# MODULE PARAMETERS
-# These variables are expected to be passed in by the operator
-# ---------------------------------------------------------------------------------------------------------------------
-
-variable "name_prefix" {
-  description = "The name used to prefix AWS Config and CloudTrail resources, including the S3 bucket names and SNS topics used for each."
-  type        = string
-}
-
-variable "aws_region" {
-  description = "The AWS Region to use as the global config recorder and seed region for GuardDuty."
-  type        = string
-}
-
-variable "aws_account_id" {
-  description = "The AWS Account ID the template should be operated on. This avoids misconfiguration errors caused by environment variables."
-  type        = string
-}
-
-variable "config_s3_bucket_name" {
-  description = "The name of the S3 Bucket where Config items will be stored. This could be a bucket in this AWS account or the name of a bucket in another AWS account where Config items should be sent. We recommend setting this to the name of an S3 bucket in a separate logs account."
-  type        = string
-}
-
-variable "config_central_account_id" {
-  description = "If the S3 bucket and SNS topics used for AWS Config live in a different AWS account, set this variable to the ID of that account. If the S3 bucket and SNS topics live in this account, set this variable to null. We recommend setting this to the ID of a separate logs account."
-  type        = string
-}
-
-variable "cloudtrail_s3_bucket_name" {
-  description = "The name of the S3 Bucket where CloudTrail logs will be stored. This could be a bucket in this AWS account or the name of a bucket in another AWS account where logs should be sent. We recommend setting this to the name of a bucket in a separate logs account."
-  type        = string
-}
-
-variable "cloudtrail_kms_key_arn" {
-  description = "All CloudTrail Logs will be encrypted with a KMS CMK (Customer Master Key) that governs access to write API calls older than 7 days and all read API calls. If that CMK already exists, set this to the ARN of that CMK. Otherwise, set this to null, and a new CMK will be created. We recommend setting this to the ARN of a CMK that already exists in a separate logs account."
-  type        = string
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# OPTIONAL IAM-GROUPS PARAMETERS
-# These variables have defaults, but may be overridden by the operator.
-# ---------------------------------------------------------------------------------------------------------------------
-
-variable "iam_groups_for_cross_account_access" {
-  description = "This variable is used to create groups that allow IAM users to assume roles in your other AWS accounts. It should be a list of objects, where each object has the fields 'group_name', which will be used as the name of the IAM group, and 'iam_role_arns', which is a list of ARNs of IAM Roles that you can assume when part of that group. For each entry in the list of objects, we will create an IAM group that allows users to assume the given IAM role(s) in the other AWS account. This allows you to define all your IAM users in one account (e.g. the users account) and to grant them access to certain IAM roles in other accounts (e.g. the stage, prod, audit accounts)."
-  type = list(object({
-    group_name    = string
-    iam_role_arns = list(string)
-  }))
-  default = []
-
-  # Example:
-  # default = [
-  #   {
-  #     group_name   = "stage-full-access"
-  #     iam_role_arns = ["arn:aws:iam::123445678910:role/mgmt-full-access"]
-  #   },
-  #   {
-  #     group_name   = "prod-read-only-access"
-  #     iam_role_arns = [
-  #       "arn:aws:iam::9876543210:role/prod-read-only-ec2-access",
-  #       "arn:aws:iam::9876543210:role/prod-read-only-rds-access"
-  #     ]
-  #   }
-  # ]
-}
-
-# The only IAM groups you typically need in the security account are full access (for admins) and groups that allows
-# access to other AWS accounts
-variable "should_create_iam_group_full_access" {
-  description = "Should we create the IAM Group for full access? Allows full access to all AWS resources. (true or false)"
-  type        = bool
-  default     = true
-}
-
-variable "should_create_iam_group_billing" {
-  description = "Should we create the IAM Group for billing? Allows read-write access to billing features only. (true or false)"
-  type        = bool
-  default     = false
-}
-
-variable "should_create_iam_group_logs" {
-  description = "Should we create the IAM Group for logs? Allows read access to CloudTrail, AWS Config, and CloudWatch. If var.cloudtrail_kms_key_arn is set, will also give decrypt access to a KMS CMK. (true or false)"
-  type        = bool
-  default     = false
-}
-
-variable "should_create_iam_group_developers" {
-  description = "Should we create the IAM Group for developers? The permissions of that group are specified via var.iam_group_developers_permitted_services. (true or false)"
-  type        = bool
-  default     = false
-}
-
-variable "should_create_iam_group_read_only" {
-  description = "Should we create the IAM Group for read-only? Allows read-only access to all AWS resources. (true or false)"
-  type        = bool
-  default     = false
-}
-
-variable "should_create_iam_group_support" {
-  description = "Should we create the IAM Group for support users? Allows users to access AWS support."
-  type        = bool
-  default     = false
-}
-
-variable "should_create_iam_group_user_self_mgmt" {
-  description = "Should we create the IAM Group for user self-management? Allows users to manage their own IAM user accounts, but not other IAM users. (true or false)"
-  type        = bool
-  default     = true
-}
-
-variable "should_create_iam_group_iam_admin" {
-  description = "Should we create the IAM Group for IAM administrator access? Allows users to manage all IAM entities, effectively granting administrator access. (true or false)"
-  type        = bool
-  default     = false
-}
-
-variable "should_create_iam_group_use_existing_iam_roles" {
-  description = "Should we create the IAM Group for use-existing-iam-roles? Allow launching AWS resources with existing IAM Roles, but no ability to create new IAM Roles. (true or false)"
-  type        = bool
-  default     = false
-}
-
-variable "should_create_iam_group_auto_deploy" {
-  description = "Should we create the IAM Group for auto-deploy? Allows automated deployment by granting the permissions specified in var.auto_deploy_permissions. (true or false)"
-  type        = bool
-  default     = false
-}
-
-variable "should_create_iam_group_cross_account_access_all" {
-  description = "Should we create the IAM Group for access to all external AWS accounts? "
-  type        = bool
-  default     = true
-}
-
-variable "iam_group_name_full_access" {
-  description = "The name to be used for the IAM Group that grants full access to all AWS resources."
-  type        = string
-  default     = "full-access"
-}
-
-variable "iam_group_name_billing" {
-  description = "The name to be used for the IAM Group that grants read/write access to all billing features in AWS."
-  type        = string
-  default     = "billing"
-}
-
-variable "iam_group_name_logs" {
-  description = "The name to be used for the IAM Group that grants read access to CloudTrail, AWS Config, and CloudWatch in AWS."
-  type        = string
-  default     = "logs"
-}
-
-variable "iam_group_name_developers" {
-  description = "The name to be used for the IAM Group that grants IAM Users a reasonable set of permissions for developers."
-  type        = string
-  default     = "developers"
-}
-
-variable "iam_group_name_read_only" {
-  description = "The name to be used for the IAM Group that grants read-only access to all AWS resources."
-  type        = string
-  default     = "read-only"
-}
-
-variable "iam_group_names_ssh_grunt_sudo_users" {
-  description = "The list of names to be used for the IAM Group that enables its members to SSH as a sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups."
-  type        = list(string)
-  default     = ["ssh-grunt-sudo-users"]
-}
-
-variable "iam_group_names_ssh_grunt_users" {
-  description = "The name to be used for the IAM Group that enables its members to SSH as a non-sudo user into any server configured with the ssh-grunt Gruntwork module. Pass in multiple to configure multiple different IAM groups to control different groupings of access at the server level. Pass in empty list to disable creation of the IAM groups."
-  type        = list(string)
-  default     = ["ssh-grunt-users"]
-}
-
-variable "iam_group_name_use_existing_iam_roles" {
-  description = "The name to be used for the IAM Group that grants IAM Users the permissions to use existing IAM Roles when launching AWS Resources. This does NOT grant the permission to create new IAM Roles."
-  type        = string
-  default     = "use-existing-iam-roles"
-}
-
-variable "iam_group_name_auto_deploy" {
-  description = "The name of the IAM Group that allows automated deployment by graning the permissions specified in var.auto_deploy_permissions."
-  type        = string
-  default     = "_machine.ecs-auto-deploy"
-}
-
-variable "iam_group_name_support" {
-  description = "The name of the IAM Group that allows access to AWS Support."
-  type        = string
-  default     = "support"
-}
-
-variable "iam_group_name_iam_user_self_mgmt" {
-  description = "The name to be used for the IAM Group that grants IAM Users the permissions to manage their own IAM User account."
-  type        = string
-  default     = "iam-user-self-mgmt"
-}
-
-variable "iam_group_name_iam_admin" {
-  description = "The name to be used for the IAM Group that grants IAM administrative access. Effectively grants administrator access."
-  type        = string
-  default     = "iam-admin"
-}
-
-variable "cross_account_access_all_group_name" {
-  description = "The name of the IAM group that will grant access to all external AWS accounts in var.iam_groups_for_cross_account_access."
-  type        = string
-  default     = "_all-accounts"
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# OPTIONAL USERS MODULE PARAMETERS
-# These variables have defaults, but may be overridden by the operator.
-# ---------------------------------------------------------------------------------------------------------------------
-
-variable "users" {
-  description = "A map of users to create. The keys are the user names and the values are an object with the optional keys 'groups' (a list of IAM groups to add the user to), 'tags' (a map of tags to apply to the user), 'pgp_key' (either a base-64 encoded PGP public key, or a keybase username in the form keybase:username, used to encrypt the user's credentials; required if create_login_profile or create_access_keys is true), 'create_login_profile' (if set to true, create a password to login to the AWS Web Console), 'create_access_keys' (if set to true, create access keys for the user), 'path' (the path), and 'permissions_boundary' (the ARN of the policy that is used to set the permissions boundary for the user)."
-
-  # Ideally, this would be a map of (string, object), but object does not support optional properties, and we want
-  # users to be able to specify, say, tags for some users, but not for others. We can't use a map(any) either, as that
-  # would require the values to all have the same type, and due to optional parameters, that wouldn't work either. So,
-  # we have to lamely fall back to any.
-  type = any
-
-  # Example:
-  # users = {
-  #   alice = {
-  #     groups = ["user-self-mgmt", "developers", "ssh-sudo-users"]
-  #   }
-  #
-  #   bob = {
-  #     path   = "/"
-  #     groups = ["user-self-mgmt", "ops", "admins"]
-  #     tags   = {
-  #       foo = "bar"
-  #     }
-  #   }
-  #
-  #   carol = {
-  #     groups               = ["user-self-mgmt", "developers", "ssh-users"]
-  #     pgp_key              = "keybase:carol_on_keybase"
-  #     create_login_profile = true
-  #     create_access_keys   = true
-  #   }
-  # }
-
-  default = {}
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
-# OPTIONAL CROSS ACCOUNT IAM ROLES PARAMETERS
-# These variables have defaults, but may be overridden by the operator.
-# ---------------------------------------------------------------------------------------------------------------------
-
-variable "allow_ssh_grunt_access_from_other_account_arns" {
-  description = "A list of IAM ARNs from other AWS accounts that will be allowed read access to IAM groups and publish SSH keys. This is used for ssh-grunt."
-  type        = list(string)
-  default     = []
-  # Example:
-  # default = [
-  #   "arn:aws:iam::123445678910:root"
-  # ]
-}
-----
-
-Finally, add some useful outputs in `outputs.tf`:
-
-.infrastructure-modules/landingzone/account-baseline-security/outputs.tf
-[source,hcl]
-----
-output "user_arns" {
-  description = "A map of usernames to the ARN for that IAM user."
-  value       = module.security_baseline.user_arns
-}
-
-output "user_passwords" {
-  description = "A map of usernames to that user's AWS Web Console password, encrypted with that user's PGP key (only shows up for users with create_login_profile = true). You can decrypt the password on the CLI: echo <password> | base64 --decode | keybase pgp decrypt"
-  value       = module.security_baseline.user_passwords
-}
-
-output "user_access_keys" {
-  description = "A map of usernames to that user's access keys (a map with keys access_key_id and secret_access_key), with the secret_access_key encrypted with that user's PGP key (only shows up for users with create_access_keys = true). You can decrypt the secret_access_key on the CLI: echo <secret_access_key> | base64 --decode | keybase pgp decrypt"
-  value       = module.security_baseline.user_access_keys
-}
-----
-
-At this point, you'll want to test your code. See
-link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library#manual_tests_terraform[Manual tests for Terraform code] and
-link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library#automated_tests_terraform[Automated tests for Terraform code]
-for instructions.
-
-When you're done testing, commit and release your changes:
-
-[source,bash]
-----
-git add landingzone/account-baseline-security
-git commit -m "Add security account baseline wrapper module"
-git tag -a "v0.3.2" -m "Created security account baseline module"
-git push --follow-tags
-----
 
 Create a `terragrunt.hcl` file in `infrastructure-live` under the file path `security/_global/account-baseline`:
 
@@ -2549,14 +1770,13 @@ infrastructure-live
         └ terragrunt.hcl
 ----
 
-Point the `source` URL in your `terragrunt.hcl` file to your `account-baseline-security` wrapper module in the `infrastructure-modules`
-repo, setting the `ref` param to the version you released earlier:
+Point the `source` URL in your `terragrunt.hcl` file to the https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.41.4/modules/landingzone/account-baseline-security[account-baseline-security] service in the Service Catalog.
 
 .infrastructure-live/security/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
 terraform {
-  source = "git::git@github.com/<YOUR_ORG>/infrastructure-modules.git//landingzone/account-baseline-security?ref=v0.3.2"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/landingzone/account-baseline-security?ref=v0.41.4"
 
   # This module deploys some resources (e.g., AWS Config) across all AWS regions, each of which needs its own provider,
   # which in Terraform means a separate process. To avoid all these processes thrashing the CPU, which leads to network
@@ -2571,26 +1791,37 @@ terraform {
 [.exceptional]
 IMPORTANT: We **strongly** recommend setting Terraform parallelism to a low value (e.g., `-parallelism=2`), as shown above, with the `account-baseline-xxx` modules. This is because these modules deploy multi-region resources (e.g., GuardDuty, AWS Config, etc), and for each region, Terraform spins up a separate process, so if you don't limit the parallelism, it may peg all your CPU cores and lead to network connectivity errors.
 
+Include all the settings from the root terragrunt.hcl file:
+
+.infrastructure-live/security/_global/account-baseline/terragrunt.hcl
+[source,hcl]
+----
+include {
+  path = find_in_parent_folders()
+}
+----
+
 Set the variables for the `account-baseline-security` module in this environment in the `inputs = { ... }` block of `terragrunt.hcl`:
 
 .infrastructure-live/security/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
+locals {
+  # A local for more convenient access to the accounts map.
+  accounts = local.common_vars.locals.accounts
+
+  # A local for convenient access to the security account root ARN.
+  security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
+}
+
 inputs = {
-  # Fill in your region you want to use (only used for API calls) and the ID of your security AWS account
-  aws_region     = "us-east-2"
-  aws_account_id = "<SECURITY_ACCOUNT_ID>"
-
-  # Prefix all resources with this name
-  name_prefix = "<COMPANY_NAME>-security"
-
-  # Use the S3 bucket and KMS key that were already created in this logs account by account-baseline-root
+  # Use the S3 bucket and KMS key that were already created in the logs account by account-baseline-root
   cloudtrail_s3_bucket_name = "<CLOUDTRAIL_BUCKET_NAME>"
   cloudtrail_kms_key_arn    = "<CLOUDTRAIL_KMS_KEY_ARN>"
 
-  # Use the S3 bucket that was already created in this logs account by account-baseline-root
+  # Use the S3 bucket that was already created in the logs account by account-baseline-root
   config_s3_bucket_name     = "<CONFIG_BUCKET_NAME>"
-  config_central_account_id = "<LOGS_ACCOUNT_ID>"
+  config_central_account_id = local.accounts.logs
 
   # Enable the IAM groups you want
   should_create_iam_group_full_access    = true
@@ -2600,65 +1831,63 @@ inputs = {
   # Configure the names for IAM groups
   iam_group_name_full_access            = "full-access"
   iam_group_name_read_only              = "read-only"
-  iam_group_name_iam_user_self_mgmt     = "self-mgmt"
+  iam_group_name_iam_user_self_mgmt     = "iam-user-self-mgmt"
   iam_group_names_ssh_grunt_sudo_users  = ["ssh-grunt-sudo-users"]
   iam_group_names_ssh_grunt_users       = ["ssh-grunt-users"]
 
   # Create IAM groups that grant access to the other AWS accounts
   iam_groups_for_cross_account_access = [
     {
-      group_name    = "_account.dev-full-access",
-      iam_role_arns = ["arn:aws:iam::<DEV_ACCOUNT_ID>:role/allow-full-access-from-other-accounts"]
+      group_name    = "_account.stage-full-access",
+      iam_role_arns = ["arn:aws:iam::${locals.accounts.stage}:role/allow-full-access-from-other-accounts"]
     },
     {
-      group_name    = "_account.dev-read-only",
-      iam_role_arns = ["arn:aws:iam::<DEV_ACCOUNT_ID>:role/allow-read-only-access-from-other-accounts"]
+      group_name    = "_account.stage-read-only",
+      iam_role_arns = ["arn:aws:iam::${locals.accounts.stage}:role/allow-read-only-access-from-other-accounts"]
     },
     {
-      group_name    = "_account.dev-dev",
-      iam_role_arns = ["arn:aws:iam::<DEV_ACCOUNT_ID>:role/allow-dev-access-from-other-accounts"]
+      group_name    = "_account.stage-dev",
+      iam_role_arns = ["arn:aws:iam::${locals.accounts.stage}:role/allow-dev-access-from-other-accounts"]
     },
     {
-      group_name    = "_account.dev-openvpn-admins",
-      iam_role_arns = ["arn:aws:iam::<DEV_ACCOUNT_ID>:role/openvpn-allow-certificate-revocations-for-external-accounts"]
+      group_name    = "_account.stage-openvpn-admins",
+      iam_role_arns = ["arn:aws:iam::${locals.accounts.stage}:role/openvpn-allow-certificate-revocations-for-external-accounts"]
     },
     {
-      group_name    = "_account.dev-openvpn-users",
-      iam_role_arns = ["arn:aws:iam::<DEV_ACCOUNT_ID>:role/openvpn-allow-certificate-requests-for-external-accounts"]
+      group_name    = "_account.stage-openvpn-users",
+      iam_role_arns = ["arn:aws:iam::${locals.accounts.stage}:role/openvpn-allow-certificate-requests-for-external-accounts"]
     },
 
-    # ... Repeat the same set of groups for each of stage, prod, logs, and shared services account IDs too!
+    # ... Repeat the same set of groups for each of dev, prod, logs, and shared services account IDs too!
   ]
 
   # Create all the IAM users for your company and assign them to IAM groups
   users = {
     alice = {
-      groups               = ["user-self-mgmt", "ssh-sudo-users", "_account.dev-full-access"]
+      groups               = ["iam-user-self-mgmt", "ssh-grunt-sudo-users", "_account.dev-full-access"]
       pgp_key              = "keybase:alice_on_keybase"
       create_login_profile = true
       create_access_keys   = false
     }
 
     bob = {
-      groups               = ["user-self-mgmt", "_account.dev-full-access", "_account.prod-read-only"]
+      groups               = ["iam-user-self-mgmt", "_account.dev-full-access", "_account.prod-read-only"]
       pgp_key              = "keybase:bob_on_keybase"
       create_login_profile = true
       create_access_keys   = false
     }
     carol = {
-      groups               = ["user-self-mgmt", "full-access"]
+      groups               = ["iam-user-self-mgmt", "full-access"]
       pgp_key              = "keybase:carol_on_keybase"
       create_login_profile = true
       create_access_keys   = true
     }
   }
 
-  # Allow ssh-grunt in all other accounts to look up user SSH keys in this account
+  # Allow accounts to have read access to IAM groups and the public SSH keys of users in the group.
   allow_ssh_grunt_access_from_other_account_arns = [
-    "arn:aws:iam::<DEV_ACCOUNT_ID>:root",
-    "arn:aws:iam::<STAGE_ACCOUNT_ID>:root",
-    "arn:aws:iam::<PROD_ACCOUNT_ID>:root",
-    "arn:aws:iam::<SHARED_SERVICES_ACCOUNT_ID>:root",
+    for name, id in local.accounts :
+      "arn:aws:iam::${id}:root" if name != "security"
   ]
 }
 ----
@@ -2671,22 +1900,13 @@ The code above does the following:
 
 . **Create IAM groups**. We've created IAM groups, both for permissions within the security account (e.g.,
   `full-access` grants admin permissions in the security account) and for permissions in other accounts (e.g.,
-  `_account.dev-full-access` grants access to an IAM role with admin permissions in the dev account).
+  `_account.stage-full-access` grants access to an IAM role with admin permissions in the stage account). Be sure to
+  fill out the section for permissions in dev, prod, logs, and shared-services accounts.
 
 . **Create IAM users**. The example above creates IAM users for `alice`, `bob`, and `carol`, and assigns them to
   the various IAM groups. You should create an IAM user for yourself in the `full-access` group, plus IAM users for the
   rest of your team in the appropriate groups. Like the root account, the code will also generate a password for each
   user and encrypt it with that user’s PGP key from Keybase (see below for how to handle the passwords).
-
-Configure your Terraform backend:
-
-.infrastructure-live/security/_global/account-baseline/terragrunt.hcl
-[source,hcl]
-----
-include {
-  path = find_in_parent_folders()
-}
-----
 
 Just as with the logs account, you're going to use the `OrganizationAccountAccessRole` IAM role created by
 `account-baseline-root` to authenticate to the security account. There are many ways to
@@ -2730,7 +1950,7 @@ aws-vault exec security-from-root -- terragrunt apply
 ----
 
 [.exceptional]
-IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 1024`.
+IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 10240`.
 
 When `apply` finishes, the module will output the encrypted passwords for the users defined above. Send the encrypted
 password to each user, along with their user name, and the IAM user sign-in URL for the account. Each user can then
@@ -2744,15 +1964,16 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 === Apply the security baseline to the other child accounts
 
 Now that your security account is fully configured, you need to apply the security baseline to the remaining child
-accounts (e.g., dev, stage, prod, shared-services) as detailed in the <<child_accounts>> section. Feel free to adjust
-this as necessary based on the accounts your company needs.
+accounts (i.e., dev, stage, prod, and shared, plus sandbox and testing accounts you might have) as
+detailed in the <<child_accounts>> section. Feel free to adjust this as necessary based on the accounts your company
+needs.
 
-You can re-use the `account-baseline-app` module you created earlier in your `infrastructure-modules` repo for all of
-these child accounts; this module can be used interchangeably between app accounts and log accounts as they deploy most
-of the same resources.
+The `account-baseline-app` module in the Service Catalog can be used interchangeably between app accounts and log
+accounts as they deploy most of the same resources. That means this module can be re-used for all of the child
+accounts.
 
 Create `terragrunt.hcl` files in `infrastructure-live` under the file paths `<ACCOUNT>/_global/account-baseline`,
-where `<ACCOUNT>` is one of these other child accounts, such as dev, stage, prod, and shared-services. In the rest of
+where `<ACCOUNT>` is one of these other child accounts, such as dev, stage, prod, and shared. In the rest of
 this example, we’ll look solely at the stage account, but make sure you follow the analogous steps for EACH of your
 child accounts.
 
@@ -2767,14 +1988,13 @@ infrastructure-live
         └ terragrunt.hcl
 ----
 
-Point the `source` URL in your `terragrunt.hcl` file to your `account-baseline-app` wrapper module in the `infrastructure-modules`
-repo, setting the `ref` param to the latest version:
+Point the `source` URL in your `terragrunt.hcl` file to the https://github.com/gruntwork-io/terraform-aws-service-catalog/tree/v0.41.4/modules/landingzone/account-baseline-app[account-baseline-app] service in the Service Catalog.
 
 .infrastructure-live/stage/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
 terraform {
-  source = "git::git@github.com/<YOUR_ORG>/infrastructure-modules.git//landingzone/account-baseline-app?ref=v0.3.2"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-service-catalog.git//modules/landingzone/account-baseline-app?ref=v0.41.4"
 
   # This module deploys some resources (e.g., AWS Config) across all AWS regions, each of which needs its own provider,
   # which in Terraform means a separate process. To avoid all these processes thrashing the CPU, which leads to network
@@ -2789,27 +2009,38 @@ terraform {
 [.exceptional]
 IMPORTANT: We **strongly** recommend setting Terraform parallelism to a low value (e.g., `-parallelism=2`), as shown above, with the `account-baseline-xxx` modules. This is because these modules deploy multi-region resources (e.g., GuardDuty, AWS Config, etc), and for each region, Terraform spins up a separate process, so if you don't limit the parallelism, it may peg all your CPU cores and lead to network connectivity errors.
 
+Include all the settings from the root terragrunt.hcl file:
+
+.infrastructure-live/stage/_global/account-baseline/terragrunt.hcl
+[source,hcl]
+----
+include {
+  path = find_in_parent_folders()
+}
+----
+
 Set the variables for the `account-baseline-app` module in this environment in the `inputs = { ... }` block of `terragrunt.hcl`:
 
 .infrastructure-live/stage/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
+locals {
+  # A local for more convenient access to the accounts map.
+  accounts = local.common_vars.locals.accounts
+
+  # A local for convenient access to the security account root ARN.
+  security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
+}
+
 inputs = {
-  # Fill in your region you want to use (only used for API calls) and the ID of your security AWS account
-  aws_region     = "us-east-2"
-  aws_account_id = "<STAGE_ACCOUNT_ID>"
-
-  # Prefix all resources with this name
-  name_prefix = "<COMPANY_NAME>-stage"
-
-  # Use the S3 bucket and KMS key that were already created in this logs account by account-baseline-root
+  # Use the S3 bucket and KMS key that were already created in the logs account by account-baseline-root
   cloudtrail_s3_bucket_name = "<CLOUDTRAIL_BUCKET_NAME>"
   cloudtrail_kms_key_arn    = "<CLOUDTRAIL_KMS_KEY_ARN>"
 
-  # Use the S3 bucket that was already created in this logs account by account-baseline-root
+  # Use the S3 bucket that was already created in the logs account by account-baseline-root
   config_s3_bucket_name                            = "<CONFIG_BUCKET_NAME>"
   config_aggregate_config_data_in_external_account = true
-  config_central_account_id                        = "<LOGS_ACCOUNT_ID>"
+  config_central_account_id                        = local.accounts.logs
 
   # Specify the services the dev IAM role will have access to
   dev_permitted_services = ["ec2", "s3", "rds", "dynamodb", "elasticache", "eks", "ecs"]
@@ -2818,13 +2049,19 @@ inputs = {
   auto_deploy_permissions = ["cloudwatch:*", "logs:*", "dynamodb:*", "ecr:*", "ecs:*", "iam:GetPolicy", "iam:GetPolicyVersion", "iam:ListEntitiesForPolicy", "eks:DescribeCluster", "route53:*", "s3:*", "autoscaling:*", "elasticloadbalancing:*", "iam:GetRole", "iam:GetRolePolicy", "iam:PassRole"]
 
   # Allow users in the security account to access the IAM roles in this account
-  allow_read_only_access_from_other_account_arns = ["arn:aws:iam::<SECURITY_ACCOUNT_ID>:root"]
-  allow_billing_access_from_other_account_arns   = ["arn:aws:iam::<SECURITY_ACCOUNT_ID>:root"]
-  allow_dev_access_from_other_account_arns       = ["arn:aws:iam::<SECURITY_ACCOUNT_ID>:root"]
-  allow_full_access_from_other_account_arns      = ["arn:aws:iam::<SECURITY_ACCOUNT_ID>:root"]
+  allow_read_only_access_from_other_account_arns = [local.security_account_root_arn]
+  allow_billing_access_from_other_account_arns   = [local.security_account_root_arn]
+  allow_dev_access_from_other_account_arns       = [local.security_account_root_arn]
+  allow_full_access_from_other_account_arns      = [local.security_account_root_arn]
 
-  # Allow a CI server in the shared-services account to assume the auto-deploy IAM role in this account
-  allow_auto_deploy_from_other_account_arns      = ["arn:aws:iam::<SHARED_SERVICES_ACCOUNT_ID>:root"]
+  # A list of account root ARNs that should be able to assume the auto deploy role.
+  allow_auto_deploy_from_other_account_arns = [
+    # External CI/CD systems may use an IAM user in the security account to perform deployments.
+    local.security_account_root_arn,
+
+    # The shared-services account contains automation and infrastructure tools, such as CI/CD systems.
+    "arn:aws:iam::${local.accounts.shared}:root",
+  ]
 }
 ----
 
@@ -2844,16 +2081,6 @@ The code above does the following:
 . **Configure cross-account IAM roles**. We then specify which other accounts are allowed to assume the IAM roles in
   this account. For the most part, we grant all permissions to the security account, so that by assigning users to IAM
   groups in that account, you'll be able to access IAM roles in all the other child accounts.
-
-Configure your Terraform backend:
-
-.infrastructure-live/stage/_global/account-baseline/terragrunt.hcl
-[source,hcl]
-----
-include {
-  path = find_in_parent_folders()
-}
-----
 
 Just as with the logs and security accounts, you're going to use the `OrganizationAccountAccessRole` IAM role created by
 `account-baseline-root` to authenticate to the stage account and all other child accounts. There are many ways to
@@ -2897,9 +2124,9 @@ aws-vault exec stage-from-root -- terragrunt apply
 ----
 
 [.exceptional]
-IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 1024`.
+IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 10240`.
 
-Remember to repeat this process in the other child accounts too (i.e., dev, prod, shared-services, etc)!
+Remember to repeat this process in the other child accounts too (i.e., dev, prod, shared, etc)!
 
 === Try authenticating as an IAM user to the child accounts
 

--- a/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
+++ b/_posts/2019-08-12-how-to-configure-production-grade-aws-account-structure.adoc
@@ -919,26 +919,35 @@ link:/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library#dep
 ====
 
 Now we're going to make some HCL files that store variables to be used across your modules. _You won't be able to fill
-everything out just yet._ Your AWS account IDs will be generated after applying the account-baseline-root to the root
+everything out just yet._ Your AWS account IDs will be generated after applying the `account-baseline-root` to the root
 account. At that point you can update these files. Create them now to have them ready to use.
+
+For example, assuming `us-east-1` is your default region, your directory structure would look like the following, with
+`_global` and `<region>` directories in each account directory:
 
 ----
 infrastructure-live
+  └ common.hcl
+  └ accounts.json
   └ terragrunt.hcl
-  └ landingzone
-    └ account-baseline-root
-    └ account-baseline-app
-      └ main.tf
-      └ outputs.tf
-      └ variables.tf
+  └ dev
+  └ logs
+  └ stage
+  └ security
+  └ shared
+  └ prod
+    └ _global
+      └ region.hcl
+    └ us-east-1
+      └ region.hcl
 ----
 
-The Terraform modules in the Service Catalog are missing some required blocks for Terraform to operate (e.g., the
-`provider` and `terraform` state backend blocks). This is by design, to allow the modules to be flexibly used in
+The Terraform modules in the Service Catalog do not define some blocks that are required for Terraform to operate
+(e.g., the `provider` and `terraform` state backend blocks). This is to allow the modules to be flexibly used in
 different contexts. We'll define a root `terragrunt.hcl` that injects these these required blocks.
 
 Create a `terragrunt.hcl` at the root of your infrastructure-live repo and insert the following contents. As you can
-see, it references `common`, `account`, and `region` hcl files which we'll create shortly.
+see, it references `common`, `account`, and `region` HCL files which we'll create shortly.
 
 .infrastructure-live/terragrunt.hcl
 [source,hcl]

--- a/assets/css/global.less
+++ b/assets/css/global.less
@@ -1611,7 +1611,7 @@ h6, .h6 { .heading-margin-variant(0.68; 0.52; @line-height-h6); }
 }
 code{
   background: none;
-  color: whitesmoke;
+  color: inherit;
   font-size: 87%;
 }
 


### PR DESCRIPTION
This updates the Landing Zone guide to remove mention of `infrastructure-modules` and use the Service Catalog instead, v0.41.4.

Note: it does take into account all the comments from the previous PR https://github.com/gruntwork-io/gruntwork-io.github.io/pull/387, which did not include removing `infrastructure-modules`.