### PR TITLE
Attempt to enhance IaC messaging

### DIFF
--- a/_data/enterprise-landing-page-tabs-eks-generatecode.yml
+++ b/_data/enterprise-landing-page-tabs-eks-generatecode.yml
@@ -1,83 +1,3 @@
-- id: reposcreenshot
-  title: File structure
-  content: |
-    <figure>
-      <pre>
-      <code class="language-treeview">infrastructure-live/
-      |-- README.md
-      |-- prod/
-      |   `-- us-west-2/
-      |       |-- networking/
-      |       |   |-- alb/
-      |       |   `-- vpc/
-      |       `-- services/
-      |           |-- eks-cluster/
-      |           |-- eks-core-services/
-      |           `-- sample-app/
-      `-- stage/
-          `-- us-west-2/
-              |-- networking/
-              |   |-- alb/
-              |   `-- vpc/
-              `-- services/
-                  |-- eks-cluster/
-                  |-- eks-core-services/
-                  `-- sample-app/</code></pre>
-    </figure>
-
-- id: vpc-deploy-code
-  title: vpc/main.tf
-  content: |
-    <figure><figcaption>prod/us-west-2/networking/vpc/main.tf</figcaption>
-      <pre>
-      <code class="language-hcl">
-      # Example snippet from Terraform code to deploy a VPC
-      # If you already have a VPC, this step will be skipped
-
-      module "vpc" {
-        source =
-          "github.com/gruntwork-io/terraform-aws-vpc//vpc-app"
-
-        vpc_name         = "prod-vpc"
-        cidr_block       = "10.0.0.0/16"
-        num_nat_gateways = 3
-
-        # EKS requires your VPCs/subnets to be tagged a specific way
-        vpc_tags             = module.tags.vpc_tags
-        public_subnet_tags   = module.tags.public_tags
-        private_subnet_tags  = module.tags.private_tags
-      }
-
-      module "tags" {
-        source =
-          "github.com/gruntwork-io/terraform-aws-eks//eks-vpc-tags"
-
-        eks_cluster_names = var.eks_cluster_names
-      }
-
-      module "vpc_network_acls" {
-        source =
-          "github.com/gruntwork-io/terraform-aws-vpc//network-acls"
-
-        vpc_id             = module.vpc.vpc_id
-        public_subnet_ids  = module.vpc.public_subnet_ids
-        private_subnet_ids = module.vpc.private_subnet_ids
-      }
-
-      module "vpc_flow_logs" {
-        source
-          = "github.com/gruntwork-io/terraform-aws-vpc/flow-logs"
-
-        vpc_id         = module.vpc.vpc_id
-        log_group_name = "${module.vpc.vpc_name}-flow-logs"
-        kms_key_users  = var.kms_key_user_iam_arns
-        kms_key_arn    = var.kms_key_arn
-        traffic_type   = var.flow_logs_traffic_type
-      }
-      </code>
-      </pre>
-      <figure>
-
 - id: cluster-deploy-code
   title: eks-cluster/main.tf
   content: |
@@ -136,6 +56,59 @@
         #       For dev, this will be set to gruntwork-dev.com
         external_dns_route53_hosted_zone_id_filters =
           ["gruntwork.io"]
+      }
+      </code>
+      </pre>
+      <figure>
+
+- id: vpc-deploy-code
+  title: vpc/main.tf
+  content: |
+    <figure><figcaption>prod/us-west-2/networking/vpc/main.tf</figcaption>
+      <pre>
+      <code class="language-hcl">
+      # Example snippet from Terraform code to deploy a VPC
+      # If you already have a VPC, this step will be skipped
+
+      module "vpc" {
+        source =
+          "github.com/gruntwork-io/terraform-aws-vpc//vpc-app"
+
+        vpc_name         = "prod-vpc"
+        cidr_block       = "10.0.0.0/16"
+        num_nat_gateways = 3
+
+        # EKS requires your VPCs/subnets to be tagged a specific way
+        vpc_tags             = module.tags.vpc_tags
+        public_subnet_tags   = module.tags.public_tags
+        private_subnet_tags  = module.tags.private_tags
+      }
+
+      module "tags" {
+        source =
+          "github.com/gruntwork-io/terraform-aws-eks//eks-vpc-tags"
+
+        eks_cluster_names = var.eks_cluster_names
+      }
+
+      module "vpc_network_acls" {
+        source =
+          "github.com/gruntwork-io/terraform-aws-vpc//network-acls"
+
+        vpc_id             = module.vpc.vpc_id
+        public_subnet_ids  = module.vpc.public_subnet_ids
+        private_subnet_ids = module.vpc.private_subnet_ids
+      }
+
+      module "vpc_flow_logs" {
+        source
+          = "github.com/gruntwork-io/terraform-aws-vpc/flow-logs"
+
+        vpc_id         = module.vpc.vpc_id
+        log_group_name = "${module.vpc.vpc_name}-flow-logs"
+        kms_key_users  = var.kms_key_user_iam_arns
+        kms_key_arn    = var.kms_key_arn
+        traffic_type   = var.flow_logs_traffic_type
       }
       </code>
       </pre>

--- a/pages/landing/enterprise-eks/_hero.html
+++ b/pages/landing/enterprise-eks/_hero.html
@@ -12,10 +12,10 @@
   </h1>
   <div class="clearfix hidden-print">
     <ul class="check-list check-white" style="display: inline-block; text-align: left; margin-bottom: 0;">
-      <li>Secure, enterprise-grade, CIS-compliant EKS cluster.</li>
-      <li>Cloud-native, self-service app deployment.</li>
-      <li>Delivered as Terraform code owned 100% by you.</li>
-      <li>With commercial maintenance and support from Gruntwork.</li>
+      <li>Deploy enterprise-grade, CIS-compliant EKS clusters into your AWS accounts.</li>
+      <li>Set up CI/CD pipelines and self-service tools for app deployment.</li>
+      <li>Control, customize, and manage everything as code using Terraform.</li>
+      <li>Get commercial maintenance and support from Gruntwork.</li>
     </ul>
   </div>
   <div>

--- a/pages/landing/enterprise-eks/index.html
+++ b/pages/landing/enterprise-eks/index.html
@@ -7,7 +7,7 @@ extra_nav_links:
   - name: Why Gruntwork
     url: /eks-for-enterprise/#why-gruntwork
 
-title: Amazon EKS for the enterprise. 100% managed as code. In about a day.
+title: Amazon EKS for the enterprise.<br/>100% managed as code.<br/>In about a day.
 permalink: /eks-for-enterprise/
 custom_js:
 - prism

--- a/pages/landing/enterprise-eks/index.html
+++ b/pages/landing/enterprise-eks/index.html
@@ -109,7 +109,7 @@ how_it_works:
       - title: Flux
         src: /assets/img/logos-technologies/logo-flux.png
 
-  - heading: "Step 2: Generate Code"
+  - heading: "Step 2: Generate and Customize Code"
     tab_code_preview: eks-generatecode
     image_side: left
     body: |

--- a/pages/landing/enterprise-eks/index.html
+++ b/pages/landing/enterprise-eks/index.html
@@ -7,7 +7,7 @@ extra_nav_links:
   - name: Why Gruntwork
     url: /eks-for-enterprise/#why-gruntwork
 
-title: Amazon EKS for the enterprise. In about a day.
+title: Amazon EKS for the enterprise. Defined as code. In about a day.
 permalink: /eks-for-enterprise/
 custom_js:
 - prism

--- a/pages/landing/enterprise-eks/index.html
+++ b/pages/landing/enterprise-eks/index.html
@@ -7,7 +7,7 @@ extra_nav_links:
   - name: Why Gruntwork
     url: /eks-for-enterprise/#why-gruntwork
 
-title: Amazon EKS for the enterprise. Defined as code. In about a day.
+title: Amazon EKS for the enterprise. 100% managed as code. In about a day.
 permalink: /eks-for-enterprise/
 custom_js:
 - prism
@@ -109,7 +109,7 @@ how_it_works:
       - title: Flux
         src: /assets/img/logos-technologies/logo-flux.png
 
-  - heading: "Step 2: Generate and Customize Code"
+  - heading: "Step 2: Generate code and customize it to your needs"
     tab_code_preview: eks-generatecode
     image_side: left
     body: |
@@ -123,12 +123,12 @@ how_it_works:
       - title: BitBucket
         src: /assets/img/landing-heroku-page/bitbucket-icon.png
 
-  - heading: "Step 3: Deploy your EKS cluster"
+  - heading: "Step 3: Deploy your EKS cluster into your AWS account"
     image: /assets/img/landing-page-enterprise/tfc-plan-apply.gif
     image_caption: Deploy generated code in the browser using Terraform Cloud / Enterprise.
     image_side: right
     body: |
-      Deploy your EKS cluster using one of the supported deployment tools:
+      Deploy your EKS cluster into your AWS account using one of the supported deployment tools:
       <ul>
           <li>Gruntwork Pipelines</li>
           <li>Terraform Cloud</li>


### PR DESCRIPTION
From the user testing studies, we learned that many folks did not seem to realize that we were providing IaC code they can customize and use to deploy the cluster.

Based on how users navigate the website, it seems that this message needs to be conveyed in the big hero text and first few steps. This PR is an attempt of highlighting that they get the code by making small, but important tweaks to two of the headings.