### PR TITLE
Remove left padding so logo aligns with body copy

### DIFF
--- a/_includes/landing-navbar.html
+++ b/_includes/landing-navbar.html
@@ -19,11 +19,12 @@
           join: "" | prepend: "/" %}
           <a
             class="navbar-brand navbar-brand-beta"
+            style="padding-left: 0"
             href="{{ landing_page_base_url }}"
             ><strong>Gruntwork</strong>&nbsp;Labs</a
           >
         </div>
-        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-2">
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-2" style="padding: 0">
           <ul class="nav navbar-nav navbar-right">
             <li>
               <a


### PR DESCRIPTION
This will affect all landing pages, but the change is trivial, and just fixes the logo alignment.