### PR TITLE
Switch Heroku page to "request access" and other fixes

### DIFF
--- a/assets/css/pages/heroku.less
+++ b/assets/css/pages/heroku.less
@@ -14,3 +14,10 @@
     }
   }
 }
+
+.check-list-white li:before {
+  font-family: 'FontAwesome';
+  content: '\f00c';
+  margin: 0 .5em 0 -1.7em;
+  color: #fff;
+}

--- a/assets/css/pages/heroku.less
+++ b/assets/css/pages/heroku.less
@@ -15,9 +15,3 @@
   }
 }
 
-.check-list-white li:before {
-  font-family: 'FontAwesome';
-  content: '\f00c';
-  margin: 0 .5em 0 -1.7em;
-  color: #fff;
-}

--- a/pages/landing/migrate-from-heroku/contact/_form.html
+++ b/pages/landing/migrate-from-heroku/contact/_form.html
@@ -11,7 +11,6 @@
     id="_subject"
     value="New contact form submission for landing page {{ site.url }}{{ page.url }}"
   />
-  <input type="hidden" name="_selection" id="_selection" />
   <input type="hidden" name="_next" id="_next" value="{{ site.url }}{{ page.url }}thank-you" />
   <input type="hidden" name="hello_gruntwork" value=""/>
   <input type="hidden" name="_landing-page" value="{{ site.url }}{{ page.url }}" />
@@ -19,6 +18,19 @@
   {% include_relative _input-text.html id="contact-name" label="Name" required=true placeholder="Jon Doe" %}
   {% include_relative _input-text.html id="contact-email" label="Email" required=true placeholder="jon@acme.com" type="email" %}
   {% include_relative _input-text.html id="contact-company" label="Company" required=true placeholder="Acme, Inc." %}
+  <div class="form-group">
+    <div class="row">
+      <div class="col-xs-12 col-md-4">
+        <label>Which plan are you interested in?</label>
+      </div>
+      <div class="col-xs-12 col-md-8">
+        {% include_relative _input-radio.html name="interested-plan" id="plan-lite" value="Lite" checked=true %}
+        {% include_relative _input-radio.html name="interested-plan" id="plan-pro" value="Pro" %}
+        {% include_relative _input-radio.html name="interested-plan" id="plan-enterprise" value="Enterprise" %}
+        {% include_relative _input-hidden.html id="user-utc-timezone-offset" %}
+      </div>
+    </div>
+  </div>
   <div class="form-group">
     <div class="row">
       <div class="col-xs-12 col-md-4">
@@ -53,5 +65,10 @@
 <script type="application/javascript">
   const urlParams = new URLSearchParams(window.location.search);
   const selection = urlParams.get('selection');
-  document.getElementById('_selection').value = selection;
+  if (selection) {
+    const radio = document.getElementById('plan-' + selection);
+    if (radio) {
+      radio.checked = true;
+    }
+  }
 </script>

--- a/pages/landing/migrate-from-heroku/contact/_hero.html
+++ b/pages/landing/migrate-from-heroku/contact/_hero.html
@@ -1,8 +1,11 @@
 <div class="container">
   <div class="row">
     <div class="col-xs-12 text-center">
-      <h1>Join the waitlist</h1>
-      <p style="margin-bottom:4px" class="lead">This product is currently in invite-only mode!<br>Please join our waitlist to be notified when you can get it.</p>
+      <h1>Request access</h1>
+      <p style="margin-bottom:4px" class="lead">
+        This product is currently in an invite-only private beta.<br>
+        Use this form to request access and we'll notify you when you can get it!
+      </p>
     </div>
   </div>
 </div>

--- a/pages/landing/migrate-from-heroku/contact/_input-radio.html
+++ b/pages/landing/migrate-from-heroku/contact/_input-radio.html
@@ -1,7 +1,7 @@
-<div class="checkbox">
-  <input id="{{ include.id }}" name="{{ include.id }}" type="checkbox" value="true">
+<div>
+  <input id="{{ include.id }}" name="{{ include.name }}" type="radio" value="{{ include.value }}"{% if include.checked %} checked{% endif %}>
   <label for="{{ include.id }}">
-    {{ include.label }}
+    {{ include.value }}
     {% if include.small_text %}
       <br>
     <small style="font-size: 12px; display: block; margin-bottom: 10px">{{ include.small_text }}</small>

--- a/pages/landing/migrate-from-heroku/contact/index.html
+++ b/pages/landing/migrate-from-heroku/contact/index.html
@@ -1,6 +1,6 @@
 ---
 layout: landing
