### PR TITLE
[APT-1373] Switch from Chargebee to Recurly for checkout.

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -44,6 +44,9 @@ p + .btn {
     transform: translateY(-2px);
     box-shadow: 0 6px 9px rgba(0,0,0,.10), 0 2px 5px rgba(0,0,0,.07);
   }
+  max-width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 .btn-link {
   box-shadow: none;
@@ -2319,10 +2322,13 @@ $play-button-height: 44px;
 }
 .checkout-panel-left {
   padding: 0px;
-  margin-right: 10px;
 
   @media (max-width: $screen-xs-max) {
     padding: 16px 8px;
+  }
+
+  @media (min-width: $screen-sm-max) {
+    margin-right: 10px;
   }
 }
 .checkout-panel-right {

--- a/assets/css/pages/checkout.scss
+++ b/assets/css/pages/checkout.scss
@@ -19,8 +19,8 @@
 }
 
 .checkout-help-notification {
-  width: 103%;
-  margin-left: -.8em;
+  width: calc(100% + 30px);
+  margin-left: -15px;
 }
 
 #checkout-money-back {
@@ -36,15 +36,12 @@
 
     .sub-panel {
       background-color: #1D252F;
-      line-height: 1;
+      line-height: 1.4;
 
       .addon-amount {
         font-size: 25px;
         margin-top: 15px;
         font-weight: bold;
-        @media (max-width: $screen-sm-max) {
-          margin-top: 0px;
-        }
       }
       .addon-duration {
         margin-top: -25px;
@@ -81,20 +78,11 @@
   }
 }
 
-#checkout-btn-container {
-  @media (max-width: $screen-xs-max) {
-    height: 25px;
-  }
-  @media (min-width: $screen-sm-min) {
-    height: 52px;
-  }
-}
-
 #checkout-btn-container-beta {
   @media (max-width: $screen-xs-max) {
-    height: 41px;
+    margin: 0;
   }
   @media (min-width: $screen-sm-min) {
-    height: 52px;
+    margin: 1em 0;
   }
 }

--- a/assets/css/pages/pricing.scss
+++ b/assets/css/pages/pricing.scss
@@ -89,6 +89,12 @@
   margin-bottom: .6em;
 }
 
