### PR TITLE
Attempt to fix redirect issue in prod.

### DIFF
--- a/pages/landing/hipaa/thank-you/index.html
+++ b/pages/landing/hipaa/thank-you/index.html
@@ -2,7 +2,7 @@
 layout: landing
 title: Thank you for joining the waitlist!
 excerpt: A Grunt will be in touch to let you know as soon as you can get access.
-permalink: /hipaa-compliance-on-aws/contact/thank-you
+permalink: /hipaa-compliance-on-aws/contact/thank-you/
 slug: contact
 ---
 


### PR DESCRIPTION
The HIPAA thank you page works fine locally, but not in prod. I'm hoping this trailing `/` is the issue.