### PR TITLE
Clarify no lock-in policy

### DIFF
--- a/pages/pricing/_terms.html
+++ b/pages/pricing/_terms.html
@@ -23,8 +23,8 @@
     </figure>
     <h3 class="margin-top-none no-anchor text-bold">No lock-in</h3>
     <p class="text-white">
-      If you cancel, you'll lose support and updates but you can
-      keep using the code at no cost.
+      If you cancel, you'll lose support and updates, but as long as any outstanding contract obligations are paid, you can
+      keep using the code at no further cost.
     </p>
   </div>
   <div class="col-xs-12 col-sm-4 text-center">

--- a/pages/pricing/_terms.html
+++ b/pages/pricing/_terms.html
@@ -23,7 +23,7 @@
     </figure>
     <h3 class="margin-top-none no-anchor text-bold">No lock-in</h3>
     <p class="text-white">
-      If you cancel after a year, you'll lose support and updates but you can
+      If you cancel, you'll lose support and updates but you can
       keep using the code at no cost.
     </p>
   </div>


### PR DESCRIPTION
A customer gave us feedback that they interpreted our current "no lock-in" promotion language as suggesting that we require an initial 1 year subscription, followed by a month-to-month contract. This admittedly subtle change hopefully removes that confusion.