### PR TITLE
Fix reference-infra link + tabbed nav

### DIFF
--- a/_includes/landing-navbar-hipaa.html
+++ b/_includes/landing-navbar-hipaa.html
@@ -67,7 +67,7 @@
                     ga-on="click"
                     ga-event-category="nav-{{ page.path | slugify }}"
                     ga-event-action="hipaa-reference-architecture"
-                    >Reference Infrastructure</a
+                    >Reference Architecture</a
                   >
                 </li>
                 <li>

--- a/_includes/landing-navbar-hipaa.html
+++ b/_includes/landing-navbar-hipaa.html
@@ -63,7 +63,7 @@
               <ul class="dropdown-menu dropdown-menu-left" role="menu">
                 <li>
                   <a
-                    href="{{ landing_page_base_url }}/technical-details#reference-infra"
+                    href="{{ landing_page_base_url }}/technical-details/#reference-infra"
                     ga-on="click"
                     ga-event-category="nav-{{ page.path | slugify }}"
                     ga-event-action="hipaa-reference-architecture"


### PR DESCRIPTION
Fixes #520 

Without the trailing slash, the guard in `main.js` that scopes tabbed navigation to the HIPAA technical details page will prevent the navigation code from running.