### PR TITLE
Change Community Forum to Knowledge Base in footer

### DIFF
--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -84,8 +84,8 @@
     - title: Newsletter
       url: /newsletter/
 
-    - title: Community Forum
-      url: "https://community.gruntwork.io/"
+    - title: Knowledge Base
+      url: "https://github.com/gruntwork-io/knowledge-base/discussions"
 
     - title: Gruntwork Store
       url: "https://store.gruntwork.io/"


### PR DESCRIPTION
I'm leaving other mentions of the Community Forum down (Terms of Service) since technically the Community Forum still exists. This just replaces the Community Forum footer with our Knowledge Base in GitHub Discussions.