### PR TITLE
Switch out sales role to sales engineer.

### DIFF
--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -206,33 +206,30 @@
 
     <h2>Sales</h2>
 
-    <h3 style="margin-top: 5px; margin-bottom: 5px;">Account Executive<br>Director of Sales</h3>
+    <h3 style="margin-top: 5px; margin-bottom: 5px;">Sales Engineer</h3>
 
-    <p>We're making for our first dedicated sales hire at Gruntwork. We've grown to millions of dollars in annual revenue with zero outside investment/debt, near-zero marketing budget, and a small number of software engineers who handle all sales calls in addition to their core work. Now we're ready to take our sales to the next level!</p>
+    <p>We've grown to millions of dollars in annual revenue with zero outside investment/debt, near-zero marketing budget, and a small number of software engineers who handle all sales calls in addition to their core work. Now we're ready to take our sales to the next level!</p>
     <p>Our product is used and purchased by software and DevOps engineers, so we are looking for a sales professional with proven experience selling products that enable software engineers. As the first sales hire, you'll report directly to the founders and have considerable impact on the overall growth of the company. Your growth path in this role could be as either a star individual contributor or team lead (at Gruntwork, we value IC and management roles equally).</p>
     <p></p>
   
     <h4>What You'll Work On</h4>
     <ul>
-      <li><strong>Improve our sales process.</strong> Identify what can be improved about our current sales process, prioritize the changes, and lead the implementation in collaboration with the rest of the team.</li>
-      <li><strong>Streamline our sales workflow.</strong> Lay the groundwork for higher personal productivity by streamlining the way we track our deals and helping us adopt best-practices sales tooling.</li>
-      <li><strong>Manage deals.</strong> Own the deal from initial inquiry through contract signature. Engage with both large enterprises and startups.</li>
-      <li><strong>Showcase the product.</strong> Show customers how the Gruntwork product works. Answer both their high-level strategic questions and common technical questions. When necessary, bring in a member of our engineering team as a sales engineer.</li>
-      <li><strong>Business development.</strong> Identify partnership opportunities, prioritize them, and lead their implementation.</li>
+      <li><strong>Manage deals.</strong> Own the deal from inquiry through contract signature. Engage with both large enterprises and startups.</li>
+      <li><strong>Showcase the product.</strong> Show customers how the Gruntwork product works. Answer both their high-level strategic questions and common technical questions. When necessary, collaborate with our engineering team to answer a detailed question or build your knowledge.</li>
+      <li><strong>Make customer-driven tweaks where needed.</strong> Does the customer want to see an integration out of the box we don't yet support? You can add it directly, following the patterns we've laid down with other integrations.</li>    
+      <li><strong>Develop new markets.</strong> Our product works well for customers building greenfield in AWS or doing migrations. What kinds of customers might find themselves in that situation? Identify those opportunities, figure out what the customer wants, and write content/guides to help showcase our solution.</li>
     </ul>
     <h4>Your Ideal Background</h4>
     <ul>
-      <li><strong>Experience in tech.</strong> You understand the cloud, are familiar with core elements of at least one major cloud provider, and have experience selling to software engineers. You don't have to be an engineer yourself, but ideally you have some kind of background in engineering or coding from earlier in your career.</li>
-      <li><strong>Technical skill.</strong> You're tech-savvy, can build a full mental model of our product, and can learn to demo a core part of it on your own without the assistance of sales engineers. At the same time, you have prior experience working with sales engineers and know when to bring them in.</li>
-      <li><strong>Sales skill.</strong> You can effectively qualify leads, understand customer needs, demo our product, and close the deal with a range of customers from startups to large enterprises. You're disciplined with follow-ups and know how to spend your time to make the most impact.</li>
-      <li><strong>Sales strategy.</strong> You have done sales for enough tech companies to understand what elements must be present to make a successful sale. You can map that experience to our sales process to lay the groundwork for sales scale.</li>
-      <li><strong>Sales leadership.</strong> You know how to recruit other sales people to build your sales team. Once on the team, you can coach and manage them effectively.</li>
+      <li><strong>Experience in tech.</strong> You understand the cloud, are familiar with core elements of at least one major cloud provider, and have experience selling to software engineers. Ideally, you have some kind of background in engineering or coding from earlier in your career.</li>
+      <li><strong>Technical skill.</strong> You're tech-savvy, can build a full mental model of our product, and can learn to demo a core part of it on your own. At the same time, you know when to bring in the product engineers to assist.</li>
+      <li><strong>Sales skill.</strong> You can effectively qualify leads, understand customer needs, demo our product, and close the deal with a range of customers from startups to large enterprises. You delight both in knowing the product and signing up customers who will genuinely benefit from it.</li>
       <li><strong>Moral grounding.</strong> You feel comfortable saying no when necessary so that we can all sleep better at night. In general, you do the right thing for customers, for Gruntwork, and for yourself.</li>
     </ul>
     <h4>What time zones do we work in?</h4>
     <p>While Gruntwork <a href="/careers/#sane-working-hours">generally</a> hires anywhere between San Francisco and Berlin, candidates for this role must be within the GMT-7 to GMT-3 time zones, with a preference for being located in the USA or Canada. We expect you'll work primarily with customers and fellow Grunts in those time zones, with limited engagement with customers worldwide and Grunts in Europe. Working during reasonable hours is a priority for us.</p>
     <p>If the above describes you:<br>
-      <a href="https://apply.workable.com/gruntwork-io/j/52C1960D89/apply/" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa" style="margin-top:10px;" role="button">Apply Now</a>
+      <a href="https://apply.workable.com/j/8FC9042E48" class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa" style="margin-top:10px;" role="button">Apply Now</a>
     </p>
 
   </div>


### PR DESCRIPTION
Originally, I was going to remove our Sales Lead job from the website, but then I realized that we're actually interested in recruiting candidates for sales engineering already, so I doctored the ad and created a new job in workable to link it to. Feedback welcome!