### PR TITLE
Make HIPAA nav links consistent across pages

### DIFF
--- a/pages/landing/hipaa/index.html
+++ b/pages/landing/hipaa/index.html
@@ -4,10 +4,10 @@ type: landing
 slug: index-page
 
 extra_nav_links:
+  - name: Technical Details
+    url: /hipaa-compliance-on-aws/technical-details
   - name: Why Gruntwork?
     url: /hipaa-compliance-on-aws/why-gruntwork
-  - name: Bootstrap your app
-    url: /hipaa-compliance-on-aws/bootstrap-your-app
 
 title: The fastest way to launch HIPAA-compliant apps on AWS
 excerpt: Build your apps on top of HIPAA-compliant application templates. Deploy your apps onto battle-tested AWS architectures that have been certified via third party auditors.
@@ -27,7 +27,7 @@ how_it_works:
     image: /assets/img/hipaa/infrastructure-hipaa.png
     image_side: right
     body: |
-      Deploy an off-the-shelf, production-grade AWS Architecture that is HIPAA compliant out-of-the-box. The architecture includes: <ul><li>Multi-account Landing Zone</li><li>Networking (VPCs, VPN, SSH, DNS)</li> <li>Orchestration (EKS, ECS, EC2)</li><li>Data Storage (RDS, ElastiCache, ElasticSearch)</li><li>CI / CD (CircleCI, Jenkins, GitLab)</li><li>Monitoring (CloudWatch, CloudTrail, AWS Config)</li><li>End-to-end encryption (TLS, secrets management)</li><li>And much more (<a href="/hipaa-compliance-on-aws/bootstrap-your-app">see the full list of features</a>)</li></ul>
+      Deploy an off-the-shelf, production-grade AWS Architecture that is HIPAA compliant out-of-the-box. The architecture includes: <ul><li>Multi-account Landing Zone</li><li>Networking (VPCs, VPN, SSH, DNS)</li> <li>Orchestration (EKS, ECS, EC2)</li><li>Data Storage (RDS, ElastiCache, ElasticSearch)</li><li>CI / CD (CircleCI, Jenkins, GitLab)</li><li>Monitoring (CloudWatch, CloudTrail, AWS Config)</li><li>End-to-end encryption (TLS, secrets management)</li><li>And much more (<a href="/hipaa-compliance-on-aws/technical-details">see the full list of features</a>)</li></ul>
 
   - heading: Step 2. Bootstrap your app with our HIPAA-compliant templates
     image: /assets/img/hipaa/hipaa-sample-app.png

--- a/pages/landing/hipaa/pricing/index.html
+++ b/pages/landing/hipaa/pricing/index.html
@@ -8,10 +8,10 @@ excerpt: Configure the plan just right for your team.
 permalink: /hipaa-compliance-on-aws/pricing/
 
 extra_nav_links:
-  - name: Gruntwork HIPAA
-    url: /hipaa-compliance-on-aws
-  - name: Bootstrap your app
-    url: /hipaa-compliance-on-aws/bootstrap-your-app
+  - name: Technical Details
+    url: /hipaa-compliance-on-aws/technical-details
+  - name: Why Gruntwork?
+    url: /hipaa-compliance-on-aws/why-gruntwork
 
 pricing:
   - title: Gruntwork HIPAA Early Access

--- a/pages/landing/hipaa/technical-details/index.html
+++ b/pages/landing/hipaa/technical-details/index.html
@@ -4,16 +4,16 @@ type: landing
 slug: index-page
 
 extra_nav_links:
+  - name: Technical Details
+    url: /hipaa-compliance-on-aws/technical-details
   - name: Why Gruntwork?
     url: /hipaa-compliance-on-aws/why-gruntwork
-  - name: Bootstrap your app
-    url: /hipaa-compliance-on-aws/bootstrap-your-app
 
 alternate_cta_link: /hipaa-compliance-on-aws/pricing
 
 title: The fastest way to launch HIPAA-compliant apps on AWS
 excerpt: Build on top of HIPAA-compliant AWS architectures, CI / CD pipelines, and application templates that have been certified HIPAA-compliant via third party audit. We’ll provide a Node.js application to start, followed by Python, Golang and more.
-permalink: /hipaa-compliance-on-aws/bootstrap-your-app/
+permalink: /hipaa-compliance-on-aws/technical-details/
 custom_js:
   - prism
 prism_css: /assets/css/prism-landing-zone.css

--- a/pages/landing/hipaa/why-gruntwork/index.html
+++ b/pages/landing/hipaa/why-gruntwork/index.html
@@ -4,10 +4,10 @@ type: landing
 slug: index-page
 
 extra_nav_links:
+  - name: Technical Details
+    url: /hipaa-compliance-on-aws/technical-details
   - name: Why Gruntwork?
     url: /hipaa-compliance-on-aws/why-gruntwork
-  - name: Bootstrap your app
-    url: /hipaa-compliance-on-aws/bootstrap-your-app
 
 alternate_cta_link: /hipaa-compliance-on-aws/pricing
 


### PR DESCRIPTION
The links weren't consistent across all of the sub-pages. This fixes that, and also renames "Bootstrap your app" to "Technical details" (no change to the content as yet, which I think @zackproser is working on).