+@media (max-width: $screen-xs-max) {
+  .need-help-button {
+    margin: 2em;
+  }
+}
+
 .pricing-steps {
   display: flex;
   align-items: center;

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -249,7 +249,10 @@ $(function () {
 
     var href = "https://gruntwork-sandbox.recurly.com/subscribe/" + type + "-monthly?";
 
-    const addOns = { "users": 20 };
+    // We'll want to pass users when we switch from using the Recurly hosted payment
+    // page to our own, at which point we can re-enable the users add-on.
+
+    const addOns = { /*"users": 20*/ };
     if (support) {
       addOns["pro-support"] = 1;
     }

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -247,7 +247,7 @@ $(function () {
     const refarch = checkoutOptions.setup_deployment;
     const compliance = checkoutOptions.setup_compliance;
 
-    var href = "https://gruntwork-sandbox.recurly.com/subscribe/" + type + "-monthly?";
+    var href = "https://gruntwork.recurly.com/subscribe/" + type + "-monthly?";
 
     // We'll want to pass users when we switch from using the Recurly hosted payment
     // page to our own, at which point we can re-enable the users add-on.

--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -244,7 +244,7 @@ $(function () {
   function _updateCheckoutLink() {
     const type = checkoutOptions.subscription_type;
     const support = checkoutOptions.pro_support;
-    const setup = checkoutOptions.setup_deployment;
+    const refarch = checkoutOptions.setup_deployment;
     const compliance = checkoutOptions.setup_compliance;
 
     var href = "https://gruntwork-sandbox.recurly.com/subscribe/" + type + "-monthly?";
@@ -253,7 +253,7 @@ $(function () {
     if (support) {
       addOns["pro-support"] = 1;
     }
-    if (setup) {
+    if (refarch) {
       addOns["ref-arch"] = 1;
     }
     if (compliance) {
@@ -266,8 +266,10 @@ $(function () {
       add_on_quantity: Object.values(addOns).toString(),
     };
 
+    sep = "";
     for (const key in params) {
-      href += "&" + key + "=" + params[key]
+      href += sep + key + "=" + params[key];
+      sep = "&";
     }
 
     $("#recurly-checkout-btn").attr("href", href);

--- a/pages/checkout/_checkout.html
+++ b/pages/checkout/_checkout.html
@@ -11,7 +11,7 @@
           <span
             class="large-price visible-xs-inline large-price--mobile"
             style="white-space: nowrap;"
-            ><span>$</span><strong id="subscription-subtotal"></strong></span
+            ><span>$</span><strong class="monthly-total"></strong></span
           ><span
             class="small text-muted visible-xs-inline"
             style="white-space: nowrap;"
@@ -27,7 +27,7 @@
           >
           <div class="visible-sm-block visible-md-block visible-lg-block">
             <span class="large-price"
-              ><span>$</span><strong id="subscription-price"></strong></span
+              ><span>$</span><strong class="monthly-total"></strong></span
             >&nbsp; / month
             <p
               class="text-center"
@@ -151,23 +151,19 @@
         Annual Contract. Billed monthly.
       </p>
       <div id="checkout-btn-container-beta">
-        <p
+        <div
           class="small text-white text-bold margin-top-none text-center"
-          id="deposit-due"
           style="margin-bottom: 0"
         >
-          Deposit Due<span class="hide-on-tiny"> Today</span>: $500
-        </p>
+          <div>
+            Due<span class="hide-on-tiny"> Today</span>: $<span id="due-now">500</span>
+          </div>
+          <div id="due-monthly-block" class="hidden-xs text-muted">
+            Then just $<span class="monthly-total"></span><span class="small" style="white-space: nowrap;">&nbsp;/ month</span>
+          </div>
+        </div>
       </div>
-      <button
-        id="checkout-btn"
-        type="button"
-        class="btn btn-info btn-block btn-checkout"
-        data-cb-type="checkout"
-        data-cb-plan-id="chargebee-subscription"
-      >
-        Checkout
-      </button>
+      <a id="recurly-checkout-btn" class="btn btn-info btn-block btn-checkout" href="https://gruntwork-io.recurly.com/subscribe/foo?quantity=5">Checkout</a>
       <p>
         <a
           id="checkout-contact-btn"

--- a/pages/checkout/_checkout.html
+++ b/pages/checkout/_checkout.html
@@ -163,7 +163,7 @@
           </div>
         </div>
       </div>
-      <a id="recurly-checkout-btn" class="btn btn-info btn-block btn-checkout" href="#">Checkout</a>
+      <a id="recurly-checkout-btn" class="btn btn-info btn-block btn-checkout" href="https://gruntwork.recurly.com/subscribe/aws-monthly?theme=modern">Checkout</a>
       <p>
         <a
           id="checkout-contact-btn"

--- a/pages/checkout/_checkout.html
+++ b/pages/checkout/_checkout.html
@@ -163,7 +163,7 @@
           </div>
         </div>
       </div>
-      <a id="recurly-checkout-btn" class="btn btn-info btn-block btn-checkout" href="https://gruntwork-io.recurly.com/subscribe/foo?quantity=5">Checkout</a>
+      <a id="recurly-checkout-btn" class="btn btn-info btn-block btn-checkout" href="#">Checkout</a>
       <p>
         <a
           id="checkout-contact-btn"


### PR DESCRIPTION
In addition to the checkout service change, this tidies up a bit of CSS, fixes a bug that caused incorrect subscription totals from being shown on mobile, and replaces the $500 deposit with a "due now" total equal to the first month + fixed costs (i. e. RefArch), and supporting text to indicate the ongoing monthly fee.

We must wait to merge this until the production Recurly service is fully configured for use, the URL updated in this patch, and the new Recurly checkout zap turned on.