### PR TITLE
Fix links on landing pages

### DIFF
--- a/_includes/landing-footer.html
+++ b/_includes/landing-footer.html
@@ -6,7 +6,7 @@
           <div class="col-xs-12 text-center">
             <h2 class="h1 no-anchor">{{ page.footer.heading }}</h2>
             <p style="margin-top: -30px">{{ page.footer.body }}</p>
-            <p><a href="pricing" class="btn btn-info" role="button" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="footer-cta">{{ page.footer.cta }}</a></p>
+            <p><a href="{{ page.permalink }}pricing/" class="btn btn-info" role="button" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="footer-cta">{{ page.footer.cta }}</a></p>
           </div>
         </div>
       {% endif %}

--- a/pages/landing/migrate-from-heroku/_hero.html
+++ b/pages/landing/migrate-from-heroku/_hero.html
@@ -15,7 +15,7 @@
   <div>
     <p class="hidden-print" style="margin-top: 30px;">
       <a
-        href="pricing/"
+        href="{{ page.permalink }}pricing/"
         class="btn get-a-demo"
         role="button"
         ga-on="click"

--- a/pages/landing/migrate-from-heroku/pricing/_plans.html
+++ b/pages/landing/migrate-from-heroku/pricing/_plans.html
@@ -47,17 +47,17 @@
       {% for pricing in page.pricing %}
         <td style="width: 25%; border-left: 1px solid #194c5f; border-right: 1px solid #194c5f; background-color: #252e3a" class="text-center">
           {% if pricing.price == "Contact Us" %}
-            <p><a class="btn btn-primary" href="contact?selection={{ pricing.title | slugify }}">Contact Us</a></p>
+            <p><a class="btn btn-primary" href="{{ page.permalink }}contact/?selection={{ pricing.title | slugify }}">Contact Us</a></p>
             <p class="text-muted small">
               <em>Annual contract.<br />Billed monthly or annually.</em>
             </p>
           {% elsif pricing.price == "Free" %}
-            <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="contact?selection={{ pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Select</a></p>
+            <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="{{ page.permalink }}contact/?selection={{ pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Select</a></p>
             <p class="text-muted small">
               <em>Annual contract.<br />Billed monthly or annually.</em>
             </p>
           {% else %}
-            <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="contact?selection={{ pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Select</a></p>
+            <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="{{ page.permalink }}contact/?selection={{ pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Select</a></p>
             <p class="text-muted small"><em>Annual contract<br>Billed monthly or annually.</em></p>
           {% endif %}
         </td>

--- a/pages/landing/template/_hero.html
+++ b/pages/landing/template/_hero.html
@@ -15,7 +15,7 @@
   <div>
     <p class="hidden-print" style="margin-top: 30px;">
       <a
-        href="pricing"
+        href="{{ page.permalink }}pricing/"
         class="btn get-a-demo"
         role="button"
         ga-on="click"

--- a/pages/landing/template/pricing/_price-col.html
+++ b/pages/landing/template/pricing/_price-col.html
@@ -12,7 +12,7 @@
           <p class="help-block"></p>
         </div>
         <div data-mh="plans-pricing-bottom" style="height:100px">
-          <p><a class="btn btn-primary" href="contact?selection={{ include.pricing.title | slugify }}">Contact Us</a></p>
+          <p><a class="btn btn-primary" href="{{ page.permalink }}contact/?selection={{ include.pricing.title | slugify }}">Contact Us</a></p>
           <p class="text-muted small">
             <em>Annual contract.<br />Billed monthly or annually.</em>
           </p>
@@ -25,7 +25,7 @@
           <p class="help-block" style="margin-top:-9px;">per month</p>
         </div>
         <div data-mh="plans-pricing-bottom" style="height:100px">
-          <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="contact?selection={{ include.pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Select</a></p>
+          <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="{{ page.permalink }}contact/?selection={{ include.pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Select</a></p>
           <p class="text-muted small"><em>Annual contract<br>Billed monthly or annually.</em></p>
         </div>
       </div>


### PR DESCRIPTION
I used relative links in the landing page template originally and those don't seem to work properly when deployed. This PR updates those links to be absolute links (starting with `/xxx`) by pre-pending `page.permalink`.