### PR TITLE
Add hubspot traffic analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ To deploy the site:
 1. Hosted on Amazon S3, with CloudFront as a CDN. Using [s3_website](https://github.com/laurilehmijoki/s3_website) to
    automatically upload static content to S3.
 1. We use [Bootstrap](http://www.getbootstrap.com/) and [Less](http://lesscss.org/).
-1. We're using [UptimeRobot](http://uptimerobot.com/) and [Google Analytics](http://www.google.com/analytics/) for
-   monitoring and metrics.
+1. We're using [UptimeRobot](http://uptimerobot.com/), [Google Analytics](http://www.google.com/analytics/), and [HubSpot Traffic Analytics](https://knowledge.hubspot.com/reports/analyze-your-site-traffic-with-the-traffic-analytics-tool) for monitoring and metrics.
 
 ## License
 

--- a/_data/cookie-policy.yml
+++ b/_data/cookie-policy.yml
@@ -36,7 +36,10 @@
     - title: Performance cookies
       ans: |
         <p>We use these cookies to enhance the performance and functionality of our Services, but they are not essential to the use of our Services. If you do not consent to our use of these cookies, certain functionality of our Services may not be available to you.</p>
-        <p><strong>Who Sets These Cookies:</strong><br />Google, Inc. (<a href="https://google.com" title="Google, Inc.">https://google.com</a>)</p>
+        <p><strong>Who Sets These Cookies:</strong>
+          <br />Google, Inc. (<a href="https://google.com" title="Google, Inc.">https://google.com</a>)
+          <br />HubSpot, Inc. (<a href="https://hubspot.com" title="HubSpot, Inc.">https://hubspot.com</a>)
+        </p>
         <p><strong>How To Opt Out of Them:</strong><br />See the section <a href="#opting-out-of-cookies" title="Opting out of cookies">Opting out of cookies</a> > <a href="#third-party-cookies" title="Third-party cookies">Third-party cookies</a></p>
     - title: Customization cookies
       ans: |

--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -140,3 +140,10 @@
   category: terms-of-service
   link: https://github.com/gruntwork-io/gruntwork-io.github.io/commit/b9e838e7
   date: 2021-06-04
+
+- guid: 10018
+  title: Reflect our use of HubSpot for gruntwork.io analytics and to collect customer information as part of our CRM
+  description: We've started using HubSpot (https://hubspot.com) internally, which means we are now storing customer information with a new data sub-processor. As a result, we've updated our Cookie Policy and Data Subprocessors list.
+  category: terms-of-service
+  link: https://github.com/gruntwork-io/gruntwork-io.github.io/commit/86665f29
+  date: 2021-07-22

--- a/_data/subprocessors.yml
+++ b/_data/subprocessors.yml
@@ -13,6 +13,11 @@
   country: USA
   website: https://google.com
 
+- name: HubSpot
+  purpose: Customer data collection
+  country: USA
+  website: https://hubspot.com
+
 - name: MailChimp
   purpose: Email newsletters
   country: USA

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -8,6 +8,9 @@
 <script src="/assets/js/{{ js_file }}.js" type="text/javascript"></script>
 {% endfor %} {% endif %} {% if site.gtm_id %}
 
+<!-- HubSpot Embed Code per https://knowledge.hubspot.com/reports/install-the-hubspot-tracking-code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/8376079.js"></script>
+
 <!-- Google Tag Manager (noscript) -->
 <noscript>
   <iframe


### PR DESCRIPTION
This PR installs the [HubSpot Tracking Code](https://knowledge.hubspot.com/reports/install-the-hubspot-tracking-code) so that we can (a) collect submissions from our contact us forms into HubSpot without using FormBucket, and (b) analyze our site with the [HubSpot Traffic Analytics tool](https://knowledge.hubspot.com/reports/analyze-your-site-traffic-with-the-traffic-analytics-tool). The HubSpot Traffic Analytics tool is an alternative to Google Analytics which may allow us to directly connect website visits to lead submissions and ultimately deals that closed. This will also enable us to "bucket" users who submit forms based on which form they came from.

### What this commit does not do
- It does not remove Google Analytics
- It does not remove FormBucket, though after this merges, I'd like to do that
- It does not change the configuration of any current contact forms, including the new landing pages

### Other notes
Adding this tracker does represent an additional data subprocessor we are using to track customers, so this PR also updates the relevant policies.