### PR TITLE
Standardize the highlighted features of the IaC Library

### DIFF
--- a/_data/library-features.yml
+++ b/_data/library-features.yml
@@ -1,5 +1,5 @@
 - title: Infrastructure as Code
-  description: Over 300,000 lines of code written in Terraform, Go, Python, and Bash
+  description: Over 350,000 lines of code written in Terraform, Go, Python, and Bash
 
 - title: Documented
   description: Includes example code and thorough documentation

--- a/_data/steps.yml
+++ b/_data/steps.yml
@@ -10,7 +10,7 @@
   description: |
     Fortunately, there's a solution: the Gruntwork <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a>
     (IaC Library) is a collection of reusable infrastructure code written in Terraform, Go, Bash, and Python that
-    solves these 1,001 problems. Instead of reinventing the wheel, you can leverage 3+ years and 300,000+ lines of
+    solves these 1,001 problems. Instead of reinventing the wheel, you can leverage 5+ years and 350,000+ lines of
     battle-tested code, including pre-built solutions for Kubernetes, MySQL, Postgres, Redis, OpenVPN, Jenkins, Lambda,
     CloudWatch, Kafka, ELK, Vault, Consul, and more, all of which has been proven in production at
     <a href="/customers/">hundreds of companies</a>. To get an idea of how the library works before signing up, try out

--- a/pages/checkout/_checkout.html
+++ b/pages/checkout/_checkout.html
@@ -69,7 +69,7 @@
               <li>
                 <span
                   class="help-text light"
-                  title="300,000+ lines of reusable, battle-tested infrastructure code."
+                  title="350,000+ lines of reusable, battle-tested infrastructure code."
                   data-toggle="tooltip"
                   >Infrastructure as Code Library</span
                 >

--- a/pages/index/_learn-more.html
+++ b/pages/index/_learn-more.html
@@ -19,7 +19,7 @@
   <div class="col-xs-12 col-sm-7 col-md-6 col-description">
     <h2>Get access to the Infrastructure as Code Library.</h2>
     <p>
-      Build your infrastructure on top of a collection of over 300,000 lines of
+      Build your infrastructure on top of a collection of over 350,000 lines of
       reusable, battle-tested infrastructure code written in Terraform, Go,
       Python, and Bash that has been proven in production at hundreds of
       companies and is maintained and supported by DevOps experts.

--- a/pages/infrastructure-as-code-library/index.html
+++ b/pages/infrastructure-as-code-library/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: AWS Infrastructure as Code Library
-excerpt: A collection of over 300,000 lines of reusable, battle-tested, production-ready infrastructure code for AWS.
+excerpt: A collection of over 350,000 lines of reusable, battle-tested, production-ready infrastructure code for AWS.
 permalink: /infrastructure-as-code-library/
 slug: gruntwork-library
 footer_heading: Ready to hand off the Gruntwork?

--- a/pages/pricing/_enterprise-pricing.html
+++ b/pages/pricing/_enterprise-pricing.html
@@ -33,14 +33,9 @@
             >Support for AWS</span
           >
         </li>
-        <li>
-          <span
-            class="help-text light"
-            title="Gain unlimited access (for your company only) to 350,000+ lines of reusable, battle-tested, production-ready infrastructure code."
-            data-toggle="tooltip"
-            >All Subscriber-Only Modules</span
-          >
-        </li>
+        <li><span class="help-text light"
+                  title="Gain access to 350,000+ lines of reusable, battle-tested, production-ready infrastructure code."
+                  data-toggle="tooltip">250+ Subscriber-Only Modules</span></li>
         <li>
           <span
             class="help-text light"

--- a/pages/pricing/_standard-pricing.html
+++ b/pages/pricing/_standard-pricing.html
@@ -23,8 +23,8 @@
                   title="Get support from both Gruntwork engineers and fellow customers on running production-grade infrastructure in AWS."
                   data-toggle="tooltip">Support for AWS</span></li>
         <li><span class="help-text light"
-                  title="Gain access to 300,000+ lines of reusable, battle-tested, production-ready infrastructure code."
-                  data-toggle="tooltip">150+ Subscriber-Only Modules</span></li>
+                  title="Gain access to 350,000+ lines of reusable, battle-tested, production-ready infrastructure code."
+                  data-toggle="tooltip">250+ Subscriber-Only Modules</span></li>
         <li><span class="help-text light"
                   title="A user is a human or machine that accesses the Gruntwork code repos, training materials, or support services. For more than 20 users, see Gruntwork Enterprise."
                   data-toggle="tooltip">Up to 20 Users</span></li>


### PR DESCRIPTION
- We now have probably 450,000 lines of code total, but in the spirit of conservatism, I've standardized on 350,000 lines of code everywhere.
- We now have over 250 modules, so the pricing page now standardizes on that as well.

Special thanks to our customer for pointing out some inconsistencies!