### PR TITLE
[APT-1578] Removed guide from navbar, changed links to the new docs subpage

### DIFF
--- a/_data/sitemap.yml
+++ b/_data/sitemap.yml
@@ -23,6 +23,9 @@
 
 - title: Learn
   links:
+    - title: Documentation
+      url: "https://docs.gruntwork.io"
+
     - title: How it Works
       url: /how-it-works/
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -100,10 +100,10 @@
           </li>
           <li>
             <a
-              href="/guides/"
+              href="https://docs.gruntwork.io"
               ga-event-category="nav-{{ page.path | slugify }}"
-              ga-event-action="guides"
-              >Guides</a
+              ga-event-action="docs"
+              >Docs</a
             >
           </li>
         </ul>

--- a/pages/index/_learn-more.html
+++ b/pages/index/_learn-more.html
@@ -53,7 +53,7 @@
     <h2>Deploy your entire tech stack.</h2>
     <p>
       Deploy your own tech stack by following our
-      <a href="/guides">Production Deployment Guides</a> or have Gruntwork
+      <a href="https://docs.gruntwork.io">Documentation</a> or have Gruntwork
       deploy a <a href="/reference-architecture">Reference Architecture</a> for
       you, giving you an end-to-end tech stack, 100% backed by code, in about 1
       day. You get to customize the tech stack to your needs, choosing from


### PR DESCRIPTION
This PR changes link from `/guide` to the new docs portal.
[APT-1578](https://gruntwork.atlassian.net/browse/APT-1578)
Preview:
![image](https://user-images.githubusercontent.com/4997537/146236438-b843210f-f0d9-43f0-ab56-1255d53c85c6.png)
![image](https://user-images.githubusercontent.com/4997537/146236482-4a6a6d43-b759-4706-be8d-d8e200bd73fd.png)
![image](https://user-images.githubusercontent.com/4997537/146236392-4e2f84d2-4f7e-40db-89de-b9b1d9530a35.png)


