### PR TITLE
Follow up: CIS Compliance guide fixes 

### DIFF
--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -962,7 +962,7 @@ Configure the `account-baseline-root` for the root account
 [.exceptional]
 IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork Compliance subscriber# to access the Gruntwork Infrastructure as Code Library and the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/[CIS AWS Foundations Benchmark modules].
 
-First, let's set consider the repository structure that is recommended by this guide. It is available for your reference in the "/examples/for-production" section in the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. Consider the following directory structure for your `infrastructure-live` repository. It showcases the configuration files foryour local variables.
+First, let's set consider the repository structure that is recommended by this guide. It is available for your reference in the "/examples/for-production" section in the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. Consider the following directory structure for your `infrastructure-live` repository. It showcases the configuration files for your local variables.
 
 ----
 .

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -1514,7 +1514,7 @@ inputs = {
   # All of the other accounts send logs to this account.
   config_linked_accounts = [
   for name, id in local.accounts :
-  id if name != "logs"
+    id if name != "logs"
   ]
 
   ################################
@@ -1528,7 +1528,7 @@ inputs = {
   cloudtrail_allow_kms_describe_key_to_external_aws_accounts = true
   cloudtrail_external_aws_account_ids_with_write_access = [
   for name, id in local.accounts :
-  id if name != "logs"
+    id if name != "logs"
   ]
 
   # The ARN is a key alias, not a key ID. This variable prevents a perpetual diff when using an alias.
@@ -1813,7 +1813,7 @@ input = {
   # Allow these accounts to have read access to IAM groups and the public SSH keys of users in the group.
   allow_ssh_grunt_access_from_other_account_arns = [
     for name, id in local.accounts :
-    "arn:aws:iam::${id}:root" if name != "security"
+      "arn:aws:iam::${id}:root" if name != "security"
   ]
 
   # A list of account root ARNs that should be able to assume the auto deploy role.

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -588,8 +588,8 @@ Use the link:https://www.terraform.io/docs/providers/aws/r/cloudtrail.html[`aws_
 is_multi_region_trail         = true
 include_global_service_events = true
 enable_log_file_validation    = true
-s3_bucket_name                = local.cloudtrail_s3_bucket_name
-cloud_watch_logs_group_arn    = local.cloudtrail_cloudwatch_group_arn
+s3_bucket_name                = "<YOUR CLOUDTRAIL BUCKET NAME>"
+cloud_watch_logs_group_arn    = "<YOUR CLOUDWATCH LOGS GROUP ARN>"
 
 event_selector {
   read_write_type           = "All"
@@ -597,7 +597,7 @@ event_selector {
 
   data_resource {
     type   = "AWS::S3::Object"
-    values = ["${local.cloudtrail_s3_bucket_arn}"]
+    values = ["<YOUR CLOUDTRAIL BUCKET ARN>"]
   }
 }
 ----
@@ -938,10 +938,10 @@ so using a virtual or hardware MFA device is preferable; that said, MFA with SMS
 
 [[deployment_approach]]
 === Deployment approach
-Before we dive into the code and deployment for each of the resources, let's take a step back and understand how the code is structured.
-Most of the features explained in the <<production_grade_design>> section will be deployed by using the Landing Zone solution, and some more standalone modules like the VPC module.
+Before we dive into the code and deployment for each resource, let's take a step back and understand how the code is structured.
+Most of the features explained in the <<production_grade_design>> section will be deployed using the Landing Zone solution, and some more standalone modules like the VPC module.
 
-The Landing Zone will be deployed in three steps - the `account-baseline-root` to set up your organisation-wide configurations, create the necessary child AWS accounts, set up the CloudTrail and AWS Config buckets. Next, we'll need to apply the `account-baseline-app` against the created logs account, adding more settings that will be used for aggregation of logs and metrics from the whole organization. Then the `account-baseline-security` will be applied, and that's responsible to set up your IAM roles, groups that would allow you to access the rest of the accounts within your organization. And finally, the `account-baseline-app` will be applied to an AWS account with the purpose of hosting an application.
+The Landing Zone will be deployed in three steps - the `account-baseline-root` to set up your organization-wide configurations, create the necessary child AWS accounts, set up the CloudTrail and AWS Config buckets. Next, we'll need to apply the `account-baseline-app` against the created logs account, adding more settings that will be used for aggregation of logs and metrics from the whole organization. Then the `account-baseline-security` will be applied, and that's responsible to set up your IAM roles and groups that would allow you to access the rest of the accounts within your organization. And finally, the `account-baseline-app` will be applied to an AWS account with the purpose of hosting an application.
 
 The standalone modules will follow the pattern of referencing the module and providing the necessary input variables for it, then applying with `terragrunt`.
 
@@ -950,14 +950,13 @@ The standalone modules will follow the pattern of referencing the module and pro
 
 ==== Apply the `account-baseline-root` to the root account
 
-===== Configure the `account-baseline-root` for the root account
+Configure the `account-baseline-root` for the root account
 
 [.exceptional]
 IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork Compliance subscriber# to access the Gruntwork Infrastructure as Code Library and the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/[CIS AWS Foundations Benchmark modules].
 
 First, let's set consider the repository structure that is recommended by this guide. It is available for your reference in the "/examples/for-production" section in the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. Consider the following directory structure for your `infrastructure-live` repository. It showcases the configuration files foryour local variables.
 
-[source]
 ----
 .
 └ infrastructure-live
@@ -971,7 +970,7 @@ First, let's set consider the repository structure that is recommended by this g
     └ accounts.json
 ----
 
-Each of the `region.hcl`, `account.hcl` and `common.hcl` should contain the relevant information, so in your modules you're able to reference the values like this:
+Each of the `region.hcl`, `accounts.hcl` and `common.hcl` should contain the relevant information, so in your modules, you're able to reference the values like this:
 
 [source, hcl]
 ----
@@ -993,7 +992,7 @@ locals {
 }
 ----
 
-You'll need to create these files in order to be able to follow the code examples following. For examples on what to put in each of these files, refer to the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. The `locals` configuration above can be used in each of the `terragrunt.hcl` files to help you avoid repetition. Note that the examples below won't show this in the interest of clarity.
+You'll need to create these files to be able to follow the code examples following. For examples on what to put in each of these files, refer to the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. Each of the `terragrunt.hcl` files will use the above `locals` configuration to help you avoid repetition. Note that the examples below won't show this in the interest of clarity.
 
 Next, we'll configure the `account-baseline-root` with settings needed for creating all the child accounts - AWS Organizations, IAM Roles, IAM Users, IAM Groups, IAM Password Policies, Amazon GuardDuty, AWS CloudTrail, AWS Config and Security Hub.
 

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -943,13 +943,22 @@ https://www.schneier.com/blog/archives/2016/08/nist_is_no_long.html[no longer re
 https://www.theverge.com/2017/9/18/16328172/sms-two-factor-authentication-hack-password-bitcoin[vulnerabilities with the cellular system],
 so using a virtual or hardware MFA device is preferable; that said, MFA with SMS is still better than no MFA at all.
 
+[[deployment_approach]]
+== Deployment approach
+Before we dive into the code and deployment for each of the resources, let's take a step back and understand how the code is structured.
+Most of the features explained in the "Production-grade design" section will be deployed by using the Landing Zone solution, and some more standalone modules like the VPC module.
+
+The Landing Zone will be deployed in three steps - the `account-baseline-root` to set up your organisation-wide configurations, and create the necessary child AWS accounts. Next, we'll need to apply the `account-baseline-app` baseline against the created logs account, which would in its turn set up the CloudTrail, AWS Config buckets and a few more settings that will be used for aggregation of logs and metrics from the whole organization. Then the `account-baseline-security` will be applied, and that's responsible to set up your IAM roles, groups that would allow you to access the rest of the accounts within your organization. And finally, the `account-baseline-app` will be applied to an AWS account with the purpose of hosting an application.
+
+The standalone modules will follow the pattern of referencing the module and providing the necessary input variables for it, then applying with `terragrunt`.
+
+[[deploy_landingzone]]
+== Deploy Landing Zone solution
 
 === Configure the "account-baseline-root" baseline for the root account
 
 [.exceptional]
 IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork subscriber# to access https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/[`terraform-aws-cis-service-catalog`].
-
-Before we dive into the code and deployment for each of the resources, let's take a step back and understand how the code is structured. Most of the features explained in the "Production-grade design" section will be deployed by using the Landing Zone solution, and some more standalone modules. The Landing Zone will be deployed in three steps - the `account-baseline-root` to set up your organisation-wide configurations, and create the necessary child AWS accounts. Then the `account-baseline-security` will be applied, and that's responsible to set up your IAM roles, groups that would allow you to access the rest of the accounts within your organization. And finally, the `account-baseline-app` will be applied to an AWS account with the purpose of hosting an application.
 
 First, let's set consider the repository structure that is recommended by this guide. It is available for your reference in the "/examples/for-production" section in the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. It looks like this:
 
@@ -957,13 +966,15 @@ First, let's set consider the repository structure that is recommended by this g
 ----
 Consider the following directory structure for your `infrastructure-live` repository. It showcases the configuration files foryour local variables.
 .
-├── prod
-│ ├── _global
-│    └── region.hcl
-│ ├── account.hcl
-│ └── us-east-1
-│    └── region.hcl
-└── common.hcl
+└ infrastructure-live
+    └ prod
+        └ account.hcl
+        └ global
+            └ region.hcl
+        └ us-east-1
+            └ region.hcl
+    └ common.hcl
+    └ accounts.json
 ----
 
 Each of the `region.hcl`, `account.hcl` and `common.hcl` should contain the relevant information, so in your modules you're able to reference the values like this:
@@ -1312,7 +1323,7 @@ we need to temporarily hard-code some of the `region` and `role_arn` parameters 
 [source,bash]
 ----
 terragrunt aws-provider-patch \
-  --terragrunt-override-attr region="eu-west-1" \
+  --terragrunt-override-attr region="${local.aws_region}" \
   --terragrunt-override-attr assume_role.role_arn=""
 ----
 
@@ -1331,7 +1342,7 @@ aws-vault exec root-iam-user -- terragrunt import \
 You should see log output that looks something like this:
 
 ----
-[terragrunt] 2020/10/13 14:19:16 Running command: terraform import module.root_baseline.module.iam_users.aws_iam_user.user["alice"] alice
+[terragrunt] 2021/05/13 14:19:16 Running command: terraform import module.root_baseline.module.iam_users.aws_iam_user.user["alice"] alice
 module.root_baseline.module.iam_users.aws_iam_user.user["alice"]: Importing from ID "alice"...
 module.root_baseline.module.iam_users.aws_iam_user.user["alice"]: Import prepared!
   Prepared aws_iam_user for import
@@ -1415,7 +1426,7 @@ cloudtrail_s3_bucket_name = "<CLOUDTRAIL_BUCKET_NAME>"
 config_s3_bucket_name     = "<CONFIG_BUCKET_NAME>"
 ----
 
-Take note of all of this data, as you'll need it again shortly! This is exactly the place where your `common.hcl` comes in handy - add all of these values in there as locals.
+Take note of all of this data, as you'll need it again shortly! This is exactly the place where your `common.hcl` comes in handy - add all of these values in there as `locals`.
 
 One other useful output will be the encrypted passwords for any IAM users you created:
 
@@ -1504,7 +1515,7 @@ locals {
   cloudtrail_s3_bucket_name = local.cloudtrail_s3_bucket_name
 
   # The Cloudtrail KMS Key is deployed at the logs account but it's value is an output from the root account.
-  cloudtrail_kms_key_arn = "arn:aws:kms:${local.aws_region}:${local.accounts.logs}:alias/cloudtrail-acme"
+  cloudtrail_kms_key_arn = "arn:aws:kms:${local.aws_region}:${local.accounts.logs}:alias/${cloudtrail_kms_key_arn}"
 
   # A local for convenient access to the security account root ARN.
   security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
@@ -1568,26 +1579,6 @@ inputs = {
   ##################################
   # Cross-account IAM role permissions
   ##################################
-
-  # By granting access to the root ARN of the Security account in each of the roles below,
-  # we allow administrators to further delegate access to other IAM entities
-
-  # A role that allows administrator access to the account.
-  allow_full_access_from_other_account_arns = [local.security_account_root_arn]
-
-  # A role for developers to use to access services in the account.
-  # Access to services is managed using the dev_permitted_services input.
-  allow_dev_access_from_other_account_arns = [local.security_account_root_arn]
-
-  # Assuming the developers role will grant access to these services.
-  dev_permitted_services = [
-    "ec2",
-    "ecs",
-    "lambda",
-    "rds",
-    "elasticache",
-    "route53",
-  ]
 
   # A role to allow users that can view and modify AWS account billing information.
   allow_billing_access_from_other_account_arns = [local.security_account_root_arn]
@@ -1664,7 +1655,7 @@ You should see JSON output indicating that you've successfully assumed an IAM ro
 }
 ----
 
-You're now ready to deploy the `account-baseline` module in the logs account by running `terragrunt apply`:
+You're now ready to deploy the `account-baseline-app` in the logs account by running `terragrunt apply`:
 
 [source,bash]
 ----
@@ -1676,7 +1667,7 @@ aws-vault exec logs-from-root -- terragrunt apply
 IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 1024`.
 
 [[apply_account_baseline_security]]
-=== Apply the security baseline to the security account
+=== Apply the `account-baseline-security` to the security account
 
 Now that your logs accounts is fully configured, you need to apply the security baseline to the security account, which
 is where all your IAM users and groups will be defined and managed.
@@ -1726,11 +1717,11 @@ locals {
   accounts = local.accounts
 
   # Both buckets are created in the logs account by account-baseline-root
-  config_s3_bucket_name     = "acme-config-bucket-logs"
-  cloudtrail_s3_bucket_name = "acme-cloudtrail-logs"
+  config_s3_bucket_name     = local.config_s3_bucket_name
+  cloudtrail_s3_bucket_name = local.cloudtrail_s3_bucket_name
 
   # The Cloudtrail KMS Key is deployed at the logs account but it's value is an output from the root account.
-  cloudtrail_kms_key_arn = "arn:aws:kms:${local.aws_region}:${local.accounts.logs}:alias/cloudtrail-acme"
+  cloudtrail_kms_key_arn = "arn:aws:kms:${local.aws_region}:${local.accounts.logs}:alias/${cloudtrail_kms_key_arn}"
 
   # A local for convenient access to the security account root ARN.
   security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
@@ -1794,46 +1785,22 @@ input = {
       "arn:aws:iam::${id}:root" if name != "security"
   ]
 
-  # A list of account root ARNs that should be able to assume the auto deploy role.
-  allow_auto_deploy_from_other_account_arns = [
-    # External CI/CD systems may use an IAM user in the security account to perform deployments.
-    "arn:aws:iam::${local.accounts.security}:root",
-
-    # The shared account contains automation and infrastructure tools, such as CI/CD systems.
-    "arn:aws:iam::${local.accounts.shared}:root",
-  ]
-  auto_deploy_permissions = [
-    "iam:GetRole",
-    "iam:GetRolePolicy",
-  ]
-
-  # Configures the auto deploy max session duration to be 4 hours
-  max_session_duration_machine_users = 14400
-
-  # Configures the max session duration for roles that humans use to be 8 hours
-  max_session_duration_human_users = 28800
   # IAM users
-
   users = {
     alice = {
-      groups               = ["user-self-mgmt", "ssh-sudo-users", "_account.dev-full-access"]
+      groups               = ["user-self-mgmt", "ssh-sudo-users"]
       pgp_key              = "keybase:alice_on_keybase"
       create_login_profile = true
       create_access_keys   = false
     }
 
     bob = {
-      groups               = ["user-self-mgmt", "_account.dev-full-access", "_account.prod-read-only"]
+      groups               = ["user-self-mgmt", "_account.prod-read-only"]
       pgp_key              = "keybase:bob_on_keybase"
       create_login_profile = true
       create_access_keys   = false
     }
   }
-
-
-  ##################################
-  # CIS compliance settings
-  ##################################
 
   security_hub_associate_to_master_account_id = local.accounts.root
 }
@@ -1928,14 +1895,14 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 ----
 
 
-=== Apply the security baseline to the other child accounts
+=== Apply the `account-baseline-app` to the other child accounts
 
-Now that your security account is fully configured, you need to apply the security baseline to the remaining child
+Now that your **security** account is fully configured, you need to apply the security baseline to the remaining child
 accounts (e.g., dev, stage, prod, shared-services). Feel free to adjust this as necessary based on the accounts your
 company needs.
 
 Create `terragrunt.hcl` files in `infrastructure-live` under the file paths `<ACCOUNT>/_global/account-baseline`,
-where `<ACCOUNT>` is one of these other child accounts, such as dev, stage, prod, and shared-services. In the rest of
+where `<ACCOUNT>` is one of these other child accounts, such as `dev`, `stage`, `prod`, and `shared-services`. In the rest of
 this example, we’ll look solely at the stage account, but make sure you follow the analogous steps for EACH of your
 child accounts.
 
@@ -1983,11 +1950,11 @@ locals {
   accounts = local.accounts
 
   # Both buckets are created in the logs account by account-baseline-root
-  config_s3_bucket_name     = "acme-config-bucket-logs"
-  cloudtrail_s3_bucket_name = "acme-cloudtrail-logs"
+  config_s3_bucket_name     = local.config_s3_bucket_name
+  cloudtrail_s3_bucket_name = local.cloudtrail_s3_bucket_name
 
   # The Cloudtrail KMS Key is deployed at the logs account but it's value is an output from the root account.
-  cloudtrail_kms_key_arn = "arn:aws:kms:${local.aws_region}:${local.accounts.logs}:alias/cloudtrail-acme"
+  cloudtrail_kms_key_arn = "arn:aws:kms:${local.aws_region}:${local.accounts.logs}:alias/${local.cloudtrail_kms_key_arn}"
 
   # A local for convenient access to the security account root ARN.
   security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
@@ -2038,27 +2005,6 @@ inputs = {
   ##################################
   # Cross-account IAM role permissions
   ##################################
-
-  # By granting access to the root ARN of the Security account in each of the roles below,
-  # we allow administrators to further delegate access to other IAM entities
-
-  # A role that allows administrator access to the account.
-  allow_full_access_from_other_account_arns = [local.security_account_root_arn]
-
-  # A role for developers to use to access services in the account.
-  # Access to services is managed using the dev_permitted_services input.
-  allow_dev_access_from_other_account_arns = [local.security_account_root_arn]
-
-  # Assuming the developers role will grant access to these services.
-  dev_permitted_services = [
-    "ec2",
-    "ecs",
-    "lambda",
-    "rds",
-    "elasticache",
-    "route53",
-  ]
-
   # A role to allow users that can view and modify AWS account billing information.
   allow_billing_access_from_other_account_arns = [local.security_account_root_arn]
 
@@ -2068,22 +2014,8 @@ inputs = {
   # A role that allows access to support only.
   allow_support_access_from_other_account_arns = [local.security_account_root_arn]
 
-  # A list of account root ARNs that should be able to assume the auto deploy role.
-  allow_auto_deploy_from_other_account_arns = [
-    # External CI/CD systems may use an IAM user in the security account to perform deployments.
-    local.security_account_root_arn,
-
-    # The shared account contains automation and infrastructure tools, such as CI/CD systems.
-    "arn:aws:iam::${local.accounts.shared}:root",
-  ]
-
-  # Assuming the auto-deploy role will grant access to these services.
-  auto_deploy_permissions = [
-    "iam:GetRole",
-    "iam:GetRolePolicy",
-  ]
-
   service_linked_roles = ["autoscaling.amazonaws.com"]
+
   ##################################
   # KMS grants
   ##################################
@@ -2107,10 +2039,6 @@ inputs = {
       ]
     }
   }
-
-  ##################################
-  # CIS compliance settings
-  ##################################
 
   security_hub_associate_to_master_account_id = local.accounts.root
 }
@@ -2143,7 +2071,7 @@ include {
 }
 ----
 
-Just as with the logs and security accounts, you're going to use the `OrganizationAccountAccessRole` IAM role created by
+Just as with the **logs** and **security** accounts, you're going to use the `OrganizationAccountAccessRole` IAM role created by
 `account-baseline-root` to authenticate to the stage account and all other child accounts. There are many ways to
 https://blog.gruntwork.io/a-comprehensive-guide-to-authenticating-to-aws-on-the-command-line-63656a686799[assume an IAM role on the CLI];
 for this guide, we're going to keep using `aws-vault`.
@@ -2176,7 +2104,7 @@ You should see JSON output indicating that you've successfully assumed an IAM ro
 }
 ----
 
-You're now ready to deploy the `account-baseline` module in the stage account by running `terragrunt apply`:
+You're now ready to deploy the `account-baseline-app` in the **stage** account by running `terragrunt apply`:
 
 [source,bash]
 ----
@@ -2286,43 +2214,29 @@ link:https://github.com/gruntwork-io/terraform-aws-security/blob/master/modules/
 to create KMS keys with key rotation enabled by default.
 
 [[vpc_flow_logs]]
-==== Create VPC flow logs
+== Create VPC flow logs
 The Benchmark recommends enabling link:https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html[VPC Flow Logs]
 for all VPCs in all regions. You can use the
 link:https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/master/modules/networking/vpc[`vpc` service]
 in the AWS CIS Service Catalog to create your VPCs. This service is configured for CIS compliance, and as such has VPC flow
-logs enabled. For example, you might create a VPC using the VPC service:
+logs enabled. See the examples below:
 
-.infrastructure-modules/networking/vpc/myvpc/main.tf
+.infrastructure-live/prod/us-east-1/prod/networking/vpc/terragrunt.hcl
 [source,hcl]
 ----
-
-module "vpc" {
-  # Replace <VERSION> with the most recent release from https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases
-  source = "git::git@github.com:gruntwork-io/terraform-aws-cis-service-catalog.git//modules/networking/vpc?ref=<VERSION>"
-
-  vpc_name                                                = var.vpc_name
-  aws_region                                              = var.aws_region
-  cidr_block                                              = var.cidr_block
-  num_nat_gateways                                        = var.num_nat_gateways
-  allow_administrative_remote_access_cidrs_public_subnets = var.allow_administrative_remote_access_cidrs_public_subnets
-  kms_key_user_iam_arns = [
-    "arn:aws:iam::${local.common_vars.locals.accounts[local.account_name]}:root",
-  ]
-}
-
-
 # ---------------------------------------------------------------------------------------------------------------------
 # MODULE PARAMETERS
 # These are the variables we have to pass in to use the module specified in the terragrunt configuration above
 # ---------------------------------------------------------------------------------------------------------------------
 inputs = {
-  vpc_name         = "mgmt"
+  vpc_name         = "app"
   num_nat_gateways = 1
   cidr_block       = local.cidr_block
   kms_key_user_iam_arns = [
     "arn:aws:iam::${local.common_vars.locals.accounts[local.account_name]}:root",
   ]
+  eks_cluster_names    = ["${local.name_prefix}-${local.account_name}"]
+  tag_for_use_with_eks = true
 
   allow_administrative_remote_access_cidrs_public_subnets = merge(
     {
@@ -2334,46 +2248,51 @@ inputs = {
 }
 ----
 
-Under the hood, the service will enable VPC flow logs. All that's remaining is to define the parameters in a `variables.tf`:
+In here you'll still need to reference the `locals` configuration, and ensure that you're setting the right `source` to the module, so add this to your `terragrunt.hcl` file too:
 
-.infrastructure-modules/networking/vpc/myvpc/variables.tf
 [source,hcl]
 ----
-variable "aws_region" {
-  description = "The AWS region to deploy to (e.g. us-east-1)"
-  type        = string
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder. If you're iterating
+# locally, you can use --terragrunt-source /path/to/local/checkout/of/module to override the source parameter to a
+# local check out of the module for faster iteration.
+terraform {
+  # We're using a local file path here just so our automated tests run against the absolute latest code. However, when
+  # using these modules in your code, you should use a Git URL with a ref attribute that pins you to a specific version:
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-cis-service-catalog.git//modules/networking/vpc?ref=v0.20.0"
+  source = "${get_parent_terragrunt_dir()}/../../..//modules/networking/vpc"
 }
 
-variable "vpc_name" {
-  description = "The name of the VPC to create"
-  type        = string
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
 }
 
-variable "cidr_block" {
-  description = "The IP address range of the app VPC in CIDR notation."
-  type        = string
-}
+# ---------------------------------------------------------------------------------------------------------------------
+# Locals are named constants that are reusable within the configuration.
+# ---------------------------------------------------------------------------------------------------------------------
+locals {
+  # Automatically load common variables shared across all accounts
+  common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))
 
-variable "num_nat_gateways" {
-  description = "The number of NAT Gateways to launch for this VPC."
-  type        = number
-}
+  # Extract the name prefix for easy access
+  name_prefix = local.common_vars.locals.name_prefix
 
-variable "allow_administrative_remote_access_cidrs_public_subnets" {
-  description = "A map of CIDR blocks that will be allowed access to administrative ports (e.g., SSH, RDP) in the public subnet tier."
-  type        = map(string)
+  # Automatically load account-level variables
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
 
-  # Example:
-  #
-  #   default = {
-  #    UsOffice = "1.2.3.4/32"
-  #    EuOffice = "5.6.7.8/32"
-  # }
+  # Extract the account_name for easy access
+  account_name = local.account_vars.locals.account_name
+
+  # Automatically load region-level variables
+  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  # Extract the region for easy access
+  aws_region = local.region_vars.locals.aws_region
+
+  cidr_block = local.common_vars.locals.app_vpc_cidrs[local.account_name]
 }
 ----
-
-Refer to the VPC
-link:https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-learning-and-testing/networking/vpc/terraform[example code].
 
 To limit the number of flow logs, you may want to use the
 link:https://github.com/gruntwork-io/cloud-nuke[`cloud-nuke defaults-aws`] command. It will remove the default VPC from
@@ -2408,12 +2327,13 @@ when creating VPCs. These variables are used to create appropriate Network ACL R
 VPC using the `vpc` service from `terraform-aws-cis-service-catalog`:
 
 ----
-infrastructure-modules
-└── networking
-    └── vpc
-        └── myvpc
-            ├── main.tf
-            └── variables.tf
+infrastructure-live
+└── prod
+    └── us-east-1
+        └── prod
+            └─ networking
+                └─ vpc
+                    └─ terragrunt.hcl
 ----
 
 .infrastructure-modules/networking/vpc/myvpc/main.tf

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -944,12 +944,53 @@ https://www.theverge.com/2017/9/18/16328172/sms-two-factor-authentication-hack-p
 so using a virtual or hardware MFA device is preferable; that said, MFA with SMS is still better than no MFA at all.
 
 
-=== Configure the security baseline for the root account
+=== Configure the "account-baseline-root" baseline for the root account
 
 [.exceptional]
-IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork subscriber# to access `terraform-aws-cis-service-catalog`.
+IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork subscriber# to access https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/[`terraform-aws-cis-service-catalog`].
 
-Next, we'll configure a security baseline for the root account that is responsible for creating all the child accounts.
+Before we dive into the code and deployment for each of the resources, let's take a step back and understand how the code is structured. Most of the features explained in the "Production-grade design" section will be deployed by using the Landing Zone solution, and some more standalone modules. The Landing Zone will be deployed in three steps - the `account-baseline-root` to set up your organisation-wide configurations, and create the necessary child AWS accounts. Then the `account-baseline-security` will be applied, and that's responsible to set up your IAM roles, groups that would allow you to access the rest of the accounts within your organization. And finally, the `account-baseline-app` will be applied to an AWS account with the purpose of hosting an application.
+
+First, let's set consider the repository structure that is recommended by this guide. It is available for your reference in the "/examples/for-production" section in the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. It looks like this:
+
+[source]
+----
+Consider the following directory structure for your `infrastructure-live` repository. It showcases the configuration files foryour local variables.
+.
+├── prod
+│ ├── _global
+│    └── region.hcl
+│ ├── account.hcl
+│ └── us-east-1
+│    └── region.hcl
+└── common.hcl
+----
+
+Each of the `region.hcl`, `account.hcl` and `common.hcl` should contain the relevant information, so in your modules you're able to reference the values like this:
+
+[source, hcl]
+----
+locals {
+  # Automatically load common variables shared across all accounts
+  common_vars = read_terragrunt_config(find_in_parent_folders("common.hcl"))
+
+  # Automatically load account-level variables
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract the account_name for easy access
+  account_name = local.account_vars.locals.account_name
+
+  # Automatically load region-level variables
+  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  # Extract the region for easy access
+  aws_region = local.region_vars.locals.aws_region
+}
+----
+
+You'll need to create these files in order to be able to follow the code examples following. For examples on what to put in each of these files, refer to the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. The `locals` configuration above can be used in each of the `terragrunt.hcl` files to help you avoid repetition. Note that the examples below won't show this in the interest of clarity.
+
+Next, we'll configure the `account-baseline-root` baseline for the root account that is responsible for creating all the child accounts.
 It will also configure AWS Organizations, IAM Roles, IAM Users, IAM Groups, IAM Password Policies, Amazon GuardDuty, AWS CloudTrail, AWS Config and Security Hub.
 
 We'll be using the `landingzone/account-baseline-root` module from https://github.com/gruntwork-io/terraform-aws-cis-service-catalog[terraform-aws-cis-service-catalog].
@@ -963,19 +1004,20 @@ Next, create a `terragrunt.hcl` file in `infrastructure-live`. It should go unde
 
 ----
 infrastructure-live
-  └ root
+  └ prod
     └ _global
+      └ region.hcl
       └ account-baseline
         └ terragrunt.hcl
 ----
 Point the `source` URL in your `terragrunt.hcl` file to the `account-baseline-root` module in the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog[terraform-aws-cis-service-catalog]
 repo, setting the `ref` param to the version you require:
 
-.infrastructure-live/root/_global/account-baseline/terragrunt.hcl
+.infrastructure-live/prod/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
 terraform {
-  source = "git::git@github.com/gruntwork-io/terraform-aws-cis-service-catalog//modules/landingzone/account-baseline-app?ref=v0.22.0"
+  source = "git::git@github.com/gruntwork-io/terraform-aws-cis-service-catalog//modules/landingzone/account-baseline-root?ref=v0.22.0"
 
   # This module deploys some resources (e.g., AWS Config) across all AWS regions, each of which needs its own provider,
   # which in Terraform means a separate process. To avoid all these processes thrashing the CPU, which leads to network
@@ -992,7 +1034,7 @@ IMPORTANT: We **strongly** recommend setting Terraform parallelism to a low valu
 
 Set the variables for the `account-baseline-root` module in this environment in the `inputs = { ... }` block of `terragrunt.hcl`:
 
-.infrastructure-live/root/_global/account-baseline/terragrunt.hcl
+.infrastructure-live/prod/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
 locals {
@@ -1121,7 +1163,7 @@ address, `root-accounts@acme.com`.
 . **Mark one of the child accounts as a logs account**. We set `is_logs_account = true` on one of the child accounts
 to indicate it is the logs account where we will aggregate AWS Config, CloudTrail, IAM Access Analyzer and Security Hub data from all the other accounts.
 The `account-baseline-root` module will automatically create an S3 bucket for AWS Config and an S3 bucket and KMS CMK
-for CloudTrail in this account and configure the root account to send all the AWS Config and CloudTrail data to these
+= for CloudTrail in this account and configure the root account to send all the AWS Config and CloudTrail data to these
 S3 buckets. Later on, you'll configure all the other accounts to send their data to these S3 buckets too.
 
 . **Create IAM groups**. By default, `account-baseline-root` will **not** create a `full-access` IAM group as CIS requirement 1.16 guides. It will create a `support` and a `billing` IAM group (for the support and finance teams).
@@ -1210,7 +1252,7 @@ An easy way to get it is to run `plan`:
 
 [source,bash]
 ----
-cd infrastructure-live/root/_global/account-baseline
+cd infrastructure-live/prod/_global/account-baseline
 aws-vault exec root-iam-user -- terragrunt plan
 ----
 
@@ -1323,7 +1365,7 @@ in the root account as in the previous two sections. To apply the security basel
 
 [source,bash]
 ----
-cd infrastructure-live/root/_global/account-baseline
+cd infrastructure-live/prod/_global/account-baseline
 aws-vault exec root-iam-user -- terragrunt apply
 ----
 
@@ -1373,7 +1415,7 @@ cloudtrail_s3_bucket_name = "<CLOUDTRAIL_BUCKET_NAME>"
 config_s3_bucket_name     = "<CONFIG_BUCKET_NAME>"
 ----
 
-Take note of all of this data, as you'll need it again shortly!
+Take note of all of this data, as you'll need it again shortly! This is exactly the place where your `common.hcl` comes in handy - add all of these values in there as locals.
 
 One other useful output will be the encrypted passwords for any IAM users you created:
 
@@ -1409,16 +1451,16 @@ for each of those child accounts—including enabling MFA and deleting the root 
 those root users again.
 
 [[apply_account_baseline_logs]]
-=== Apply the security baseline to the logs account
+=== Apply the `account-baseline-app` baseline to the logs account
 
-The next step is to configure the logs account, which is used to aggregate AWS Config and CloudTrail data from all the
+The next step is to configure the **logs** account, which is used to aggregate AWS Config and CloudTrail data from all the
 other accountss.
 
 Create a `terragrunt.hcl` file in `infrastructure-live` under the file path `logs/_global/account-baseline`:
 
 ----
 infrastructure-live
-  └ root
+  └ prod
   └ logs
     └ _global
       └ account-baseline
@@ -1458,8 +1500,8 @@ locals {
   accounts = local.accounts
 
   # Both buckets are created in the logs account by account-baseline-root
-  config_s3_bucket_name     = "acme-config-bucket-logs"
-  cloudtrail_s3_bucket_name = "acme-cloudtrail-logs"
+  config_s3_bucket_name     = local.config_s3_bucket_name
+  cloudtrail_s3_bucket_name = local.cloudtrail_s3_bucket_name
 
   # The Cloudtrail KMS Key is deployed at the logs account but it's value is an output from the root account.
   cloudtrail_kms_key_arn = "arn:aws:kms:${local.aws_region}:${local.accounts.logs}:alias/cloudtrail-acme"
@@ -1555,27 +1597,6 @@ inputs = {
 
   # A role that allows access to support only.
   allow_support_access_from_other_account_arns = [local.security_account_root_arn]
-
-  # A list of account root ARNs that should be able to assume the auto deploy role.
-  allow_auto_deploy_from_other_account_arns = [
-    # External CI/CD systems may use an IAM user in the security account to perform deployments.
-    local.security_account_root_arn,
-
-    # The shared account contains automation and infrastructure tools, such as CI/CD systems.
-    "arn:aws:iam::${local.accounts.shared}:root",
-  ]
-
-  # Assuming the auto-deploy role will grant access to these services.
-  auto_deploy_permissions = [
-    "iam:GetRole",
-    "iam:GetRolePolicy",
-  ]
-
-  service_linked_roles = ["autoscaling.amazonaws.com"]
-
-  ##################################
-  # CIS compliance settings
-  ##################################
 
   security_hub_associate_to_master_account_id = local.accounts.root
 }
@@ -1912,10 +1933,6 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 Now that your security account is fully configured, you need to apply the security baseline to the remaining child
 accounts (e.g., dev, stage, prod, shared-services). Feel free to adjust this as necessary based on the accounts your
 company needs.
-
-You can re-use the `account-baseline-app` module you created earlier in your `infrastructure-modules` repo for all of
-these child accounts; this module can be used interchangeably between app accounts and log accounts as they deploy most
-of the same resources.
 
 Create `terragrunt.hcl` files in `infrastructure-live` under the file paths `<ACCOUNT>/_global/account-baseline`,
 where `<ACCOUNT>` is one of these other child accounts, such as dev, stage, prod, and shared-services. In the rest of
@@ -2289,6 +2306,31 @@ module "vpc" {
   cidr_block                                              = var.cidr_block
   num_nat_gateways                                        = var.num_nat_gateways
   allow_administrative_remote_access_cidrs_public_subnets = var.allow_administrative_remote_access_cidrs_public_subnets
+  kms_key_user_iam_arns = [
+    "arn:aws:iam::${local.common_vars.locals.accounts[local.account_name]}:root",
+  ]
+}
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  vpc_name         = "mgmt"
+  num_nat_gateways = 1
+  cidr_block       = local.cidr_block
+  kms_key_user_iam_arns = [
+    "arn:aws:iam::${local.common_vars.locals.accounts[local.account_name]}:root",
+  ]
+
+  allow_administrative_remote_access_cidrs_public_subnets = merge(
+    {
+      for cidr in local.common_vars.locals.ip_allow_list
+      : index(local.common_vars.locals.ip_allow_list, cidr) => cidr
+    },
+    { length(local.common_vars.locals.ip_allow_list) = local.cidr_block }
+  )
 }
 ----
 
@@ -2377,20 +2419,33 @@ infrastructure-modules
 .infrastructure-modules/networking/vpc/myvpc/main.tf
 [source,hcl]
 ----
-module "vpc" {
-  # Replace <VERSION> with the most recent release from the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/releases:
-  source = "git::git@github.com:gruntwork-io/terraform-aws-cis-service-catalog.git//modules/networking/vpc?ref=<VERSION>"
-
-  # Set the basic required variables first
-  vpc_name         = var.vpc_name
-  aws_region       = var.aws_region
-  cidr_block       = var.cidr_block
-  num_nat_gateways = var.num_nat_gateways
+terraform { # We're using a local file path here just so our automated tests run against the absolute latest code. However, when
+  # using these modules in your code, you should use a Git URL with a ref attribute that pins you to a specific version:
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-cis-service-catalog.git//modules/networking/vpc-mgmt?ref=v0.20.0"
+  source = "${get_parent_terragrunt_dir()}/../../..//modules/networking/vpc-mgmt"
+----
+[source, hcl]
+----
+inputs = {
+  vpc_name         = "mgmt"
+  num_nat_gateways = 1
+  cidr_block       = local.cidr_block
+  kms_key_user_iam_arns = [
+    "arn:aws:iam::${local.common_vars.locals.accounts[local.account_name]}:root",
+  ]
 
   # Next, pass values for the allow_administrative_remote_access_* variables, thus creating the NACL rules under the hood
-  allow_administrative_remote_access_cidrs_public_subnets              = var.allow_administrative_remote_access_cidrs
   allow_administrative_remote_access_cidrs_private_app_subnets         = { all_app_vpc_cidrs  = module.vpc.vpc_cidr_block }
   allow_administrative_remote_access_cidrs_private_persistence_subnets = { all_app_vpc_cidrs  = module.vpc.vpc_cidr_block }
+
+  allow_administrative_remote_access_cidrs_public_subnets = merge(
+    {
+      for cidr in local.common_vars.locals.ip_allow_list
+      : index(local.common_vars.locals.ip_allow_list, cidr) => cidr
+    },
+    { length(local.common_vars.locals.ip_allow_list) = local.cidr_block }
+  )
+}
 ----
 
 Refer to the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-learning-and-testing/networking/vpc/terraform[terraform-aws-cis-service-catalog]

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -961,7 +961,7 @@ First, let's set consider the repository structure that is recommended by this g
 ----
 .
 └ infrastructure-live
-    └ prod
+    └ root
         └ account.hcl
         └ global
             └ region.hcl
@@ -1009,7 +1009,7 @@ Next, create a `terragrunt.hcl` file in `infrastructure-live`. It should go unde
 
 ----
 infrastructure-live
-  └ prod
+  └ root
     └ _global
       └ region.hcl
       └ account-baseline
@@ -1018,7 +1018,7 @@ infrastructure-live
 Point the `source` URL in your `terragrunt.hcl` file to the `account-baseline-root` module in the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog[terraform-aws-cis-service-catalog]
 repo, setting the `ref` param to the version you require:
 
-.infrastructure-live/prod/_global/account-baseline/terragrunt.hcl
+.infrastructure-live/root/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
 terraform {
@@ -1039,7 +1039,7 @@ IMPORTANT: We **strongly** recommend setting Terraform parallelism to a low valu
 
 Set the variables for the `account-baseline-root` module in this environment in the `inputs = { ... }` block of `terragrunt.hcl`:
 
-.infrastructure-live/prod/_global/account-baseline/terragrunt.hcl
+.infrastructure-live/root/_global/account-baseline/terragrunt.hcl
 [source,hcl]
 ----
 locals {
@@ -1257,7 +1257,7 @@ An easy way to get it is to run `plan`:
 
 [source,bash]
 ----
-cd infrastructure-live/prod/_global/account-baseline
+cd infrastructure-live/root/_global/account-baseline
 aws-vault exec root-iam-user -- terragrunt plan
 ----
 
@@ -1370,7 +1370,7 @@ in the root account as in the previous two sections. To apply the security basel
 
 [source,bash]
 ----
-cd infrastructure-live/prod/_global/account-baseline
+cd infrastructure-live/root/_global/account-baseline
 aws-vault exec root-iam-user -- terragrunt apply
 ----
 
@@ -1465,7 +1465,7 @@ Create a `terragrunt.hcl` file in `infrastructure-live` under the file path `log
 
 ----
 infrastructure-live
-  └ prod
+  └ root
   └ logs
     └ _global
       └ account-baseline
@@ -1891,7 +1891,7 @@ echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 ==== Apply the `account-baseline-app` to the other child accounts
 
 Now that your **security** account is fully configured, you need to apply the security baseline to the remaining child
-accounts (e.g., dev, stage, prod, shared-services). Feel free to adjust this as necessary based on the accounts your
+accounts (e.g., `dev`, `stage`, `prod`, `shared-services`). Feel free to adjust this as necessary based on the accounts your
 company needs.
 
 Create `terragrunt.hcl` files in `infrastructure-live` under the file paths `<ACCOUNT>/_global/account-baseline`,
@@ -2014,7 +2014,7 @@ inputs = {
   ##################################
 
   # These grants allow the autoscaling service-linked role to access to the AMI encryption key so that it
-  # can launch instances from AMIs that were shared from the shared-services account.
+  # can launch instances from AMIs that were shared from the `shared-services` account.
   kms_grant_regions = {
     ami_encryption_key = local.aws_region
   }
@@ -2047,7 +2047,7 @@ The code above does the following:
 the services specified in `dev_permitted_services`.
 
 . **Configure the Auto Deploy IAM role**. We also create an `auto-deploy` IAM role that can be assumed by a CI server
-in the shared-services account to do deployments. This role will have the permissions specified in
+in the `shared-services` account to do deployments. This role will have the permissions specified in
 `auto_deploy_permissions`.
 
 . **Configure cross-account IAM roles**. We then specify which other accounts are allowed to assume the IAM roles in
@@ -2108,7 +2108,7 @@ aws-vault exec stage-from-root -- terragrunt apply
 [.exceptional]
 IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 1024`.
 
-.Remember to repeat this process in the other child accounts too (i.e., dev, prod, shared-services, etc)!
+.Remember to repeat this process in the other child accounts too (i.e., `dev`, `prod`, `shared-services`, etc)!
 
 **Next, try authenticating as an IAM user to the child accounts:**
 
@@ -2126,7 +2126,7 @@ IMPORTANT: On some operating systems, such as MacOS, you may also need to increa
   https://github.com/gruntwork-io/module-security/tree/master/modules/cross-account-iam-roles#resources-created[here]).
 . Alternatively, you can use the `aws-vault login xxx` command to login to the AWS Web Console for any profile `xxx`
   that you've configured in `aws-vault`. For example, `aws-vault login logs-from-root` will open up your web browser
-  and log you into the logs account using the `OrganizationAccountAccessRole` IAM Role.
+  and log you into the `logs` account using the `OrganizationAccountAccessRole` IAM Role.
 
 [[configure_security_hub]]
 **Configure AWS Security Hub in the root account**
@@ -2212,7 +2212,7 @@ link:https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/mast
 in the AWS CIS Service Catalog to create your VPCs. This service is configured for CIS compliance, and as such has VPC flow
 logs enabled. See the examples below:
 
-.infrastructure-live/prod/us-east-1/prod/networking/vpc/terragrunt.hcl
+.infrastructure-live/root/us-east-1/prod/networking/vpc/terragrunt.hcl
 [source,hcl]
 ----
 # ---------------------------------------------------------------------------------------------------------------------
@@ -2319,7 +2319,7 @@ VPC using the `vpc` service from `terraform-aws-cis-service-catalog`:
 
 ----
 infrastructure-live
-└── prod
+└── root
     └── us-east-1
         └── prod
             └─ networking

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -589,7 +589,7 @@ is_multi_region_trail         = true
 include_global_service_events = true
 enable_log_file_validation    = true
 s3_bucket_name                = local.cloudtrail_s3_bucket_name
-cloud_watch_logs_group_arn    = local.cloudtrail_s3_bucket_arn
+cloud_watch_logs_group_arn    = local.cloudtrail_cloudwatch_group_arn
 
 event_selector {
   read_write_type           = "All"
@@ -597,7 +597,7 @@ event_selector {
 
   data_resource {
     type   = "AWS::S3::Object"
-    values = ["${local.cloudtrail_s3_bucket_name}"]
+    values = ["${local.cloudtrail_s3_bucket_arn}"]
   }
 }
 ----
@@ -963,7 +963,7 @@ First, let's set consider the repository structure that is recommended by this g
 └ infrastructure-live
     └ root
         └ account.hcl
-        └ global
+        └ _global
             └ region.hcl
         └ us-east-1
             └ region.hcl
@@ -995,8 +995,7 @@ locals {
 
 You'll need to create these files in order to be able to follow the code examples following. For examples on what to put in each of these files, refer to the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. The `locals` configuration above can be used in each of the `terragrunt.hcl` files to help you avoid repetition. Note that the examples below won't show this in the interest of clarity.
 
-Next, we'll configure the `account-baseline-root` baseline for the root account that is responsible for creating all the child accounts.
-It will also configure AWS Organizations, IAM Roles, IAM Users, IAM Groups, IAM Password Policies, Amazon GuardDuty, AWS CloudTrail, AWS Config and Security Hub.
+Next, we'll configure the `account-baseline-root` with settings needed for creating all the child accounts - AWS Organizations, IAM Roles, IAM Users, IAM Groups, IAM Password Policies, Amazon GuardDuty, AWS CloudTrail, AWS Config and Security Hub.
 
 We'll be using the `landingzone/account-baseline-root` module from https://github.com/gruntwork-io/terraform-aws-cis-service-catalog[terraform-aws-cis-service-catalog].
 
@@ -1415,14 +1414,15 @@ child_accounts = {
     # (...)
   }
 }
-cloudtrail_kms_key_arn    = "<CLOUDTRAIL_KMS_KEY_ARN>"
-cloudtrail_s3_bucket_name = "<CLOUDTRAIL_BUCKET_NAME>"
-config_s3_bucket_name     = "<CONFIG_BUCKET_NAME>"
+cloudtrail_kms_key_arn          = "<CLOUDTRAIL_KMS_KEY_ARN>"
+cloudtrail_s3_bucket_name       = "<CLOUDTRAIL_BUCKET_NAME>"
+config_s3_bucket_name           = "<CONFIG_BUCKET_NAME>"
+cloudtrail_cloudwatch_group_arn = "<CLOUDWATCH_GROUP_ARN>"
 ----
 
-Take note of all of this data, as you'll need it again shortly! This is exactly the place where your `common.hcl` comes in handy - add all of these values in there as `locals`.
+Add all of these values in your `common.hcl` file as `locals`. You will need to refer to these values often.
 
-One other useful output will be the encrypted passwords for any IAM users you created:
+Keep a note also of the encrypted passwords for any IAM users you created:
 
 [source,hcl]
 ----

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -944,7 +944,7 @@ https://www.theverge.com/2017/9/18/16328172/sms-two-factor-authentication-hack-p
 so using a virtual or hardware MFA device is preferable; that said, MFA with SMS is still better than no MFA at all.
 
 [[deployment_approach]]
-== Deployment approach
+=== Deployment approach
 Before we dive into the code and deployment for each of the resources, let's take a step back and understand how the code is structured.
 Most of the features explained in the "Production-grade design" section will be deployed by using the Landing Zone solution, and some more standalone modules like the VPC module.
 
@@ -953,9 +953,9 @@ The Landing Zone will be deployed in three steps - the `account-baseline-root` t
 The standalone modules will follow the pattern of referencing the module and providing the necessary input variables for it, then applying with `terragrunt`.
 
 [[deploy_landingzone]]
-== Deploy Landing Zone solution
+=== Deploy Landing Zone solution
 
-=== Configure the "account-baseline-root" baseline for the root account
+==== 1. Configure the "account-baseline-root" baseline for the root account
 
 [.exceptional]
 IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork subscriber# to access https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/[`terraform-aws-cis-service-catalog`].
@@ -1238,7 +1238,7 @@ You should get JSON output with information about your IAM user:
 You're now almost ready to deploy the `account-baseline` module in the root account. But first, you may need to import
 some existing resources.
 
-=== Import existing resources from the root account
+==== 2. Import existing resources from the root account
 
 Before applying the security baseline to the root account, we need to import any existing resources—including the IAM
 user you created manually earlier—into Terraform state, so that Terraform manages those existing resources instead of
@@ -1369,7 +1369,7 @@ rm -rf .terragrunt-cache
 ----
 
 [[apply_account_baseline_root]]
-=== Apply the security baseline to the root account
+==== 3. Apply the security baseline to the root account
 
 You're now ready to apply the security baseline to the root account. You should be authenticated as the same IAM user
 in the root account as in the previous two sections. To apply the security baseline, you run `terragrunt apply`:
@@ -1446,7 +1446,7 @@ Each user can then decrypt the password on their own computer (which should have
 echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 ----
 
-=== Reset the root user password in each child account
+===== Reset the root user password in each child account
 
 When creating the child accounts, you may have noticed that you provided an email address for each root user, but
 confusingly, not a password. So how do you login as the root user then? It's not obvious, but the answer is that you
@@ -1455,14 +1455,14 @@ using the "Forgot your password?" prompt on the https://console.aws.amazon.com/[
 you a reset link, which you can click to go to a page that will allow you to configure a password for the root user.
 Use this process to reset the password for the root user of each child account you created.
 
-=== Lock down the root user in the child accounts
+===== Lock down the root user in the child accounts
 
 Once you're able to access the root user of each child account, you should follow the steps in <<lock_down_root_user>>
 for each of those child accounts—including enabling MFA and deleting the root user's access keys—and (almost) never use
 those root users again.
 
 [[apply_account_baseline_logs]]
-=== Apply the `account-baseline-app` baseline to the logs account
+==== 4. Apply the `account-baseline-app` baseline to the logs account
 
 The next step is to configure the **logs** account, which is used to aggregate AWS Config and CloudTrail data from all the
 other accountss.
@@ -1667,7 +1667,7 @@ aws-vault exec logs-from-root -- terragrunt apply
 IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 1024`.
 
 [[apply_account_baseline_security]]
-=== Apply the `account-baseline-security` to the security account
+==== 5. Apply the `account-baseline-security` to the security account
 
 Now that your logs accounts is fully configured, you need to apply the security baseline to the security account, which
 is where all your IAM users and groups will be defined and managed.
@@ -2115,12 +2115,9 @@ aws-vault exec stage-from-root -- terragrunt apply
 [.exceptional]
 IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 1024`.
 
-Remember to repeat this process in the other child accounts too (i.e., dev, prod, shared-services, etc)!
+.Remember to repeat this process in the other child accounts too (i.e., dev, prod, shared-services, etc)!
 
-=== Try authenticating as an IAM user to the child accounts
-
-Now that you have IAM users in the security account and IAM roles in the other accounts, it's time to practice
-authenticating:
+**Next, try authenticating as an IAM user to the child accounts:**
 
 . Use your IAM user's user name and password (decrypted using keybase) to log into the web console of the security
   account (remember to use the IAM user sign-in URL for the security account).
@@ -2139,7 +2136,7 @@ authenticating:
   and log you into the logs account using the `OrganizationAccountAccessRole` IAM Role.
 
 [[configure_security_hub]]
-=== Configure AWS Security Hub in the root account
+**Configure AWS Security Hub in the root account**
 
 Next, we'll configure link:https://aws.amazon.com/security-hub/[AWS Security Hub] in the root account. AWS Security Hub
 is deployed by the account baselines in every enabled region of an AWS account to check your account link:https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards.html[for compliance]
@@ -2155,7 +2152,7 @@ compliance; it is a failure of the AWS audit tool. Note also that the accounts a
 the benchmark, v1.3.0; the AWS Security Hub does not support this version at the current time.
 
 [[iam_roles_for_instances]]
-=== Use IAM roles for EC2 instances
+**Use IAM roles for EC2 instances**
 All Gruntwork modules that require AWS API access use roles rather than an IAM user with static API credentials for
 authentication. For example:
 
@@ -2174,7 +2171,7 @@ Use these modules whenever possible. You should always use IAM roles in your own
 access to the AWS API. Using static API credentials should be avoided whenever possible.
 
 [[maintain_compliance_iam]]
-=== Maintaining compliance by following IAM best practices
+**Maintaining compliance by following IAM best practices**
 We conclude the IAM section with a few parting words of wisdom for maintaining compliance over time:
 
 . Do not attach any policies without requiring MFA.
@@ -2189,10 +2186,10 @@ the use of root].  Fortunately, most of these activities are rare, so usage of t
 a minimum.
 
 [[maintain_compliance_storage]]
-=== Maintaining compliance by following Storage best practices
+**Maintaining compliance by following Storage best practices**
 
 [[s3_buckets_deployment]]
-==== S3 Buckets
+**S3 Buckets**
 To make sure your S3 buckets are compliant with the benchmark, use the
 link:https://github.com/gruntwork-io/terraform-aws-security/tree/master/modules/private-s3-bucket[`private-s3-bucket` module]
 to create and manage all of your S3 buckets. This module blocks public access and enforces encryption by default. Note
@@ -2202,19 +2199,20 @@ You can either use the `private-s3-bucket` module in your own modules, or, if yo
 from the Gruntwork Service Catalog.
 
 [[maintain_compliance_logging]]
-=== Maintaining compliance by following Logging best practices
+**Maintaining compliance by following Logging best practices**
 
 The logging section of the Benchmark includes configurations for CloudTrail, AWS Config, KMS keys, and VPC
 flow logs.
 
 [[kms]]
-==== Enable key rotation for KMS keys
+**Enable key rotation for KMS keys**
 To make sure your KMS keys are compliant with the benchmark, use the
 link:https://github.com/gruntwork-io/terraform-aws-security/blob/master/modules/kms-master-key/README.md[`kms-master-key` module]
 to create KMS keys with key rotation enabled by default.
 
 [[vpc_flow_logs]]
-== Create VPC flow logs
+=== Create VPC flow logs
+
 The Benchmark recommends enabling link:https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html[VPC Flow Logs]
 for all VPCs in all regions. You can use the
 link:https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/blob/master/modules/networking/vpc[`vpc` service]

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -775,7 +775,7 @@ automatically.
 [[gruntwork_solution]]
 === The Gruntwork solution
 Gruntwork offers battle-tested infrastructure as code modules to help you create production grade infrastructure in a
-fraction of the time it would take to develop from scratch. Each of the core modules are "compliance-ready"; they are
+fraction of the time it would take you to develop from scratch. Each of the core modules are "compliance-ready"; they are
 mostly unopinionated by default, but they can be configured for compliance with the right settings.
 
 To further simplify and expedite compliance, the Gruntwork CIS Service Catalog uses both standalone compliance
@@ -2144,7 +2144,7 @@ with the AWS CIS Foundations Benchmark. The Security Hub runs the exact audit st
 Config managed rules. _Note: Security Hub is not explicitly required by the Benchmark, however we suggest enabling it,
 so you can track your compliance efforts and be notified if any recommendations have not been implemented._
 
-In order to ensure the Security Hub dashboard shows a positive score, you will need to follow these link:https://gruntwork.io/guides/compliance/how-to-achieve-cis-benchmark-compliance/#identity-and-access-management-2[Manual Steps]
+TIP: In order to ensure the Security Hub dashboard shows a positive score, you will need to follow these link:https://gruntwork.io/guides/compliance/how-to-achieve-cis-benchmark-compliance/#identity-and-access-management-2[Manual Steps]
 to complete CIS compliance. These steps cannot be automated using AWS APIs. Additionally, in the AWS Console UI, AWS Security
 Hub will show a low security score for the CIS AWS Foundations Benchmark v1.2.0. This is due to AWS limitations on
 checking compliance standards for cross-region/cross-account rules. This does not indicate that the accounts are not in

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -1586,12 +1586,6 @@ inputs = {
     "iam:GetRolePolicy",
   ]
 
-  # Configures the auto deploy max session duration to be 4 hours.
-  max_session_duration_machine_users = 14400
-
-  # Configures the max session duration for roles that humans use to be 8 hours.
-  max_session_duration_human_users = 28800
-
   service_linked_roles = ["autoscaling.amazonaws.com"]
 
   ##################################

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -588,8 +588,8 @@ Use the link:https://www.terraform.io/docs/providers/aws/r/cloudtrail.html[`aws_
 is_multi_region_trail         = true
 include_global_service_events = true
 enable_log_file_validation    = true
-s3_bucket_name                = <YOUR BUCKET NAME>
-cloud_watch_logs_group_arn    = <YOUR CLOUDWATCH LOGS GROUP ARN>
+s3_bucket_name                = local.
+cloud_watch_logs_group_arn    = local.
 
 event_selector {
   read_write_type           = "All"
@@ -597,7 +597,7 @@ event_selector {
 
   data_resource {
     type   = "AWS::S3::Object"
-    values = [<YOUR BUCKET ARN>]
+    values = [${local.}]
   }
 }
 ----
@@ -996,10 +996,10 @@ Set the variables for the `account-baseline-root` module in this environment in 
 [source,hcl]
 ----
 locals {
-  aws_region = "us-east-1"
+  aws_region = local.aws_region
 
   accounts = {
-    root = "216044045972"
+    root = local.accounts.root
   }
 
   # Both buckets will created in the logs account by account-baseline-root
@@ -1101,12 +1101,6 @@ inputs = {
     "iam:GetRole",
     "iam:GetRolePolicy",
   ]
-
-  # Configures the auto deploy max session duration to be 4 hours.
-  max_session_duration_machine_users = 14400
-
-  # Configures the max session duration for roles that humans use to be 8 hours.
-  max_session_duration_human_users = 28800
 }
 ----
 
@@ -1166,7 +1160,7 @@ Enter Secret Key: YYYYYYYYYYYY
 You should also enable MFA for the IAM user (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_virtual.html)[see the AWS docs on enabling a virtual MFA device]) and add the configuration to your profile as follows:
 [source,bash]
 ----
-mfa_serial=arn:aws:iam::<YOUR_ROOT_ACCOUNT_ID>:mfa/<YOUR_IAM_USER>
+mfa_serial=arn:aws:iam::${local.accounts.root}:mfa/<YOUR_IAM_USER>
 ----
 
 Next, https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html[install the AWS CLI], and check that
@@ -1183,8 +1177,8 @@ You should get JSON output with information about your IAM user:
 ----
 {
   "UserId": "AIDAXXXXXXXXXXXX",
-  "Account": "<ROOT_ACCOUNT_ID>",
-  "Arn": "arn:aws:iam::<ROOT_ACCOUNT_ID>:user/<YOUR_IAM_USER>"
+  "Account": "${local.accounts.logs}",
+  "Arn": "arn:aws:iam::${local.accounts.root}:user/<YOUR_IAM_USER>"
 }
 ----
 
@@ -1459,24 +1453,16 @@ Set the variables for the `account-baseline-app` module in this environment in t
 [source,hcl]
 ----
 locals {
-  aws_region = "us-east-1"
+  aws_region = local.aws_region
 
-  accounts = {
-    logs     = "409800740445"
-    security = "673123100581"
-    shared   = "384759303421"
-    dev      = "293847503945"
-    stage    = "384924092834"
-    prod     = "784260063686"
-    root     = "216044045972"
-  }
+  accounts = local.accounts
 
   # Both buckets are created in the logs account by account-baseline-root
   config_s3_bucket_name     = "acme-config-bucket-logs"
   cloudtrail_s3_bucket_name = "acme-cloudtrail-logs"
 
   # The Cloudtrail KMS Key is deployed at the logs account but it's value is an output from the root account.
-  cloudtrail_kms_key_arn = "arn:aws:kms:us-east-1:409800740445:alias/cloudtrail-acme"
+  cloudtrail_kms_key_arn = "arn:aws:kms:${local.aws_region}:${local.accounts.logs}:alias/cloudtrail-acme"
 
   # A local for convenient access to the security account root ARN.
   security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
@@ -1635,7 +1621,7 @@ Add a new `profile` entry in `~/.aws/config` for your logs account that uses the
 [source,text]
 ----
 [profile logs-from-root]
-role_arn=arn:aws:iam::<LOGS_ACCOUNT_ID>:role/OrganizationAccountAccessRole
+role_arn=arn:aws:iam::${local.accounts.logs}:role/OrganizationAccountAccessRole
 source_profile=root-iam-user
 ----
 
@@ -1652,8 +1638,8 @@ You should see JSON output indicating that you've successfully assumed an IAM ro
 ----
 {
   "UserId": "AIDAXXXXXXXXXXXX:1111111111111111111",
-  "Account": "<LOGS_ACCOUNT_ID>",
-  "Arn": "arn:aws:sts::<LOGS_ACCOUNT_ID>:assumed-role/OrganizationAccountAccessRole/1111111111111111111"
+  "Account": "${local.accounts.logs}",
+  "Arn": "arn:aws:sts::${local.accounts.logs}:assumed-role/OrganizationAccountAccessRole/1111111111111111111"
 }
 ----
 
@@ -1714,24 +1700,16 @@ Set the variables for the `account-baseline-security` module in this environment
 [source,hcl]
 ----
 locals {
-  aws_region = "us-east-1"
+  aws_region = local.aws_region
 
-  accounts = {
-    logs     = "409800740445"
-    security = "673123100581"
-    shared   = "384759303421"
-    dev      = "293847503945"
-    stage    = "384924092834"
-    prod     = "784260063686"
-    root     = "216044045972"
-  }
+  accounts = local.accounts
 
   # Both buckets are created in the logs account by account-baseline-root
   config_s3_bucket_name     = "acme-config-bucket-logs"
   cloudtrail_s3_bucket_name = "acme-cloudtrail-logs"
 
   # The Cloudtrail KMS Key is deployed at the logs account but it's value is an output from the root account.
-  cloudtrail_kms_key_arn = "arn:aws:kms:us-east-1:${local.accounts.logs}:alias/cloudtrail-acme"
+  cloudtrail_kms_key_arn = "arn:aws:kms:${local.aws_region}:${local.accounts.logs}:alias/cloudtrail-acme"
 
   # A local for convenient access to the security account root ARN.
   security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
@@ -1983,24 +1961,16 @@ Set the variables for the `account-baseline-app` module in this environment in t
 [source,hcl]
 ----
 locals {
-  aws_region = "us-east-1"
+  aws_region = local.aws_region
 
-  accounts = {
-    logs     = "409800740445"
-    security = "673123100581"
-    shared   = "384759303421"
-    dev      = "293847503945"
-    stage    = "384924092834"
-    prod     = "784260063686"
-    root     = "216044045972"
-  }
+  accounts = local.accounts
 
   # Both buckets are created in the logs account by account-baseline-root
   config_s3_bucket_name     = "acme-config-bucket-logs"
   cloudtrail_s3_bucket_name = "acme-cloudtrail-logs"
 
   # The Cloudtrail KMS Key is deployed at the logs account but it's value is an output from the root account.
-  cloudtrail_kms_key_arn = "arn:aws:kms:us-east-1:${local.accounts.logs}:alias/cloudtrail-acme"
+  cloudtrail_kms_key_arn = "arn:aws:kms:${local.aws_region}:${local.accounts.logs}:alias/cloudtrail-acme"
 
   # A local for convenient access to the security account root ARN.
   security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
@@ -2108,7 +2078,7 @@ inputs = {
   }
   kms_grants = {
     ami_encryption_key = {
-      kms_cmk_arn       = "arn:aws:kms:us-east-1:${local.accounts.shared}:alias/ami-encryption"
+      kms_cmk_arn       = "arn:aws:kms:${local.aws_region}:${local.accounts.shared}:alias/ami-encryption"
       grantee_principal = "arn:aws:iam::${local.accounts[local.account_name]}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
       granted_operations = [
         "Encrypt",

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -774,17 +774,11 @@ automatically.
 
 [[gruntwork_solution]]
 === The Gruntwork solution
-Gruntwork offers battle-tested infrastructure as code modules to help you create production grade infrastructure in a
-fraction of the time it would take you to develop from scratch. Each of the core modules are "compliance-ready"; they are
-mostly unopinionated by default, but they can be configured for compliance with the right settings.
+Gruntwork offers infrastructure-as-code battle-tested modules that will help you create _production-grade_ infrastructure faster and much more efficiently than if you develop your modules from scratch. In the CIS compliance library, there are many core modules, and each one of them is "compliance-ready". They are configured in a way to help you achieve CIS compliance up to the latest supported benchmark, but still allow some flexibility in the setup.
 
-To further simplify and expedite compliance, the Gruntwork CIS Service Catalog uses both standalone compliance
-modules as well as "wrappers" around the core, unopinionated modules in the Infrastructure as Code Library. The
-standalone compliance modules are designed with the compliance requirements built-in, whereas the wrappers
-call the core modules with configuration values that are compliant with the AWS Foundations Benchmark. You can use both
-types of modules by creating a module of your own (in the case of the wrapper modules, this can be considered a second
-wrapper) and using the compliance module as the `source`. Optionally, you can also use `terragrunt` to call your module,
-thus creating a chain of IaC modules.
+The compliance library is known as "Gruntwork CIS Service Catalog" and it has its own standalone modules, or could be building on top of the existing standard & non-compliant core modules from the "Standard Service Catalog" or "Infrastructure as Code Library". Each of these modules can be used on their own, or within "wrappers" (explained later) by passing in the required inputs and using `terraform` or `terragrunt`.
+
+The image below shows the hierarchy between the different levels of modules from the different code libraries Gruntwork offers.
  +
  +
 

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -588,8 +588,8 @@ Use the link:https://www.terraform.io/docs/providers/aws/r/cloudtrail.html[`aws_
 is_multi_region_trail         = true
 include_global_service_events = true
 enable_log_file_validation    = true
-s3_bucket_name                = local.
-cloud_watch_logs_group_arn    = local.
+s3_bucket_name                = local.cloudtrail_s3_bucket_name
+cloud_watch_logs_group_arn    = local.cloudtrail_s3_bucket_arn
 
 event_selector {
   read_write_type           = "All"
@@ -597,7 +597,7 @@ event_selector {
 
   data_resource {
     type   = "AWS::S3::Object"
-    values = [${local.}]
+    values = ["${local.cloudtrail_s3_bucket_name}"]
   }
 }
 ----
@@ -1177,7 +1177,7 @@ You should get JSON output with information about your IAM user:
 ----
 {
   "UserId": "AIDAXXXXXXXXXXXX",
-  "Account": "${local.accounts.logs}",
+  "Account": "${local.accounts.root}",
   "Arn": "arn:aws:iam::${local.accounts.root}:user/<YOUR_IAM_USER>"
 }
 ----

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -523,7 +523,7 @@ statement {
   effect  = "Deny"
   actions = ["s3:*"]
   resources = [
-    <YOUR BUCKET ARN>,
+    "<YOUR BUCKET ARN>",
     "${<YOUR BUCKET ARN>}/*"
   ]
   principals {
@@ -899,7 +899,6 @@ The only time you'll need it is for account recovery situations (e.g., you accid
 your credentials) or for the
 https://docs.aws.amazon.com/general/latest/gr/aws_tasks-that-require-root.html[small number of tasks that require root user credentials].
 
-
 [[create_iam_user_in_root]]
 === Create an IAM user in the root account
 
@@ -953,11 +952,11 @@ The Landing Zone will be deployed in three steps - the `account-baseline-root` t
 The standalone modules will follow the pattern of referencing the module and providing the necessary input variables for it, then applying with `terragrunt`.
 
 [[deploy_landingzone]]
-== Deploy Landing Zone solution
+=== Deploy Landing Zone solution
 
-=== Deploy the `account-baseline-root` to the root account
+==== Apply the `account-baseline-root` to the root account
 
-==== 1. Configure the `account-baseline-root` for the root account
+===== Configure the `account-baseline-root` for the root account
 
 [.exceptional]
 IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork subscriber# to access https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/[`terraform-aws-cis-service-catalog`].
@@ -1240,7 +1239,7 @@ You should get JSON output with information about your IAM user:
 You're now almost ready to deploy the `account-baseline` module in the root account. But first, you may need to import
 some existing resources.
 
-==== 2. Import existing resources from the root account
+===== Import existing resources from the root account
 
 Before applying the security baseline to the root account, we need to import any existing resources—including the IAM
 user you created manually earlier—into Terraform state, so that Terraform manages those existing resources instead of
@@ -1371,7 +1370,7 @@ rm -rf .terragrunt-cache
 ----
 
 [[apply_account_baseline_root]]
-==== 3. Apply the `account-baseline-root` baseline to the root account
+===== Apply the `account-baseline-root` baseline to the root account
 
 You're now ready to apply the security baseline to the root account. You should be authenticated as the same IAM user
 in the root account as in the previous two sections. To apply the security baseline, you run `terragrunt apply`:
@@ -1448,7 +1447,7 @@ Each user can then decrypt the password on their own computer (which should have
 echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 ----
 
-==== 4. Reset the root user password in each child account
+===== Reset the root user password in each child account
 
 When creating the child accounts, you may have noticed that you provided an email address for each root user, but
 confusingly, not a password. So how do you login as the root user then? It's not obvious, but the answer is that you
@@ -1457,14 +1456,14 @@ using the "Forgot your password?" prompt on the https://console.aws.amazon.com/[
 you a reset link, which you can click to go to a page that will allow you to configure a password for the root user.
 Use this process to reset the password for the root user of each child account you created.
 
-==== 5. Lock down the root user in the child accounts
+===== Lock down the root user in the child accounts
 
 Once you're able to access the root user of each child account, you should follow the steps in <<lock_down_root_user>>
 for each of those child accounts—including enabling MFA and deleting the root user's access keys—and (almost) never use
 those root users again.
 
 [[apply_account_baseline_logs]]
-=== Apply the `account-baseline-app` baseline to the logs account
+==== Apply the `account-baseline-app` to the logs account
 
 The next step is to configure the **logs** account, which is used to aggregate AWS Config and CloudTrail data from all the
 other accountss.
@@ -1669,7 +1668,7 @@ aws-vault exec logs-from-root -- terragrunt apply
 IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 1024`.
 
 [[apply_account_baseline_security]]
-=== Apply the `account-baseline-security` to the security account
+==== Apply the `account-baseline-security` to the security account
 
 Now that your logs accounts is fully configured, you need to apply the security baseline to the security account, which
 is where all your IAM users and groups will be defined and managed.
@@ -1896,7 +1895,7 @@ decrypt the password on their own computer (which should have their PGP key) as 
 echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 ----
 
-=== Apply the `account-baseline-app` to the other child accounts
+==== Apply the `account-baseline-app` to the other child accounts
 
 Now that your **security** account is fully configured, you need to apply the security baseline to the remaining child
 accounts (e.g., dev, stage, prod, shared-services). Feel free to adjust this as necessary based on the accounts your
@@ -2298,7 +2297,7 @@ link:https://github.com/gruntwork-io/cloud-nuke[`cloud-nuke defaults-aws`] comma
 all regions in an account, saving you the hassle of creating flow logs in each default VPC.
 
 [[maintain_compliance_monitoring]]
-==== 1. Maintaining compliance by following Monitoring best practices
+==== Maintaining compliance by following Monitoring best practices
 The Monitoring section of the Benchmark centers on a collection of
 link:https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html[CloudWatch Logs Metric
 Filters]. Gruntwork has simplified this section to a single module: the
@@ -2312,7 +2311,7 @@ Note that you must have a subscriber on the SNS topic to be compliant. Refer to 
 setup a subscriber to the SNS topics that are created.
 
 [[maintain_compliance_networking]]
-==== 2. Maintaining compliance by following Networking best practices
+==== Maintaining compliance by following Networking best practices
 
 To ensure all the networking recommendations are satisfied, use the
 link:https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/modules/networking/vpc[`vpc`] (and/or
@@ -2342,6 +2341,7 @@ terraform { # We're using a local file path here just so our automated tests run
   # using these modules in your code, you should use a Git URL with a ref attribute that pins you to a specific version:
   # source = "git::git@github.com:gruntwork-io/terraform-aws-cis-service-catalog.git//modules/networking/vpc-mgmt?ref=v0.20.0"
   source = "${get_parent_terragrunt_dir()}/../../..//modules/networking/vpc-mgmt"
+}
 ----
 
 [source, hcl]
@@ -2381,7 +2381,6 @@ Congratulations! If you've made it this far, you should have achieved compliance
 Benchmark. Now it's time to confirm that your configurations are correct and you didn't miss any steps.
  +
  +
-
 
 [[traceability_matrix]]
 == Traceability matrix

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -953,9 +953,11 @@ The Landing Zone will be deployed in three steps - the `account-baseline-root` t
 The standalone modules will follow the pattern of referencing the module and providing the necessary input variables for it, then applying with `terragrunt`.
 
 [[deploy_landingzone]]
-=== Deploy Landing Zone solution
+== Deploy Landing Zone solution
 
-==== 1. Configure the "account-baseline-root" baseline for the root account
+=== Deploy the `account-baseline-root` to the root account
+
+==== 1. Configure the `account-baseline-root` for the root account
 
 [.exceptional]
 IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork subscriber# to access https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/[`terraform-aws-cis-service-catalog`].
@@ -1369,7 +1371,7 @@ rm -rf .terragrunt-cache
 ----
 
 [[apply_account_baseline_root]]
-==== 3. Apply the security baseline to the root account
+==== 3. Apply the `account-baseline-root` baseline to the root account
 
 You're now ready to apply the security baseline to the root account. You should be authenticated as the same IAM user
 in the root account as in the previous two sections. To apply the security baseline, you run `terragrunt apply`:
@@ -1446,7 +1448,7 @@ Each user can then decrypt the password on their own computer (which should have
 echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 ----
 
-===== Reset the root user password in each child account
+==== 4. Reset the root user password in each child account
 
 When creating the child accounts, you may have noticed that you provided an email address for each root user, but
 confusingly, not a password. So how do you login as the root user then? It's not obvious, but the answer is that you
@@ -1455,14 +1457,14 @@ using the "Forgot your password?" prompt on the https://console.aws.amazon.com/[
 you a reset link, which you can click to go to a page that will allow you to configure a password for the root user.
 Use this process to reset the password for the root user of each child account you created.
 
-===== Lock down the root user in the child accounts
+==== 5. Lock down the root user in the child accounts
 
 Once you're able to access the root user of each child account, you should follow the steps in <<lock_down_root_user>>
 for each of those child accounts—including enabling MFA and deleting the root user's access keys—and (almost) never use
 those root users again.
 
 [[apply_account_baseline_logs]]
-==== 4. Apply the `account-baseline-app` baseline to the logs account
+=== Apply the `account-baseline-app` baseline to the logs account
 
 The next step is to configure the **logs** account, which is used to aggregate AWS Config and CloudTrail data from all the
 other accountss.
@@ -1667,7 +1669,7 @@ aws-vault exec logs-from-root -- terragrunt apply
 IMPORTANT: On some operating systems, such as MacOS, you may also need to increase your open files limit to avoid "pipe: too many open files" errors by running: `ulimit -n 1024`.
 
 [[apply_account_baseline_security]]
-==== 5. Apply the `account-baseline-security` to the security account
+=== Apply the `account-baseline-security` to the security account
 
 Now that your logs accounts is fully configured, you need to apply the security baseline to the security account, which
 is where all your IAM users and groups will be defined and managed.
@@ -1893,7 +1895,6 @@ decrypt the password on their own computer (which should have their PGP key) as 
 ----
 echo "<PASSWORD>" | base64 --decode | keybase pgp decrypt
 ----
-
 
 === Apply the `account-baseline-app` to the other child accounts
 
@@ -2297,7 +2298,7 @@ link:https://github.com/gruntwork-io/cloud-nuke[`cloud-nuke defaults-aws`] comma
 all regions in an account, saving you the hassle of creating flow logs in each default VPC.
 
 [[maintain_compliance_monitoring]]
-=== Maintaining compliance by following Monitoring best practices
+==== 1. Maintaining compliance by following Monitoring best practices
 The Monitoring section of the Benchmark centers on a collection of
 link:https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html[CloudWatch Logs Metric
 Filters]. Gruntwork has simplified this section to a single module: the
@@ -2311,7 +2312,7 @@ Note that you must have a subscriber on the SNS topic to be compliant. Refer to 
 setup a subscriber to the SNS topics that are created.
 
 [[maintain_compliance_networking]]
-=== Maintaining compliance by following Networking best practices
+==== 2. Maintaining compliance by following Networking best practices
 
 To ensure all the networking recommendations are satisfied, use the
 link:https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/modules/networking/vpc[`vpc`] (and/or
@@ -2342,6 +2343,7 @@ terraform { # We're using a local file path here just so our automated tests run
   # source = "git::git@github.com:gruntwork-io/terraform-aws-cis-service-catalog.git//modules/networking/vpc-mgmt?ref=v0.20.0"
   source = "${get_parent_terragrunt_dir()}/../../..//modules/networking/vpc-mgmt"
 ----
+
 [source, hcl]
 ----
 inputs = {

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -430,10 +430,9 @@ The command output should return an array that contains all of the SSL/TLS certi
 	"ServerCertificateMetadataList": [{
 		"ServerCertificateId": "EHDGFRW7EJFYTE88D",
 		"ServerCertificateName": "MyServerCertificate",
-		"Expiration": "2020-07-10T23:59:59Z",
+		"Expiration": "2021-07-05T23:59:59Z",
 		"Path": "/",
-		"Arn": "arn:aws:iam::012345678910:server-
-		certificate / MySSLCertificate ",
+		"Arn": "arn:aws:iam::012345678910:server-certificate/MySSLCertificate",
 		"UploadDate": "2018-06-10T11:56:08Z"
 	}]
 }
@@ -1652,9 +1651,9 @@ You should see JSON output indicating that you've successfully assumed an IAM ro
 [source,json]
 ----
 {
-  "UserId": "AIDAXXXXXXXXXXXX:1597932316055520000",
+  "UserId": "AIDAXXXXXXXXXXXX:1111111111111111111",
   "Account": "<LOGS_ACCOUNT_ID>",
-  "Arn": "arn:aws:sts::<LOGS_ACCOUNT_ID>:assumed-role/OrganizationAccountAccessRole/1597932316055520000"
+  "Arn": "arn:aws:sts::<LOGS_ACCOUNT_ID>:assumed-role/OrganizationAccountAccessRole/1111111111111111111"
 }
 ----
 
@@ -1732,7 +1731,7 @@ locals {
   cloudtrail_s3_bucket_name = "acme-cloudtrail-logs"
 
   # The Cloudtrail KMS Key is deployed at the logs account but it's value is an output from the root account.
-  cloudtrail_kms_key_arn = "arn:aws:kms:us-east-1:216044045972:alias/cloudtrail-acme"
+  cloudtrail_kms_key_arn = "arn:aws:kms:us-east-1:${local.accounts.logs}:alias/cloudtrail-acme"
 
   # A local for convenient access to the security account root ARN.
   security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
@@ -1887,7 +1886,7 @@ Add a new `profile` entry in `~/.aws/config` for your security account that uses
 [source,text]
 ----
 [profile security-from-root]
-role_arn=arn:aws:iam::<SECURITY_ACCOUNT_ID>:role/OrganizationAccountAccessRole
+role_arn=arn:aws:iam::${local.accounts.security}:role/OrganizationAccountAccessRole
 source_profile=root-iam-user
 ----
 
@@ -1903,9 +1902,9 @@ You should see JSON output indicating that you've successfully assumed an IAM ro
 [source,json]
 ----
 {
-  "UserId": "AIDAXXXXXXXXXXXX:1597932316055520000",
-  "Account": "<SECURITY_ACCOUNT_ID>",
-  "Arn": "arn:aws:sts::<SECURITY_ACCOUNT_ID>:assumed-role/OrganizationAccountAccessRole/1597932316055520000"
+  "UserId": "AIDAXXXXXXXXXXXX:1111111111111111111",
+  "Account": "${local.accounts.security}",
+  "Arn": "arn:aws:sts::${local.accounts.security}:assumed-role/OrganizationAccountAccessRole/1111111111111111111"
 }
 ----
 
@@ -2001,7 +2000,7 @@ locals {
   cloudtrail_s3_bucket_name = "acme-cloudtrail-logs"
 
   # The Cloudtrail KMS Key is deployed at the logs account but it's value is an output from the root account.
-  cloudtrail_kms_key_arn = "arn:aws:kms:us-east-1:409800740445:alias/cloudtrail-acme"
+  cloudtrail_kms_key_arn = "arn:aws:kms:us-east-1:${local.accounts.logs}:alias/cloudtrail-acme"
 
   # A local for convenient access to the security account root ARN.
   security_account_root_arn = "arn:aws:iam::${local.accounts.security}:root"
@@ -2097,12 +2096,6 @@ inputs = {
     "iam:GetRolePolicy",
   ]
 
-  # Configures the auto deploy max session duration to be 4 hours.
-  max_session_duration_machine_users = 14400
-
-  # Configures the max session duration for roles that humans use to be 8 hours.
-  max_session_duration_human_users = 28800
-
   service_linked_roles = ["autoscaling.amazonaws.com"]
   ##################################
   # KMS grants
@@ -2174,7 +2167,7 @@ Add a new `profile` entry in `~/.aws/config` for your stage account that uses th
 [source,text]
 ----
 [profile stage-from-root]
-role_arn=arn:aws:iam::<STAGE_ACCOUNT_ID>:role/OrganizationAccountAccessRole
+role_arn=arn:aws:iam::${local.accounts.stage}:role/OrganizationAccountAccessRole
 source_profile=root-iam-user
 ----
 
@@ -2190,9 +2183,9 @@ You should see JSON output indicating that you've successfully assumed an IAM ro
 [source,json]
 ----
 {
-  "UserId": "AIDAXXXXXXXXXXXX:1597932316055520000",
-  "Account": "<STAGE_ACCOUNT_ID>",
-  "Arn": "arn:aws:sts::<STAGE_ACCOUNT_ID>:assumed-role/OrganizationAccountAccessRole/1597932316055520000"
+  "UserId": "AIDAXXXXXXXXXXXX:1111111111111111111",
+  "Account": "${local.accounts.stage}",
+  "Arn": "arn:aws:sts::${local.accounts.stage}:assumed-role/OrganizationAccountAccessRole/1111111111111111111"
 }
 ----
 

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -939,9 +939,9 @@ so using a virtual or hardware MFA device is preferable; that said, MFA with SMS
 [[deployment_approach]]
 === Deployment approach
 Before we dive into the code and deployment for each of the resources, let's take a step back and understand how the code is structured.
-Most of the features explained in the "Production-grade design" section will be deployed by using the Landing Zone solution, and some more standalone modules like the VPC module.
+Most of the features explained in the <<production_grade_design>> section will be deployed by using the Landing Zone solution, and some more standalone modules like the VPC module.
 
-The Landing Zone will be deployed in three steps - the `account-baseline-root` to set up your organisation-wide configurations, and create the necessary child AWS accounts. Next, we'll need to apply the `account-baseline-app` baseline against the created logs account, which would in its turn set up the CloudTrail, AWS Config buckets and a few more settings that will be used for aggregation of logs and metrics from the whole organization. Then the `account-baseline-security` will be applied, and that's responsible to set up your IAM roles, groups that would allow you to access the rest of the accounts within your organization. And finally, the `account-baseline-app` will be applied to an AWS account with the purpose of hosting an application.
+The Landing Zone will be deployed in three steps - the `account-baseline-root` to set up your organisation-wide configurations, create the necessary child AWS accounts, set up the CloudTrail and AWS Config buckets. Next, we'll need to apply the `account-baseline-app` against the created logs account, adding more settings that will be used for aggregation of logs and metrics from the whole organization. Then the `account-baseline-security` will be applied, and that's responsible to set up your IAM roles, groups that would allow you to access the rest of the accounts within your organization. And finally, the `account-baseline-app` will be applied to an AWS account with the purpose of hosting an application.
 
 The standalone modules will follow the pattern of referencing the module and providing the necessary input variables for it, then applying with `terragrunt`.
 
@@ -953,13 +953,12 @@ The standalone modules will follow the pattern of referencing the module and pro
 ===== Configure the `account-baseline-root` for the root account
 
 [.exceptional]
-IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork subscriber# to access https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/[`terraform-aws-cis-service-catalog`].
+IMPORTANT: You must be a [js-subscribe-cta]#Gruntwork Compliance subscriber# to access the Gruntwork Infrastructure as Code Library and the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/[CIS AWS Foundations Benchmark modules].
 
-First, let's set consider the repository structure that is recommended by this guide. It is available for your reference in the "/examples/for-production" section in the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. It looks like this:
+First, let's set consider the repository structure that is recommended by this guide. It is available for your reference in the "/examples/for-production" section in the https://github.com/gruntwork-io/terraform-aws-cis-service-catalog/tree/master/examples/for-production[`terraform-aws-cis-service-catalog` repository]. Consider the following directory structure for your `infrastructure-live` repository. It showcases the configuration files foryour local variables.
 
 [source]
 ----
-Consider the following directory structure for your `infrastructure-live` repository. It showcases the configuration files foryour local variables.
 .
 └ infrastructure-live
     └ prod
@@ -1047,7 +1046,7 @@ locals {
   aws_region = local.aws_region
 
   accounts = {
-    root = local.accounts.root
+    root = "<ROOT_ACCOUNT_ID>"
   }
 
   # Both buckets will created in the logs account by account-baseline-root
@@ -2198,7 +2197,7 @@ from the Gruntwork Service Catalog.
 The logging section of the Benchmark includes configurations for CloudTrail, AWS Config, KMS keys, and VPC
 flow logs.
 
-[[kms]]
+[[enable_key_rotation_for_kms]]
 **Enable key rotation for KMS keys**
 To make sure your KMS keys are compliant with the benchmark, use the
 link:https://github.com/gruntwork-io/terraform-aws-security/blob/master/modules/kms-master-key/README.md[`kms-master-key` module]
@@ -2411,7 +2410,7 @@ sections above.
 3.5;<<apply_account_baseline_security>>;Use the `account-baseline-security` module to ensure AWS Config is enabled in all regions
 3.6;<<apply_account_baseline_logs>>;Use the `account-baseline-*` modules to ensure Cloudtrail S3 bucket has access logging enabled
 3.7;<<apply_account_baseline_logs>>;Use the `account-baseline-*` modules to ensure Cloudtrail logs are encrypted at rest using KMS CMKs
-3.8;<<kms>>;Use the KMS module
+3.8;<<enable_key_rotation_for_kms>>;Use the KMS module
 3.9;<<vpc_flow_logs>>;Use the Gruntwork CIS-compliant `vpc` service to provision VPCs with flow logs enabled
 3.10-3.11;<<apply_account_baseline_logs>>;Use the `account-baseline-*` modules to ensure Object-level logging is enabled for S3 buckets for read and write events
 4.1-4.15;<<maintain_compliance_monitoring>>;The CloudWatch Logs metrics filters wrapper module will satisfy each recommendation

--- a/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
+++ b/_posts/2019-10-17-how-to-achieve-cis-benchmark-compliance.adoc
@@ -1070,9 +1070,6 @@ inputs = {
   # Send Config logs to the common S3 bucket.
   config_s3_bucket_name = local.config_s3_bucket_name
 
-  # Do not allow objects in the Config S3 bucket to be forcefully removed during destroy operations.
-  config_force_destroy = false
-
   ################################
   # Parameters for CloudTrail
   ################################
@@ -1082,9 +1079,6 @@ inputs = {
 
   # The ARN is a key alias, not a key ID. This variable prevents a perpetual diff when using an alias.
   cloudtrail_kms_key_arn_is_alias = true
-
-  # Do not allow objects in the CloudTrail S3 bucket to be forcefully removed during destroy operations.
-  cloudtrail_force_destroy = false
 
   ##################################
   # Cross-account IAM role permissions
@@ -1505,9 +1499,6 @@ inputs = {
   # Send Config logs and events to the logs account.
   config_central_account_id = local.accounts.logs
 
-  # Do not allow objects in the Config S3 bucket to be forcefully removed during destroy operations.
-  config_force_destroy = false
-
   #  This is the Logs account, so we create the SNS topic for aggregating Config logs from all accounts.
   config_should_create_sns_topic = true
 
@@ -1539,8 +1530,6 @@ inputs = {
   cloudtrail_kms_key_administrator_iam_arns = ["arn:aws:iam::${local.accounts.logs}:root"]
   cloudtrail_kms_key_user_iam_arns          = ["arn:aws:iam::${local.accounts.logs}:root"]
 
-  # Do not allow objects in the CloudTrail S3 bucket to be forcefully removed during destroy operations.
-  cloudtrail_force_destroy = false
   ##################################
   # Benchmark SNS alarms configuration
   ##################################
@@ -1770,9 +1759,6 @@ input = {
 
   # Send Config logs and events to the logs account.
   config_central_account_id = local.accounts.logs
-
-  # Do not allow objects in the Config S3 bucket to be forcefully removed during destroy operations.
-  config_force_destroy = false
 
   # This account sends logs to the Logs account.
   config_aggregate_config_data_in_external_account = true
@@ -2042,9 +2028,6 @@ inputs = {
 
   # Send Config logs and events to the logs account.
   config_central_account_id = local.accounts.logs
-
-  # Do not allow objects in the Config S3 bucket to be forcefully removed during destroy operations.
-  config_force_destroy = false
 
   # This account sends logs to the Logs account.
   config_aggregate_config_data_in_external_account = true


### PR DESCRIPTION
This PR is a follow up from the previous [CIS Compliance guide PR](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426) to address all the NITs and additional feedback. This should help us to manage the changes better and see them easier (the last one was getting too big).

The NITs are taken from comments in this PR and translated into these checkboxes below:

**Cleanup tasks:**
- [x] Change accounts declaration from `accounts = {x,y,z}` to `accounts = jsondecode(file("accounts.json"))` See [comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652050290)
- [x] Update formatting of for-loops
- [x] Update `local.accounts["stage"]` to `local.accounts.stage` to be consistent across guides (e.g. the LZ guide) See [comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652052836)
- [x] Review references of accounts such as in [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652053437)
- [x] Remove specific regions mentioned - e.g. `us-east-1`, and replace with a generic placeholder. See [comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652053938)
- [x] Replace `acme-*` specific placeholders with potentially `<RESOURCE_ACCOUNT>` like suggested [here ](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652055340) and [here](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652773187)
- [x] Replace `name_prefix = "stage-logs"` with something unique like `name_prefix = "<SOME UNIQUE IDENTIFIER>-logs"` - see [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652064101)
- [x] Replace specific ARNs with placeholders - e.g. `kms_cmk_arn = "arn:aws:kms:us-east-1:${local.accounts.shared}:alias/ami-encryption"` should be more generic - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652061073)
- [x] Remove `force_destroy_*` params - we don't need those in a production guide - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652766413)
- [x] Set defaults for `max_session_duration_machine_users` and `max_session_duration_human_users` - See [this comment ](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652768799)

**Readability tasks:**
More generic feedback to address (⚠️ Consider a separate PR for these if they're not small and quick changes)
- [x] A "very large number of sub-sections below deployment walkthrough -  See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#pullrequestreview-685262124) - potentially group into sections
- [x] Review the section "The Gruntwork solution" section a little hard to follow" and follow the suggestions by Jim - See [comment here](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652755048)
- [x] Introduce a `common.hcl` to hold hard-coded values that are repeated across the code examples - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652772822)
- [x] Call out explicitly that we have baselines for all types of accounts - root, logs, app and security - [See this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652777981)
- [x] Remove any mention of the `infra-modules` - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652780292)
- [x] Transform the message around Security Hub showing 1.2 compliance in AWS console to be a `callout` format so it's easy for customers to spot - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652781975)

**Potential bugs:** (⚠️ Consider a separate PR for these if they're not small and quick changes)
- [x] See if the right baseline is used in the `terraform source` on lines 978-979 - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652767158) 
- [x] Does the code comment on lines 1093-1094 make sense - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652767915)
- [x] Don't allow dev permissions in the root account - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652768193) 
- [x] Do we need the `auto-deploy` permissions in the root baseline example? Remove it, as we shouldn't be needing this access - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652768425)
- [x] We should remove the `dev_services` in the `logs` account example - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652774922)
- [x] Review the `logs` account example - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652775703) & [this one](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652775837)
- [x] Remove `auto-scaling` configuration from `logs` account - do we need any? - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652776023) 
- [x] Review Security account example code - See [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426#discussion_r652779627)

**Additional notes:**
- To make sure this PR is quick and easy, some of these tasks might need to be split out into separate PRs too
- To make sure all the [old PR comments](https://github.com/gruntwork-io/gruntwork-io.github.io/pull/426) are met - please review them one by one and assess if they still make sense to follow

