### PR TITLE
Fix link in footer

### DIFF
--- a/_includes/landing-footer.html
+++ b/_includes/landing-footer.html
@@ -16,7 +16,7 @@
               {%
               else
               %}
-              href="pricing"
+              href="{{ page.permalink }}pricing/"
               {%
               endif
               %}class="btn btn-info"


### PR DESCRIPTION
I fixed this previously, but it must've been re-broken after a merge with the HIPAA stuff.