-title: Join the waitlist
+title: Request access
 permalink: /migrate-from-heroku-to-aws/pricing/contact/
 slug: contact
 custom_js:

--- a/pages/landing/migrate-from-heroku/index.html
+++ b/pages/landing/migrate-from-heroku/index.html
@@ -109,7 +109,12 @@ how_it_works:
 
 footer:
   heading: The infrastructure you've always wanted
-  body: The seamless experience you expect from Heroku. The control and scalability you expect from AWS. The production-grade code you expect from Gruntwork.
+  body: |
+    <ul class="check-list check-white" style="display: inline-block; text-align: left; margin-top: 10px; margin-bottom: 0">
+      <li>The seamless experience you expect from Heroku.</li>
+      <li>The control and scalability you expect from AWS.</li>
+      <li>The production-grade code you expect from Gruntwork.</li>
+    </ul>
   cta: Request early access!
 ---
 

--- a/pages/landing/migrate-from-heroku/index.html
+++ b/pages/landing/migrate-from-heroku/index.html
@@ -12,7 +12,7 @@ prism_css: /assets/css/prism-landing-zone.css
 
 hero:
   image: /assets/img/infrastructure-cube-icons/infrastructure-in-a-day.png
-  cta: Migrate your first app for free!
+  cta: Request early access!
   logos:
   - /assets/img/logos-technologies/partner_logo_aws.png
   - /assets/img/logos-technologies/partner_logo_kubernetes.png
@@ -110,7 +110,7 @@ how_it_works:
 footer:
   heading: The infrastructure you've always wanted
   body: The seamless experience you expect from Heroku. The control and scalability you expect from AWS. The production-grade code you expect from Gruntwork.
-  cta: Migrate your first app now!
+  cta: Request early access!
 ---
 
 <div class="main">

--- a/pages/landing/migrate-from-heroku/index.html
+++ b/pages/landing/migrate-from-heroku/index.html
@@ -121,7 +121,6 @@ footer:
       <li>The seamless experience you expect from Heroku.</li>
       <li>The control and scalability you expect from AWS.</li>
       <li>The production-grade code you expect from Gruntwork.</li>
-      <li>Migrate your first app for free!</li>
     </ul>
   cta: Request early access!
 ---

--- a/pages/landing/migrate-from-heroku/index.html
+++ b/pages/landing/migrate-from-heroku/index.html
@@ -4,7 +4,14 @@ type: landing
 slug: index-page
 
 title: Migrate from Heroku to AWS in about a day.
-excerpt: Automatically package your app and deploy into a production-grade architecture on AWS in ~1 day. Get the delightful "git push to deploy" workflow of Heroku with the scalability and control of managing 100% of your infrastructure as code.
+excerpt: |
+  <ul class="check-list check-list-white" style="display: inline-block; text-align: left; margin-top: 10px; margin-bottom: 0">
+    <li>Configure a "git push to deploy" CI / CD pipeline.</li>
+    <li>Instrument your app with cloud-native packaging, monitoring, logging, etc.</li>
+    <li>Deploy your app onto a production-grade architecture on AWS.</li>
+    <li>Manage 100% of your infrastructure as code using Terraform.</li>
+    <li>Migrate your first app for free!</li>
+  </ul>
 permalink: /migrate-from-heroku-to-aws/
 custom_js:
 - prism
@@ -12,7 +19,7 @@ prism_css: /assets/css/prism-landing-zone.css
 
 hero:
   image: /assets/img/infrastructure-cube-icons/infrastructure-in-a-day.png
-  cta: Request early access!
+  cta: Request early access
   logos:
   - /assets/img/logos-technologies/partner_logo_aws.png
   - /assets/img/logos-technologies/partner_logo_kubernetes.png
@@ -78,7 +85,7 @@ how_it_works:
     tab_block: site.data.heroku-landing-page-tabs-images
     image_side: right
     body: |
-      Gruntwork will update your app with cloud-native best practices for monitoring, logging, service discovery, secrets management, schema migrations, and more.
+      Gruntwork will update your app with cloud-native best practices for packaging, monitoring, logging, service discovery, secrets management, schema migrations, and more.
     logos:
       - title: CloudWatch
         src: /assets/img/landing-heroku-page/cloudwatch-icon.png
@@ -110,10 +117,11 @@ how_it_works:
 footer:
   heading: The infrastructure you've always wanted
   body: |
