### PR TITLE
Update circleci image from deprecated circleci class to cimg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ orbs:
 references:
   base_container: &base_container
     docker:
-      - image: circleci/ruby:2.7.1-buster
+      - image: cimg/ruby:2.7.1-buster
 
   ######################################################################################################################
   # Build steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ orbs:
 references:
   base_container: &base_container
     docker:
-      - image: cimg/ruby:2.7.1-buster
+      - image: cimg/ruby:2.7.1
 
   ######################################################################################################################
   # Build steps


### PR DESCRIPTION
NOTE: Is there a way to test that this works correctly without merging to `master`? As far as I can tell, I don't think there is a way to do this.