### PR TITLE
Patcher use cases page: Remove boxes image

### DIFF
--- a/pages/landing/patcher/use-cases/_use-cases.html
+++ b/pages/landing/patcher/use-cases/_use-cases.html
@@ -163,10 +163,6 @@
     border: none;
   }
 
-  .section-dark {
-    margin-bottom: 80px;
-  }
-
 </style>
 
 <script>

--- a/pages/landing/patcher/use-cases/_use-cases.html
+++ b/pages/landing/patcher/use-cases/_use-cases.html
@@ -163,6 +163,10 @@
     border: none;
   }
 
+  .section-dark {
+    margin-bottom: 80px;
+  }
+
 </style>
 
 <script>

--- a/pages/landing/patcher/use-cases/index.html
+++ b/pages/landing/patcher/use-cases/index.html
@@ -67,7 +67,7 @@ footer:
   <div class="section page-pricing-header">
     {% include_relative _hero.html %}
   </div>
-  <div id="use-cases" class="section section-dark">
+  <div id="use-cases" class="section">
     <div class="container">
       {% include_relative _use-cases.html %}
     </div>


### PR DESCRIPTION
Closes #590.

~Added some padding on the bottom, so that the boxes image now fits within the dark background area.~

~On another thought, not sure we want this image there at all, it might be better without it? Thoughts welcome.~

Edit: Decided to remove the boxes image completely.

Preview: https://deploy-preview-601--keen-clarke-470db9.netlify.app/patcher/use-cases/.

Before: 
<img width="1004" alt="before" src="https://user-images.githubusercontent.com/1786860/130068133-a1fd5433-69cc-40fd-9900-61eae3521d5b.png">

After:
<img width="1004" alt="after" src="https://user-images.githubusercontent.com/1786860/130071136-efbfd98a-3d26-4d7b-bc34-326fa067d6ae.png">

