### PR TITLE
[WiP][APT-1486] Understand what Gruntwork offers regarding GCP and Azure

### DIFF
--- a/pages/gruntwork-for-azure/_form.html
+++ b/pages/gruntwork-for-azure/_form.html
@@ -1,21 +1,22 @@
 <div id="error-message"></div>
 <!-- add new link for the formbucket (Azure) -->
-<form id="contact-form" method="post" target="_blank" action="">
+<form id="contact-form" method="post" target="_blank" action="https://formbucket.com/f/buk_T0LjTMcNI2uaq0e0zYvvs4y0">
   <input type="hidden" name="_subject" id="_subject" value="New inquiry from {{ site.url }}" />
   <input type="hidden" name="_viewing" id="_viewing" value="v1-static" />
   <input type="hidden" name="_next" id="_next" value="{{ site.url }}/thanks/" />
   <input type="hidden" name="hello_gruntwork" value="" />
+  <input type="hidden" name="cloud" value="Azure" />
   <input type="text" name="_gotcha" style="display:none" />
   {% include_relative _input-text.html id="contact-name" label="Name"
-  required=true placeholder="Jon Doe" %} {% include_relative _input-text.html
-  id="contact-email" label="Email" required=true placeholder="jon@acme.com"
+  required=true placeholder="Janice Doe" %} {% include_relative _input-text.html
+  id="contact-email" label="Email" required=true placeholder="janice@acme.com"
   type="email" %} {% include_relative _input-text.html id="contact-company"
   label="Company" required=true placeholder="Acme, Inc." %}
 
   <div class="form-group">
     <div class="row">
       <div class="col-xs-12 col-md-4">
-        <label for="contact-message">How can we help?</label>
+        <label for="contact-message">What would you most like to see in a Gruntwork for Azure solution?</label>
       </div>
       <div class="col-xs-12 col-md-8">
         <textarea id="contact-message" name="contact-message" class="form-control" rows="3" required="required"

--- a/pages/gruntwork-for-azure/_form.html
+++ b/pages/gruntwork-for-azure/_form.html
@@ -1,0 +1,33 @@
+<div id="error-message"></div>
+<!-- add new link for the formbucket (Azure) -->
+<form id="contact-form" method="post" target="_blank" action="">
+  <input type="hidden" name="_subject" id="_subject" value="New inquiry from {{ site.url }}" />
+  <input type="hidden" name="_viewing" id="_viewing" value="v1-static" />
+  <input type="hidden" name="_next" id="_next" value="{{ site.url }}/thanks/" />
+  <input type="hidden" name="hello_gruntwork" value="" />
+  <input type="text" name="_gotcha" style="display:none" />
+  {% include_relative _input-text.html id="contact-name" label="Name"
+  required=true placeholder="Jon Doe" %} {% include_relative _input-text.html
+  id="contact-email" label="Email" required=true placeholder="jon@acme.com"
+  type="email" %} {% include_relative _input-text.html id="contact-company"
+  label="Company" required=true placeholder="Acme, Inc." %}
+
+  <div class="form-group">
+    <div class="row">
+      <div class="col-xs-12 col-md-4">
+        <label for="contact-message">How can we help?</label>
+      </div>
+      <div class="col-xs-12 col-md-8">
+        <textarea id="contact-message" name="contact-message" class="form-control" rows="3" required="required"
+          placeholder="Enter a message"></textarea>
+      </div>
+    </div>
+  </div>
+  <div class="text-center">
+    <br />
+    <button type="submit" id="submit-button" class="btn btn-primary" ga-on="click"
+      ga-event-category="contact-form-azure" ga-event-action="submit">
+      Submit
+    </button>
+  </div>
+</form>

--- a/pages/gruntwork-for-azure/_gruntwork-for-azure.html
+++ b/pages/gruntwork-for-azure/_gruntwork-for-azure.html
@@ -1,9 +1,8 @@
 <div class="row row-page-header">
   <div class="col-xs-12">