-    <ul class="check-list check-white" style="display: inline-block; text-align: left; margin-top: 10px; margin-bottom: 0">
+    <ul class="check-list" style="display: inline-block; text-align: left; margin-top: 10px; margin-bottom: 0">
       <li>The seamless experience you expect from Heroku.</li>
       <li>The control and scalability you expect from AWS.</li>
       <li>The production-grade code you expect from Gruntwork.</li>
+      <li>Migrate your first app for free!</li>
     </ul>
   cta: Request early access!
 ---

--- a/pages/landing/migrate-from-heroku/index.html
+++ b/pages/landing/migrate-from-heroku/index.html
@@ -4,14 +4,7 @@ type: landing
 slug: index-page
 
 title: Migrate from Heroku to AWS in about a day.
-excerpt: |
-  <ul class="check-list check-list-white" style="display: inline-block; text-align: left; margin-top: 10px; margin-bottom: 0">
-    <li>Configure a "git push to deploy" CI / CD pipeline.</li>
-    <li>Instrument your app with cloud-native packaging, monitoring, logging, etc.</li>
-    <li>Deploy your app onto a production-grade architecture on AWS.</li>
-    <li>Manage 100% of your infrastructure as code using Terraform.</li>
-    <li>Migrate your first app for free!</li>
-  </ul>
+excerpt: Deploy your app onto a scalable, production-grade AWS architecture, configure a "git push to deploy" CI / CD pipeline, and manage 100% of your infrastructure as code using Terraform, all in ~1 day. <b>Migrate your first app for free!</b>
 permalink: /migrate-from-heroku-to-aws/
 custom_js:
 - prism
@@ -19,7 +12,7 @@ prism_css: /assets/css/prism-landing-zone.css
 
 hero:
   image: /assets/img/infrastructure-cube-icons/infrastructure-in-a-day.png
-  cta: Request early access
+  cta: Request early access!
   logos:
   - /assets/img/logos-technologies/partner_logo_aws.png
   - /assets/img/logos-technologies/partner_logo_kubernetes.png

--- a/pages/landing/migrate-from-heroku/pricing/_faq.html
+++ b/pages/landing/migrate-from-heroku/pricing/_faq.html
@@ -1,7 +1,7 @@
 <div id="pricing-faqs" class="row row-page-header">
   <div class="col-xs-12">
     <h2>Pricing FAQ's</h2>
-    {% assign faq_length_half = page.faq.size | divided_by: 2 | plus: 1 %}
+    {% assign faq_length_half = page.faq.size | divided_by: 2 %}
     <div class="row">
       <div class="col-md-6">
         {% for item in page.faq limit:faq_length_half %}

--- a/pages/landing/migrate-from-heroku/pricing/_price-rows.html
+++ b/pages/landing/migrate-from-heroku/pricing/_price-rows.html
@@ -21,16 +21,26 @@
       {% if pricing.price == "Contact Us" %}
         <p><a class="btn btn-primary" href="{{ page.permalink }}contact/?selection={{ pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Contact Us</a></p>
         <p class="text-muted small">
-          <em>Annual contract.<br />Billed monthly or annually.</em>
+          <em>
+            Currently in private beta.<br>
+            Annual subscription.
+          </em>
         </p>
       {% elsif pricing.price == "Free" %}
-        <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="{{ page.permalink }}contact/?selection={{ pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Select</a></p>
+        <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="{{ page.permalink }}contact/?selection={{ pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Request Access</a></p>
         <p class="text-muted small">
-          <em>Annual contract.<br />Billed monthly or annually.</em>
+          <em>
+            Currently in private beta.
+          </em>
         </p>
       {% else %}
-        <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="{{ page.permalink }}contact/?selection={{ pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Select</a></p>
-        <p class="text-muted small"><em>Annual contract<br>Billed monthly or annually.</em></p>
+        <p><a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="{{ page.permalink }}contact/?selection={{ pricing.title | slugify }}" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Request Access</a></p>
+        <p class="text-muted small">
+          <em>
+            Currently in private beta.<br>
+            Annual subscription.
+          </em>
+        </p>
       {% endif %}
     </td>
   {% endfor %}

--- a/pages/landing/migrate-from-heroku/pricing/index.html
+++ b/pages/landing/migrate-from-heroku/pricing/index.html
@@ -3,7 +3,7 @@ layout: landing
 type: landing
 slug: index-page
 
-title: Pricing
+title: Pick a plan
 excerpt: Pick the plan just right for your team.
 permalink: /migrate-from-heroku-to-aws/pricing/
 
