### PR TITLE
Remove MongoDB from marketing site carousel

### DIFF
--- a/_data/technologies.yml
+++ b/_data/technologies.yml
@@ -19,12 +19,8 @@
 - name: Jenkins
   logo: /assets/img/logos-technologies/logo-jenkins.png
 
-- name: MongoDB
-  logo: /assets/img/logos-technologies/logo-mongodb.png
-
 - name: Redis
   logo: /assets/img/logos-technologies/logo-redis.png
 
 - name: Kafka
   logo: /assets/img/logos-technologies/logo-kafka.png
-


### PR DESCRIPTION
A PR to address https://github.com/gruntwork-io/gruntwork-io.github.io/issues/704 since our MongoDB module has been deprecated. 