-    <h3>Gruntwork for Azure</h3>
-    <p>We will add support for Azure in the future. Once we feel our AWS solution implements the critical subset of our
-      full vision, we will use the same patterns to create a solution for Azure.</p>
-    <p>Interested in being notified when Azure support is available? Let us know.
+    <h3>We will add support for Azure in the future.</h3>
+    <p>Once our AWS solution implements the critical subset of our full vision, we will use the same patterns 
+       to create a new solution for Azure. Interested in being notified when Azure support is available? Let us know.
     </p>
   </div>
 </div>

--- a/pages/gruntwork-for-azure/_gruntwork-for-azure.html
+++ b/pages/gruntwork-for-azure/_gruntwork-for-azure.html
@@ -1,0 +1,9 @@
+<div class="row row-page-header">
+  <div class="col-xs-12">
+    <h3>Gruntwork for Azure</h3>
+    <p>We will add support for Azure in the future. Once we feel our AWS solution implements the critical subset of our
+      full vision, we will use the same patterns to create a solution for Azure.</p>
+    <p>Interested in being notified when Azure support is available? Let us know.
+    </p>
+  </div>
+</div>

--- a/pages/gruntwork-for-azure/_hero.html
+++ b/pages/gruntwork-for-azure/_hero.html
@@ -1,0 +1,7 @@
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12">
+      <h1>{{ page.title }}</h1>
+    </div>
+  </div>
+</div>

--- a/pages/gruntwork-for-azure/_input-check.html
+++ b/pages/gruntwork-for-azure/_input-check.html
@@ -1,0 +1,10 @@
+<div class="checkbox">
+  <input id="{{ include.id }}" name="{{ include.id }}" type="checkbox" value="true">
+  <label for="{{ include.id }}">
+    {{ include.label }}
+    {% if include.small_text %}
+      <br>
+    <small style="font-size: 12px; display: block; margin-bottom: 10px">{{ include.small_text }}</small>
+    {% endif %}
+  </label>
+</div>

--- a/pages/gruntwork-for-azure/_input-hidden.html
+++ b/pages/gruntwork-for-azure/_input-hidden.html
@@ -1,0 +1,1 @@
+<input id="{{ include.id }}" name="{{ include.id }}" type="hidden" class="form-control">

--- a/pages/gruntwork-for-azure/_input-text.html
+++ b/pages/gruntwork-for-azure/_input-text.html
@@ -1,0 +1,10 @@
+<div class="form-group">
+  <div class="row">
+    <div class="col-xs-12 col-md-4">
+      <label for="{{ include.id }}">{{ include.label }}</label>
+    </div>
+    <div class="col-xs-12 col-md-8">
+      <input id="{{ include.id }}" name="{{ include.id }}" type="{% if include.type %}{{ include.type }}{% else %}text{% endif %}" class="form-control" placeholder="{{ include.placeholder }}"{% if include.required %} required="required"{% endif %}>
+    </div>
+  </div>
+</div>

--- a/pages/gruntwork-for-azure/index.html
+++ b/pages/gruntwork-for-azure/index.html
@@ -1,8 +1,11 @@
 ---
 layout: default
-title: Azure
+title: Gruntwork IaC Library for Azure
 permalink: /gruntwork-for-azure/
 slug: gruntwork-for-azure
+custom_js:
+  - contact
+use_recaptcha: true
 ---
 
 <div class="main gruntwork-for-azure">

