### PR TITLE
Fix unnecessary scrollbar on pricing tables

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -2962,3 +2962,10 @@ input[type=number]::-webkit-outer-spin-button {
 .center-pills {
   display: inline-block;
 }
+
+// This is a fix for https://github.com/gruntwork-io/gruntwork-io.github.io/issues/573. For some reason, when we have
+// the table-responsive class on tables, and those tables have some interior borders, we get an unnecessary horizontal
+// scrollbar. For some crazy reason, adding a transparent 1px border to the table somehow removes that scrollbar.
+.table-responsive-border-fix {
+  border: 1px solid transparent;
+}

--- a/pages/landing/enterprise-eks/pricing/_plans.html
+++ b/pages/landing/enterprise-eks/pricing/_plans.html
@@ -1,6 +1,6 @@
 <div class="row" style="display: block;">
   <div class="table-responsive" style="border: 0;">
-    <table class="table table-condensed table-center">
+    <table class="table table-condensed table-center table-responsive-border-fix">
       <thead>
         {% include_relative _pricing-header.html %}
       </thead>

--- a/pages/landing/hipaa/pricing/_plans.html
+++ b/pages/landing/hipaa/pricing/_plans.html
@@ -1,6 +1,6 @@
 <div class="row" style="display: block;">
   <div class="table-responsive" style="border: 0;">
-    <table class="table table-condensed table-center" style="margin-top: 100px">
+    <table class="table table-condensed table-center table-responsive-border-fix" style="margin-top: 100px">
       <thead>
         {% include_relative _pricing-header.html %}
       </thead>

--- a/pages/landing/migrate-from-heroku/pricing/_plans.html
+++ b/pages/landing/migrate-from-heroku/pricing/_plans.html
@@ -1,6 +1,6 @@
 <div class="row" style="display: block;">
   <div class="table-responsive" style="border: 0;">
-    <table class="table table-condensed table-center" style="margin-top: 100px">
+    <table class="table table-condensed table-center table-responsive-border-fix" style="margin-top: 100px">
       <thead>
         {% include_relative _pricing-header.html %}
       </thead>

--- a/pages/landing/patcher/pricing/_plans.html
+++ b/pages/landing/patcher/pricing/_plans.html
@@ -1,6 +1,6 @@
 <div class="row" style="display: block;">
   <div class="table-responsive" style="border: 0;">
-    <table class="table table-condensed table-center" style="margin-top: 100px">
+    <table class="table table-condensed table-center table-responsive-border-fix" style="margin-top: 100px">
       <thead>
       {% include_relative _pricing-header.html %}
       </thead>


### PR DESCRIPTION
Fixes #573. I found an odd workaround for the horizontal scrollbar that showed up unnecessarily on pricing tables.

Before the PR:

![Screen Shot 2021-08-19 at 1 35 41 PM](https://user-images.githubusercontent.com/711908/130069270-cf63fe7f-6543-44cd-9b58-1c30738053b2.png)


After the PR:

![Screen Shot 2021-08-19 at 1 35 52 PM](https://user-images.githubusercontent.com/711908/130069276-f00c4ce6-5ba1-4ac8-9499-95fae788dfb9.png)
