### PR TITLE
HIPAA Landing Page: Fix contact button, redirect from /hipaa-compliance.

### DIFF
--- a/pages/landing/hipaa/contact/_form.html
+++ b/pages/landing/hipaa/contact/_form.html
@@ -12,7 +12,7 @@
     value="New contact form submission for landing page {{ site.url }}{{ page.url }}"
   />
   <input type="hidden" name="_selection" id="_selection" />
-  <input type="hidden" name="_next" id="_next" value="{{ site.url }}{{ page.url }}/thank-you" />
+  <input type="hidden" name="_next" id="_next" value="{{ site.url }}{{ page.url }}thank-you" />
   <input type="hidden" name="hello_gruntwork" value=""/>
   <input type="hidden" name="_landing-page" value="{{ site.url }}{{ page.url }}" />
   <input type="text" name="_gotcha" style="display:none" />

--- a/pages/landing/hipaa/contact/index.html
+++ b/pages/landing/hipaa/contact/index.html
@@ -2,6 +2,9 @@
 layout: landing
 title: Gruntwork HIPAA early access
 permalink: /hipaa-compliance-on-aws/contact/
+redirect_from: 
+  - /hipaa-cloud-compliance/contact/
+  - /hipaa-compliance/contact/
 slug: contact
 custom_js:
   - contact

--- a/pages/landing/hipaa/index.html
+++ b/pages/landing/hipaa/index.html
@@ -12,7 +12,9 @@ extra_nav_links:
 title: The fastest way to launch HIPAA-compliant apps on AWS
 excerpt: Build your apps on top of HIPAA-compliant application templates. Deploy your apps onto battle-tested AWS architectures that have been certified via third party auditors.
 permalink: /hipaa-compliance-on-aws/
-redirect_from: /hipaa-cloud-compliance/
+redirect_from: 
+  - /hipaa-cloud-compliance/
+  - /hipaa-compliance/
 alternate_cta_link: /hipaa-compliance-on-aws/pricing
 
 hero:

--- a/pages/landing/hipaa/pricing/_need-help.html
+++ b/pages/landing/hipaa/pricing/_need-help.html
@@ -1,6 +1,6 @@
 <div class="panel panel-default panel-light pricing-help-notification" style="margin-top: 100px">
   <div class="panel-body text-center">
     <h2 class="need-help-text">Need help deciding?</h2>
-    <a class="btn btn-primary-hollow btn-sm need-help-button contact-cta" href="{{ page.permalink }}contact/">Contact Sales</a>
+    <a class="btn btn-primary-hollow btn-sm need-help-button contact-cta" href="/hipaa-compliance-on-aws/contact/">Contact Sales</a>
   </div>
 </div>

--- a/pages/landing/hipaa/pricing/_price-col.html
+++ b/pages/landing/hipaa/pricing/_price-col.html
@@ -14,7 +14,7 @@
       </div>
       <div data-mh="plans-pricing-bottom">
         <p>
-          <a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="/hipaa-compliance-on-aws/contact" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">I'm interested</a>
+          <a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="/hipaa-compliance-on-aws/contact" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">Join the waitlist</a>
         </p>
         <p class="text-muted small">
           <em>Annual contract<br>Billed monthly or annually.</em><br>* All prices are subject to change.

--- a/pages/landing/hipaa/pricing/_price-col.html
+++ b/pages/landing/hipaa/pricing/_price-col.html
@@ -14,7 +14,7 @@
       </div>
       <div data-mh="plans-pricing-bottom">
         <p>
-          <a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="/hipaa-compliance/contact" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">I'm interested</a>
+          <a id="pricing-cta-aws" class="btn btn-info pricing-ctas" href="/hipaa-compliance-on-aws/contact" ga-on="click" ga-event-category="{{ page.path | slugify }}" ga-event-action="select-cta">I'm interested</a>
         </p>
         <p class="text-muted small">
           <em>Annual contract<br>Billed monthly or annually.</em><br>* All prices are subject to change.

--- a/pages/landing/hipaa/technical-details/index.html
+++ b/pages/landing/hipaa/technical-details/index.html
@@ -14,7 +14,9 @@ alternate_cta_link: /hipaa-compliance-on-aws/pricing
 title: HIPAA-compliant development patterns and best practices in your favorite languages
 excerpt: We've already developed HIPAA-compliant application templates showing you how to follow the latest compliance standards and cloud-native best practices. All you need to do is follow them in your own code!
 permalink: /hipaa-compliance-on-aws/bootstrap-your-app/
-redirect_from: /hipaa-cloud-compliance/bootstrap-your-app
+redirect_from: 
+  - /hipaa-cloud-compliance/bootstrap-your-app/
+  - /hipaa-compliance/bootstrap-your-app/
 custom_js:
   - prism
 prism_css: /assets/css/prism-landing-zone.css

--- a/pages/landing/hipaa/thank-you/index.html
+++ b/pages/landing/hipaa/thank-you/index.html
@@ -2,7 +2,7 @@
 layout: landing
 title: Thank you for joining the waitlist!
 excerpt: A Grunt will be in touch to let you know as soon as you can get access.
-permalink: /hipaa-compliance-on-aws/pricing/contact/thank-you
+permalink: /hipaa-compliance-on-aws/contact/thank-you
 slug: contact
 ---
 

--- a/pages/landing/hipaa/why-gruntwork/index.html
+++ b/pages/landing/hipaa/why-gruntwork/index.html
@@ -14,7 +14,9 @@ alternate_cta_link: /hipaa-compliance-on-aws/pricing
 title: The fastest way to launch HIPAA-compliant apps on AWS
 excerpt: Build on top of HIPAA-compliant AWS architectures, CI / CD pipelines, and application templates that have been certified via third party audit. We’ll provide a Node.js application to start, followed by Python, Golang and more.
 permalink: /hipaa-compliance-on-aws/why-gruntwork/
-redirect_from: /hipaa-cloud-compliance/why-gruntwork/
+redirect_from: 
+  - /hipaa-cloud-compliance/why-gruntwork/
+  - /hipaa-compliance/why-gruntwork/
 
 hero:
   image: /assets/img/infrastructure-cube-icons/infrastructure-in-a-day.png


### PR DESCRIPTION
Previously clicking the "I'm interested" button went to a 404. This PR fixes that.

In addition, there is now a redirect from `/hipaa-compliance` to `/hipaa-compliance-on-aws`.