@@ -254,10 +254,10 @@ faq:
 
   - question: What's a user?
     answer: |
-        <p>
-          A user is any human or machine that makes use of Gruntwork's services, including using the Gruntwork Customer
-          Portal, accessing code from the Infrastructure as Code Library, or submitting requests to support.
-        </p>
+      <p>
+        A user is any human or machine that makes use of Gruntwork's services, including using the Gruntwork Customer
+        Portal, accessing code from the Infrastructure as Code Library, or submitting requests to support.
+      </p>
 ---
 
 <div class="main page-pricing">

--- a/pages/landing/migrate-from-heroku/pricing/index.html
+++ b/pages/landing/migrate-from-heroku/pricing/index.html
@@ -4,7 +4,7 @@ type: landing
 slug: index-page
 
 title: Pricing
-excerpt: Configure the plan just right for your team.
+excerpt: Pick the plan just right for your team.
 permalink: /migrate-from-heroku-to-aws/pricing/
 
 categories:
@@ -190,13 +190,13 @@ categories:
 
 pricing:
   - title: Lite
-    description: For solopreneuers and personal projects.
+    description: For solo devs, solopreneuers, and personal projects.
     price: Free
     image: /assets/img/grunty-free@2x.png
     image_styles: "max-width: 150px; margin-top: 18px"
 
   - title: Pro
-    description: For startups, small businesses planning on running a few apps.
+    description: For startups and small businesses planning on running a few apps.
     price: "795"
     image: /assets/img/grunty-pro@2x.png
     image_styles: "max-width: 150px; margin-top: 18px"
@@ -218,13 +218,6 @@ faq:
         <li><strong>Gruntwork Pro</strong>: $500 / month and up</li>
         <li><strong>Gruntwork Pro</strong>: $2,000 / month and up</li>
       </ul>
-
-  - question: What's a user?
-    answer: |
-        <p>
-          A user is any human or machine that makes use of Gruntwork's services, including using the Gruntwork Customer
-          Portal, accessing code from the Infrastructure as Code Library, or submitting requests to support.
-        </p>
 
   - question: Is an annual subscription required?
     answer: |
@@ -252,6 +245,19 @@ faq:
       <p>
         If, however, you remain a subscriber for at least 12 months, the license allows you to fork and modify the code and create derivative works as much as you want, and even if you cancel your subscription, you can keep using all the code you had been using up to that point. We recommend that prior to canceling, you make copies of all the repos in the Infrastructure as Code Library into your own version control system. After you cancel your Gruntwork Subscription, you'll no longer have access to the customer portal UI, or any of the updates, additions, and fixes we make to the Infrastructure as Code Library, support from the Gruntwork team, security alerts, and any other subscription benefits. However, your infrastructure will continue to work just fine and you'll still have all the code you had been using up to that point.
       </p>
+
+  - question: How does the private beta work?
+    answer: |
+      <p>
+        We are currently testing this product out on an invite-only basis with select customers. If you're interested in joining the beta, please request access, and we'll get in touch when the product is available to you!
+      </p>
+
+  - question: What's a user?
+    answer: |
+        <p>
+          A user is any human or machine that makes use of Gruntwork's services, including using the Gruntwork Customer
+          Portal, accessing code from the Infrastructure as Code Library, or submitting requests to support.
+        </p>
 ---
 
 <div class="main page-pricing">

--- a/pages/landing/migrate-from-heroku/thank-you/index.html
+++ b/pages/landing/migrate-from-heroku/thank-you/index.html
@@ -2,7 +2,7 @@
 layout: landing
 title: Thank you for joining the waitlist!
 excerpt: A Grunt will be in touch to let you know as soon as you can get access.
-permalink: /migrate-from-heroku-to-aws/pricing/contact/thank-you
+permalink: /migrate-from-heroku-to-aws/pricing/contact/thank-you/
 slug: contact
 ---
 


### PR DESCRIPTION
1. The CTA is now "request access" and the pricing and contact pages, as well as the FAQ, mention this is a private beta.
1. Expose "what plan are you interested in" radio buttons on the contact page so the user can see / change their selection.
1. Change footer to a checklist. The HIPAA landing page had this and I liked the way it looked.
1. Try to fix the thank you page. I _think_ the `permalink` must end with a trailing slash to work in prod. Not sure of the reason.

Preview env: https://deploy-preview-466--keen-clarke-470db9.netlify.app/migrate-from-heroku-to-aws/