### PR TITLE
Add information security policy

### DIFF
--- a/pages/information-security-policy/index.html
+++ b/pages/information-security-policy/index.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Gruntwork Information Security Policy
+permalink: /information-security-policy/
+redirect_to:
+  - https://gruntwork.notion.site/Gruntwork-Information-Security-Plan-1790362823a640fe9a0d8565bc17151e
+---

--- a/pages/legal/_security-docs.html
+++ b/pages/legal/_security-docs.html
@@ -1,0 +1,10 @@
+<div class="row row-page-header">
+  <div class="col-xs-12">
+    <h3>Security Documents</h3>
+    <ul style="margin-left: -20px;">
+      <li>
+        <a target="_blank" href="/information-security-policy">Information Security Policy</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/pages/legal/index.html
+++ b/pages/legal/index.html
@@ -16,4 +16,10 @@ slug: legal
       {% include_relative _legal-docs.html %}
     </div>
   </div>
+  <div class="section section-dark" style="padding-top:0;">
+    <div class="container">
+      {% include_relative _security-docs.html %}
+    </div>
+  </div>
+  
 </div>


### PR DESCRIPTION
Our lawyer recommended we update to a new Data Processing Agreement, which asked for a public reference to our information security plan. Note that I made our information security plan in Notion public to accommodate this requirement. I scanned it for any sensitive information and did not find any.

Update: You can see the updated page at https://deploy-preview-673--keen-clarke-470db9.netlify.app/legal/#security-documents.