### PR TITLE
Minor text fixes in the Contractor job description

### DIFF
--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -141,16 +141,15 @@
       <li>
         <strong>World-class customer support:</strong> While participating in
         business-hours only support rotations, triage customer requests, teach
-        Gruntwork and DevOps best-practices, help resolve problems, escalate to
-        internal SMEs, and automate and document the solutions so that problems
-        are mitigated for future users.
+        Gruntwork and DevOps best-practices, help resolve problems, and automate
+        and document the solutions so that problems are mitigated for future users.
       </li>
     </ul>
     <h4>Your Ideal Background</h4>
     <ul>
       <li>You have a strong background in software engineering, with 5+ years of experience.</li>
       <li>You know how to write Infrastructure as Code using Terraform. </li>
-      <li>You know have deep experience with AWS.</li>
+      <li>You have deep experience with AWS.</li>
       <li>
         You hate doing the same thing twice and would rather spend the time to
         automate a problem away than do the same work again.


### PR DESCRIPTION
- Remove "escalate to internal SMEs"
- Remove extra word at "You know have deep experience with AWS".