--- a/pages/gruntwork-for-azure/index.html
+++ b/pages/gruntwork-for-azure/index.html
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Azure
+permalink: /gruntwork-for-azure/
+slug: gruntwork-for-azure
+---
+
+<div class="main gruntwork-for-azure">
+  <div class="section section-hero">
+    {% include_relative _hero.html %}
+  </div>
+  <div class="section section-dark">
+    <div class="container">
+      {% include_relative _gruntwork-for-azure.html %}
+      <div class="row row-form">
+        <div class="col-xs-12 col-md-8 col-md-offset-2">
+          {% include_relative _form.html %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/pages/gruntwork-for-gcp/_form.html
+++ b/pages/gruntwork-for-gcp/_form.html
@@ -1,0 +1,33 @@
+<div id="error-message"></div>
+<!-- add new link for the formbucket (GCP) -->
+<form id="contact-form" method="post" target="_blank" action="">
+  <input type="hidden" name="_subject" id="_subject" value="New inquiry from {{ site.url }}" />
+  <input type="hidden" name="_viewing" id="_viewing" value="v1-static" />
+  <input type="hidden" name="_next" id="_next" value="{{ site.url }}/thanks/" />
+  <input type="hidden" name="hello_gruntwork" value="" />
+  <input type="text" name="_gotcha" style="display:none" />
+  {% include_relative _input-text.html id="contact-name" label="Name"
+  required=true placeholder="Jon Doe" %} {% include_relative _input-text.html
+  id="contact-email" label="Email" required=true placeholder="jon@acme.com"
+  type="email" %} {% include_relative _input-text.html id="contact-company"
+  label="Company" required=true placeholder="Acme, Inc." %}
+
+  <div class="form-group">
+    <div class="row">
+      <div class="col-xs-12 col-md-4">
+        <label for="contact-message">How can we help?</label>
+      </div>
+      <div class="col-xs-12 col-md-8">
+        <textarea id="contact-message" name="contact-message" class="form-control" rows="3" required="required"
+          placeholder="Enter a message"></textarea>
+      </div>
+    </div>
+  </div>
+  <div class="text-center">
+    <br />
+    <button type="submit" id="submit-button" class="btn btn-primary" ga-on="click" ga-event-category="contact"
+      ga-event-action="submit">
+      Submit
+    </button>
+  </div>
+</form>

--- a/pages/gruntwork-for-gcp/_form.html
+++ b/pages/gruntwork-for-gcp/_form.html
@@ -1,21 +1,22 @@
 <div id="error-message"></div>
 <!-- add new link for the formbucket (GCP) -->
-<form id="contact-form" method="post" target="_blank" action="">
+<form id="contact-form" method="post" target="_blank" action="https://formbucket.com/f/buk_T0LjTMcNI2uaq0e0zYvvs4y0">
   <input type="hidden" name="_subject" id="_subject" value="New inquiry from {{ site.url }}" />
   <input type="hidden" name="_viewing" id="_viewing" value="v1-static" />
   <input type="hidden" name="_next" id="_next" value="{{ site.url }}/thanks/" />
   <input type="hidden" name="hello_gruntwork" value="" />
+  <input type="hidden" name="cloud" value="GCP" />
   <input type="text" name="_gotcha" style="display:none" />
   {% include_relative _input-text.html id="contact-name" label="Name"
-  required=true placeholder="Jon Doe" %} {% include_relative _input-text.html
-  id="contact-email" label="Email" required=true placeholder="jon@acme.com"
+  required=true placeholder="Janice Doe" %} {% include_relative _input-text.html
+  id="contact-email" label="Email" required=true placeholder="janice@acme.com"
   type="email" %} {% include_relative _input-text.html id="contact-company"
   label="Company" required=true placeholder="Acme, Inc." %}
 
   <div class="form-group">
     <div class="row">
       <div class="col-xs-12 col-md-4">
-        <label for="contact-message">How can we help?</label>
+        <label for="contact-message">What would you most like to see in a Gruntwork for GCP solution?</label>
       </div>
       <div class="col-xs-12 col-md-8">
         <textarea id="contact-message" name="contact-message" class="form-control" rows="3" required="required"
@@ -25,8 +26,8 @@
   </div>
   <div class="text-center">
     <br />
-    <button type="submit" id="submit-button" class="btn btn-primary" ga-on="click" ga-event-category="contact"
-      ga-event-action="submit">
+    <button type="submit" id="submit-button" class="btn btn-primary" ga-on="click" 
+      ga-event-category="contact-form-gcp" ga-event-action="submit">
       Submit
     </button>
   </div>

--- a/pages/gruntwork-for-gcp/_gruntwork-for-gcp.html
+++ b/pages/gruntwork-for-gcp/_gruntwork-for-gcp.html
@@ -1,12 +1,11 @@
 <div class="row row-page-header">
   <div class="col-xs-12">
-    <h3>Gruntwork for GCP</h3>
-    <p>We will add commercial support for GCP in the future. Once we feel our AWS solution implements the critical
-      subset of our full vision, we will use the same patterns to create a new solution for GCP. If you want a small
+    <h3>We will add support for GCP in the future.</h3>
+    <p>Once our AWS solution implements the critical subset of our full vision, we will use the same patterns 
+      to create a new solution for GCP. If you want a small
       preview of some early work we did for GCP in partnership with Google, check out our <a
-        href="https://github.com/gruntwork-io/terraform-google-gke/issues/129" title="Open source GCP modules"
-        target="_blank">open
-        source GCP modules.</a></p>
+      href="https://github.com/gruntwork-io?q=google" title="Open source GCP modules"
+      target="_blank">open source GCP modules.</a></p>
     <p>Interested in being notified when GCP support is available? Let us know.
     </p>
   </div>

--- a/pages/gruntwork-for-gcp/_gruntwork-for-gcp.html
+++ b/pages/gruntwork-for-gcp/_gruntwork-for-gcp.html
@@ -1,0 +1,13 @@
+<div class="row row-page-header">
+  <div class="col-xs-12">
+    <h3>Gruntwork for GCP</h3>
+    <p>We will add commercial support for GCP in the future. Once we feel our AWS solution implements the critical
+      subset of our full vision, we will use the same patterns to create a new solution for GCP. If you want a small
+      preview of some early work we did for GCP in partnership with Google, check out our <a
+        href="https://github.com/gruntwork-io/terraform-google-gke/issues/129" title="Open source GCP modules"
+        target="_blank">open
+        source GCP modules.</a></p>
+    <p>Interested in being notified when GCP support is available? Let us know.
+    </p>
+  </div>
+</div>

--- a/pages/gruntwork-for-gcp/_hero.html
+++ b/pages/gruntwork-for-gcp/_hero.html
@@ -1,0 +1,7 @@
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12">
+      <h1>{{ page.title }}</h1>
+    </div>
+  </div>
+</div>

--- a/pages/gruntwork-for-gcp/_input-check.html
+++ b/pages/gruntwork-for-gcp/_input-check.html
@@ -1,0 +1,10 @@
+<div class="checkbox">
+  <input id="{{ include.id }}" name="{{ include.id }}" type="checkbox" value="true">
+  <label for="{{ include.id }}">
+    {{ include.label }}
+    {% if include.small_text %}
+      <br>
+    <small style="font-size: 12px; display: block; margin-bottom: 10px">{{ include.small_text }}</small>
+    {% endif %}
+  </label>
+</div>

--- a/pages/gruntwork-for-gcp/_input-hidden.html
+++ b/pages/gruntwork-for-gcp/_input-hidden.html
@@ -1,0 +1,1 @@
+<input id="{{ include.id }}" name="{{ include.id }}" type="hidden" class="form-control">

--- a/pages/gruntwork-for-gcp/_input-text.html
+++ b/pages/gruntwork-for-gcp/_input-text.html
@@ -1,0 +1,10 @@
+<div class="form-group">
+  <div class="row">
+    <div class="col-xs-12 col-md-4">
+      <label for="{{ include.id }}">{{ include.label }}</label>
+    </div>
+    <div class="col-xs-12 col-md-8">
+      <input id="{{ include.id }}" name="{{ include.id }}" type="{% if include.type %}{{ include.type }}{% else %}text{% endif %}" class="form-control" placeholder="{{ include.placeholder }}"{% if include.required %} required="required"{% endif %}>
+    </div>
+  </div>
+</div>

--- a/pages/gruntwork-for-gcp/index.html
+++ b/pages/gruntwork-for-gcp/index.html
@@ -1,0 +1,22 @@
+---
+layout: default
+title: GCP
+permalink: /gruntwork-for-gcp/
+slug: gruntwork-for-gcp
+---
+
+<div class="main gruntwork-for-gcp">
+  <div class="section section-hero">
+    {% include_relative _hero.html %}
+  </div>
+  <div class="section section-dark">
+    <div class="container">
+      {% include_relative _gruntwork-for-gcp.html %}
+      <div class="row row-form">
+        <div class="col-xs-12 col-md-8 col-md-offset-2">
+          {% include_relative _form.html %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/pages/gruntwork-for-gcp/index.html
+++ b/pages/gruntwork-for-gcp/index.html
@@ -1,8 +1,11 @@
 ---
 layout: default
-title: GCP
+title: Gruntwork IaC Library for GCP
 permalink: /gruntwork-for-gcp/
 slug: gruntwork-for-gcp
+custom_js:
+  - contact
+use_recaptcha: true
 ---
 
 <div class="main gruntwork-for-gcp">

--- a/pages/infrastructure-as-code-library/_supported-clouds.html
+++ b/pages/infrastructure-as-code-library/_supported-clouds.html
@@ -1,11 +1,12 @@
 <div class="row row-page-header">
   <div class="col-xs-12">
-    <h2>Supported Clouds</h2>
+    <h2>What clouds do you support?</h2>
     <p>
-      The Gruntwork IaC Library is designed for use with Amazon Web Services (AWS). Learn more about our support for:
+      The Gruntwork IaC Library is designed for use with <strong>Amazon Web Services (AWS)</strong>. We hope to add support
+      for other clouds in the future. Learn more below:
     <ul>
-      <li><a href="/gruntwork-for-azure">Azure</a></li>
-      <li><a href="/gruntwork-for-gcp">GCP</a></li>
+      <li><a href="/gruntwork-for-azure">Gruntwork IaC Library for Azure</a></li>
+      <li><a href="/gruntwork-for-gcp">Gruntwork IaC Library for GCP</a></li>
     </ul>
     </p>
   </div>

--- a/pages/infrastructure-as-code-library/_supported-clouds.html
+++ b/pages/infrastructure-as-code-library/_supported-clouds.html
@@ -1,0 +1,12 @@
+<div class="row row-page-header">
+  <div class="col-xs-12">
+    <h2>Supported Clouds</h2>
+    <p>
+      The Gruntwork IaC Library is designed for use with Amazon Web Services (AWS). Learn more about our support for:
+    <ul>
+      <li><a href="/gruntwork-for-azure">Azure</a></li>
+      <li><a href="/gruntwork-for-gcp">GCP</a></li>
+    </ul>
+    </p>
+  </div>
+</div>

--- a/pages/infrastructure-as-code-library/index.html
+++ b/pages/infrastructure-as-code-library/index.html
@@ -23,6 +23,7 @@ redirect_from:
         <div class="col-xs-12">
           {% include_relative _library.html %} {% include_relative
           _features.html %} {% include_relative _process.html %}
+          {% include_relative _supported-clouds.html %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
[APT-1486](https://gruntwork.atlassian.net/browse/APT-1486)

This PR adds:
- new page 'gruntwork for azure'
- new page 'gruntwork for gcp'
- new section to the IAC library page (supported clouds)

Still in progress, I based on this comment: https://gruntwork.atlassian.net/browse/APT-1486?focusedCommentId=14144
 
Few questions:
- I'm not really sure if we are on the same page with this task so please let me know if this a good start? 
- I couldn't find which text should be in the hero (I've added Azure & GCP)
- Should I add two separate formbuckets to these forms? (If so we don't access to your formbucket acc anymore) 
- what else should we change here

`/infrastructure-as-code-library`
![51 195 102 206_4000_infrastructure-as-code-library_](https://user-images.githubusercontent.com/4997537/139509540-35a058a7-70ad-4dec-b09c-ae79c80e7d41.png)

`/gruntwork-for-azure`
![51 195 102 206_4000_gruntwork-for-azure_](https://user-images.githubusercontent.com/4997537/139509631-a94e0d51-f417-48c9-8b73-a449ee569af9.png)

`/gruntwork-for-gcp`
![51 195 102 206_4000_gruntwork-for-gcp_](https://user-images.githubusercontent.com/4997537/139509673-d060c118-2d48-4308-a3c8-4b2870a2fccf.png)


