### PR TITLE
Fix code viewer height - replace red badge with comment

### DIFF
--- a/_data/hipaa-landing-page-tabs-code.yml
+++ b/_data/hipaa-landing-page-tabs-code.yml
@@ -1,9 +1,13 @@
 - id: runapp
   title: Bash
   content: |
-    <figure><figcaption>Read Secrets From AWS Secrets Manager on startup</figcaption>
+    <figure>
       <pre>
       <code class="language-bash">
+      ######################################
+      # How to read from AWS Secrets Manager 
+      # ####################################
+       
       # Returns the raw value of a secret string stored in AWS Secrets Manager.
       function read_secret_from_aws_secrets_manager {
         local -r environment_name="$1"
@@ -27,9 +31,12 @@
 - id: database
   title: database.js
   content: |
-    <figure><figcaption>Use database secrets to connect securely</figcaption>
+    <figure>
       <pre>
       <code class="language-javascript">
+        /****************************************************
+        * How to use config to connect to a database securely
+        *****************************************************/
         const { sendBackendResponse, sendResponse } = require("../views/views.jsx");
         const db = require("../models/db");
         const config = require("config");
@@ -84,9 +91,12 @@
 - id: servicediscovery
   title: service-call.js
   content: |
-    <figure><figcaption>Discover and call other services</figcaption>
+    <figure>
       <pre>
       <code class="language-js">
+     /****************************************************
+      * How to discover and call other services
+      *****************************************************/
       const { sendResponse } = require("../views/views.jsx");
       const service = require("../models/service");
       const config = require("config");

--- a/_data/hipaa-landing-page-tabs-code.yml
+++ b/_data/hipaa-landing-page-tabs-code.yml
@@ -37,6 +37,7 @@
         /****************************************************
         * How to use config to connect to a database securely
         *****************************************************/
+
         const { sendBackendResponse, sendResponse } = require("../views/views.jsx");
         const db = require("../models/db");
         const config = require("config");
@@ -97,6 +98,7 @@
      /****************************************************
       * How to discover and call other services
       *****************************************************/
+
       const { sendResponse } = require("../views/views.jsx");
       const service = require("../models/service");
       const config = require("config");

--- a/pages/landing/hipaa/technical-details/_how-it-works.html
+++ b/pages/landing/hipaa/technical-details/_how-it-works.html
@@ -32,7 +32,7 @@
             </div>
           {% endfor %}
         </div>
-        <div class="tab_code_content">
+        <div style="max-height: 450px; overflow-y: scroll;"class="tab_code_content">
           {% for tab in site.data.hipaa-landing-page-tabs-code %}
           <div id="{{tab.id}}" class="item_precode {% if forloop.first %}first_tabcontent_code tabcontent_code{% else %}tabcontent_code{% endif %}">
               {{ tab.content }}

--- a/pages/landing/hipaa/technical-details/_how-it-works.html
+++ b/pages/landing/hipaa/technical-details/_how-it-works.html
@@ -32,7 +32,7 @@
             </div>
           {% endfor %}
         </div>
-        <div style="max-height: 450px; overflow-y: scroll;"class="tab_code_content">
+        <div style="height: 450px; overflow-y: scroll;"class="tab_code_content">
           {% for tab in site.data.hipaa-landing-page-tabs-code %}
           <div id="{{tab.id}}" class="item_precode {% if forloop.first %}first_tabcontent_code tabcontent_code{% else %}tabcontent_code{% endif %}">
               {{ tab.content }}


### PR DESCRIPTION
These changes fix the issues raised in [this comment](https://github.com/gruntwork-io/gruntwork-io.github.io/issues/474#issuecomment-885281283) on the application templates (technical details) page. Namely, they: 
* Replace the code viewer's red label with code comments that say the same thing
* Prevent the code viewer from causing re-layout on tab navigation by constraining its maximum height to 450px
* Add `overflow-y: scroll` to the code viewer so that examples longer than 450px automatically scroll.