### PR TITLE
Add new job openings

### DIFF
--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -400,8 +400,8 @@
         <strong>Domain expertise.</strong>
         We don't expect you to know everything coming in, but to create products in our space, you must be able to
         quickly build a deep understanding of our domain: DevOps, cloud software, software delivery, CI / CD, and
-        infrastructure as code. If you happen to have prior experience in software engineering, working on dev tools, o
-        other technical domains, that is a big plus.
+        infrastructure as code. Prior experience in software engineering, working on dev tools, or other technical
+        domains is required.
       </li>
       <li>
         <strong>Values.</strong>
@@ -480,8 +480,7 @@
         <strong>Domain expertise.</strong>
         We don't expect you to know everything coming in, but to create products in our space, you must be able to
         quickly build a deep understanding of our domain: DevOps, CLI tools, SaaS software, CI / CD, and infrastructure
-        as code. If you happen to have prior experience in software engineering, working on dev tools, or other
-        technical domains, that is a big plus.
+        as code. Prior experience in software engineering, working on dev tools, or other technical domains is required.
       </li>
       <li>
         <strong>Values.</strong>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -159,9 +159,9 @@
     <p>
       You'll be working with a team in the <strong>European time zones</strong>, so you can be located in almost any
       country as long as your time zone is no further west than the UK (GMT+0/BST) and no further east than Germany
-      (GMT+2). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
-      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
-      willing to work hours different from your current time zone.
+      (GMT+1/GMT+2). We've found that when everyone on the team is located in similar time zones, it's easier to
+      collaborate and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if
+      you're willing to work hours different from your current time zone.
     </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
@@ -492,9 +492,9 @@
     <p>
       You'll be working with a team in the <strong>European time zones</strong>, so you can be located in almost any
       country as long as your time zone is no further west than the UK (GMT+0/BST) and no further east than Germany
-      (GMT+2). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
-      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
-      willing to work hours different from your current time zone.
+      (GMT+1/GMT+2). We've found that when everyone on the team is located in similar time zones, it's easier to
+      collaborate and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if
+      you're willing to work hours different from your current time zone.
     </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
@@ -575,9 +575,9 @@
     <p>
       You'll be working with a team in the <strong>European time zones</strong>, so you can be located in almost any
       country as long as your time zone is no further west than the UK (GMT+0/BST) and no further east than Germany
-      (GMT+2). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
-      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
-      willing to work hours different from your current time zone.
+      (GMT+1/GMT+2). We've found that when everyone on the team is located in similar time zones, it's easier to
+      collaborate and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if
+      you're willing to work hours different from your current time zone.
     </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -356,7 +356,7 @@
         a major upcoming redesign.
       </li>
       <li>
-        <strong>Compliance.</strong>
+        <strong>Compliance Platform.</strong>
         Finally, you'll also be the owner of
         <a href="achieve-compliance" target="_blank">Gruntwork Compliance</a>, which includes out-of-the-box compliance
         with the CIS AWS Foundations Benchmark today, and soon, SOC 2. You'll set the direction for our compliance

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -387,12 +387,12 @@
     <h4>Your Ideal Background</h4>
     <ul>
       <li>
-        <strong>Product sensibility.</strong>
+        <strong>Product vision.</strong>
         As the future owner of several major new products at Gruntwork, we'll look to you for leadership, insights, and
-        methodologies that will help us translate our shared vision into a fantastic experience for customers.
+        methodologies that will help us create a shared vision for customers.
       </li>
       <li>
-        <strong>Leadership.</strong>
+        <strong>Product execution.</strong>
         We're looking for someone with a proven track record of delivering products that move the needle. You must
         have the ability to lead a team through ideation, prototyping, user testing, development, launch, and iteration.
       </li>
@@ -466,13 +466,13 @@
     <h4>Your Ideal Background</h4>
     <ul>
       <li>
-        <strong>Product sensibility.</strong>
-        As the future owner of a major new product at Gruntwork, we'll look to you for leadership, insights, and
-        methodologies that will help us translate our shared vision into a fantastic product. Experience with launching
+        <strong>Product vision.</strong>
+        As the future owner of several major new products at Gruntwork, we'll look to you for leadership, insights, and
+        methodologies that will help us create a shared vision for customers. Experience with launching
         products from 0 to 1 is a plus.
       </li>
       <li>
-        <strong>Leadership.</strong>
+        <strong>Product execution.</strong>
         We're looking for someone with a proven track record of delivering products that move the needle. You must
         have the ability to lead a team through ideation, prototyping, user testing, development, launch, and iteration.
       </li>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -10,20 +10,20 @@
     </p>
 
     <ul>
-      <li><a href="#senior-software-engineer-developer-experience-team">Senior Software Engineer - Developer Experience Team</a></li>
-      <li><a href="#senior-software-engineer-brand-new-product">Senior Software Engineer - Brand New Product</a></li>
-      <li><a href="#senior-software-engineer-contract-part-time">Senior Software Engineer (Contract/Part-Time)</a></li>
-      <li><a href="#engineering-manager">Engineering Manager</a></li>
-      <li><a href="#product-manager-iac">Senior Product Manager - Infrastructure as Code</a></li>
-      <li><a href="#product-manager-brand-new-product">Senior Product Manager - Brand New Product</a></li>
-      <li><a href="#designer-brand-new-product">Senior Designer - Brand New Product</a></li>
+      <li><a href="#senior-software-engineer-developer-experience-team">Senior Software Engineer - Reference Architecture, US time zones</a></li>
+      <li><a href="#senior-software-engineer-brand-new-product">Senior Software Engineer - New Product, EU time zones</a></li>
+      <li><a href="#senior-software-engineer-contract-part-time">Senior Software Engineer (Contract/Part-Time) - Infrastructure as Code Library, US time zones</a></li>
+      <li><a href="#engineering-manager">Engineering Manager - Infrastructure as Code Library, US time zones</a></li>
+      <li><a href="#product-manager-iac">Senior Product Manager - Infrastructure as Code Library, US time zones</a></li>
+      <li><a href="#product-manager-brand-new-product">Senior Product Manager - New Product, EU time zones</a></li>
+      <li><a href="#designer-brand-new-product">Senior Designer - New Product, EU time zones</a></li>
     </ul>
 
     <hr />
 
     <h2>Software Engineering</h2>
 
-    <h3 id="senior-software-engineer-developer-experience-team" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer - Developer Experience Team</h3>
+    <h3 id="senior-software-engineer-developer-experience-team" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer - Reference Architecture</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> US time zones</div>
 
     <h4>What You'll Work On</h4>
@@ -96,7 +96,7 @@
 
     <hr />
 
-    <h3 id="senior-software-engineer-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer - Brand New Product</h3>
+    <h3 id="senior-software-engineer-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer - New Product</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> European time zones</div>
 
     <h4>What You'll Work On</h4>
@@ -167,7 +167,7 @@
 
     <hr />
 
-    <h3 id="senior-software-engineer-contract-part-time" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer (Contract/Part-Time)</h3>
+    <h3 id="senior-software-engineer-contract-part-time" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer (Contract/Part-Time) - Infrastructure as Code Library</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> US time zones</div>
 
     <h4>Now seeking senior and principal levels</h4>
@@ -256,7 +256,7 @@
 
     <h2>Engineering Management</h2>
 
-    <h3 id="engineering-manager" style="margin-top: 5px; margin-bottom: 5px">Engineering Manager</h3>
+    <h3 id="engineering-manager" style="margin-top: 5px; margin-bottom: 5px">Engineering Manager - Infrastructure as Code Library</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> US time zones</div>
 
     <h4>What You'll Work On</h4>
@@ -324,7 +324,7 @@
 
     <h2>Product</h2>
 
-    <h3 id="product-manager-iac" style="margin-top: 5px; margin-bottom: 5px">Senior Product Manager - Infrastructure as Code</h3>
+    <h3 id="product-manager-iac" style="margin-top: 5px; margin-bottom: 5px">Senior Product Manager - Infrastructure as Code Library</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> US time zones</div>
 
     <h4>What You'll Work On</h4>
@@ -421,7 +421,7 @@
 
     <hr />
 
-    <h3 id="product-manager-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Product Manager - Brand New Product</h3>
+    <h3 id="product-manager-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Product Manager - New Product</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> European time zones</div>
 
     <h4>What You'll Work On</h4>
@@ -501,7 +501,7 @@
 
     <hr />
 
-    <h3 id="designer-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Designer - Brand New Product</h3>
+    <h3 id="designer-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Designer - New Product</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> European time zones</div>
 
     <h4>What You'll Work On</h4>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -24,7 +24,7 @@
     <h2>Software Engineering</h2>
 
     <h3 id="senior-software-engineer-developer-experience-team" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer - Developer Experience Team</h3>
-    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT-8 to GMT-4</div>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> US time zones</div>
 
     <h4>What You'll Work On</h4>
     <ul>
@@ -75,10 +75,13 @@
       <li>Bonus points for a sense of humor, empathy, and curiosity.</li>
     </ul>
     <h4>Compatible time zones</h4>
-    <p>This role is specifically for the <strong>GMT-8 (Los Angeles standard time) to GMT-4 (New York daylight time) time zones</strong>,
-      though you can be located in almost any country within those time zones. We've found that when everyone on the team
-      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
-      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.</p>
+    <p>
+      You'll be working with a team in the <strong>US time zones</strong>, so you can be located in almost any
+      country as long as your time zone is no further west than Los Angeles (GMT-8) and no further east than New York
+      (GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
+      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
+      willing to work hours different from your current time zone.
+    </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
       If you're excited by the above:<br />
@@ -94,7 +97,7 @@
     <hr />
 
     <h3 id="senior-software-engineer-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer - Brand New Product</h3>
-    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT+0 to GMT+2</div>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> European time zones</div>
 
     <h4>What You'll Work On</h4>
     <ul>
@@ -144,10 +147,11 @@
     </ul>
     <h4>Compatible time zones</h4>
     <p>
-      This role is specifically for the <strong>GMT+0 (e.g., London) to GMT+2 (e.g., Berlin) time zones</strong>,
-      though you can be located in almost any country within those time zones. We've found that when everyone on the team
-      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
-      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.
+      You'll be working with a team in the <strong>European time zones</strong>, so you can be located in almost any
+      country as long as your time zone is no further west than the UK (GMT+0/BST) and no further east than Germany
+      (GMT+2). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
+      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
+      willing to work hours different from your current time zone.
     </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
@@ -164,7 +168,7 @@
     <hr />
 
     <h3 id="senior-software-engineer-contract-part-time" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer (Contract/Part-Time)</h3>
-    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT-8 to GMT-4</div>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> US time zones</div>
 
     <h4>Now seeking senior and principal levels</h4>
 
@@ -230,11 +234,13 @@
       <li>You can respond to support & maintenance requests within a 2 business day SLA.</li>
     </ul>
     <h4>Compatible time zones</h4>
-    <p>This role is specifically for the <strong>GMT-8 (Los Angeles standard time) to GMT-4 (New York daylight time) time zones</strong>,
-      though you can be located in almost any country within those time zones. We've found that when everyone on the team
-      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
-      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.</p>
-
+    <p>
+      You'll be working with a team in the <strong>US time zones</strong>, so you can be located in almost any
+      country as long as your time zone is no further west than Los Angeles (GMT-8) and no further east than New York
+      (GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
+      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
+      willing to work hours different from your current time zone.
+    </p>
     <p>
       If the above describes you:<br />
       <a
@@ -251,7 +257,7 @@
     <h2>Engineering Management</h2>
 
     <h3 id="engineering-manager" style="margin-top: 5px; margin-bottom: 5px">Engineering Manager</h3>
-    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT-8 to GMT-4</div>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> US time zones</div>
 
     <h4>What You'll Work On</h4>
     <ul>
@@ -295,10 +301,13 @@
       <li>Bonus points for a sense of humor, empathy, and curiosity.</li>
     </ul>
     <h4>Compatible time zones</h4>
-    <p>This role is specifically for the <strong>GMT-8 (Los Angeles standard time) to GMT-4 (New York daylight time) time zones</strong>,
-      though you can be located in almost any country within those time zones. We've found that when everyone on the team
-      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
-      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.</p>
+    <p>
+      You'll be working with a team in the <strong>US time zones</strong>, so you can be located in almost any
+      country as long as your time zone is no further west than Los Angeles (GMT-8) and no further east than New York
+      (GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
+      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
+      willing to work hours different from your current time zone.
+    </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
       If you're excited by the above:<br />
@@ -316,7 +325,7 @@
     <h2>Product</h2>
 
     <h3 id="product-manager-iac" style="margin-top: 5px; margin-bottom: 5px">Senior Product Manager - Infrastructure as Code</h3>
-    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT-8 to GMT-4</div>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> US time zones</div>
 
     <h4>What You'll Work On</h4>
     <ul>
@@ -391,10 +400,11 @@
     </ul>
     <h4>Compatible time zones</h4>
     <p>
-      This role is specifically for the <strong>GMT-8 (Los Angeles standard time) to GMT-4 (New York daylight time) time zones</strong>,
-      though you can be located in almost any country within those time zones. We've found that when everyone on the team
-      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
-      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.
+      You'll be working with a team in the <strong>US time zones</strong>, so you can be located in almost any
+      country as long as your time zone is no further west than Los Angeles (GMT-8) and no further east than New York
+      (GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
+      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
+      willing to work hours different from your current time zone.
     </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
@@ -412,7 +422,7 @@
     <hr />
 
     <h3 id="product-manager-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Product Manager - Brand New Product</h3>
-    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT+0 to GMT+2</div>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> European time zones</div>
 
     <h4>What You'll Work On</h4>
     <ul>
@@ -470,10 +480,11 @@
     </ul>
     <h4>Compatible time zones</h4>
     <p>
-      This role is specifically for the <strong>GMT+0 (e.g., London) to GMT+2 (e.g., Berlin) time zones</strong>,
-      though you can be located in almost any country within those time zones. We've found that when everyone on the team
-      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
-      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.
+      You'll be working with a team in the <strong>European time zones</strong>, so you can be located in almost any
+      country as long as your time zone is no further west than the UK (GMT+0/BST) and no further east than Germany
+      (GMT+2). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
+      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
+      willing to work hours different from your current time zone.
     </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
@@ -491,7 +502,7 @@
     <hr />
 
     <h3 id="designer-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Designer - Brand New Product</h3>
-    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT+0 to GMT+2</div>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> European time zones</div>
 
     <h4>What You'll Work On</h4>
     <ul>
@@ -552,10 +563,11 @@
     </ul>
     <h4>Compatible time zones</h4>
     <p>
-      This role is specifically for the <strong>GMT+0 (e.g., London) to GMT+2 (e.g., Berlin) time zones</strong>,
-      though you can be located in almost any country within those time zones. We've found that when everyone on the team
-      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
-      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.
+      You'll be working with a team in the <strong>European time zones</strong>, so you can be located in almost any
+      country as long as your time zone is no further west than the UK (GMT+0/BST) and no further east than Germany
+      (GMT+2). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
+      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
+      willing to work hours different from your current time zone.
     </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -357,11 +357,12 @@
       </li>
       <li>
         <strong>Compliance Platform.</strong>
-        Finally, you'll also be the owner of
-        <a href="achieve-compliance" target="_blank">Gruntwork Compliance</a>, which includes out-of-the-box compliance
-        with the CIS AWS Foundations Benchmark today, and soon, SOC 2. You'll set the direction for our compliance
-        business, including figuring out which standards we'll target in the future (e.g., ISO 27001, PCI, HIPAA, other
-        CIS benchmarks, etc.), how to package the product, how to help customers ensure ongoing compliance, and so on.
+        Finally, you'll also be the owner of the
+        <a href="achieve-compliance" target="_blank">Gruntwork Compliance Platform</a>, which includes out-of-the-box
+        compliance with the CIS AWS Foundations Benchmark today, and soon, SOC 2. You'll set the direction for our
+        compliance platform, including figuring out which standards we'll target in the future (e.g., ISO 27001, PCI,
+        HIPAA, other CIS benchmarks, etc.), what key features to build, how to package the product, how to integrate
+        compliance with other Gruntwork products, how to help customers ensure ongoing compliance, and so on.
       </li>
       <li>
         <strong>Work alongside engineering and design.</strong>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -9,11 +9,21 @@
       looking for:
     </p>
 
+
+    <h3>Software Engineering</h3>
     <ul>
       <li><a href="#senior-software-engineer-developer-experience-team">Senior Software Engineer - Reference Architecture, US time zones</a></li>
       <li><a href="#senior-software-engineer-brand-new-product">Senior Software Engineer - New Product, EU time zones</a></li>
       <li><a href="#senior-software-engineer-contract-part-time">Senior Software Engineer (Contract/Part-Time) - Infrastructure as Code Library, US time zones</a></li>
+    </ul>
+
+    <h3>Management</h3>
+    <ul>
       <li><a href="#engineering-manager">Engineering Manager - Infrastructure as Code Library, US time zones</a></li>
+    </ul>
+
+    <h3>Product</h3>
+    <ul>
       <li><a href="#product-manager-iac">Senior Product Manager - Infrastructure as Code Library, US time zones</a></li>
       <li><a href="#product-manager-brand-new-product">Senior Product Manager - New Product, EU time zones</a></li>
       <li><a href="#designer-brand-new-product">Senior Designer - New Product, EU time zones</a></li>
@@ -254,7 +264,7 @@
 
     <hr />
 
-    <h2>Engineering Management</h2>
+    <h2>Management</h2>
 
     <h3 id="engineering-manager" style="margin-top: 5px; margin-bottom: 5px">Engineering Manager - Infrastructure as Code Library</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> US time zones</div>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -87,10 +87,10 @@
     <h4>Compatible time zones</h4>
     <p>
       You'll be working with a team in the <strong>US time zones</strong>, so you can be located in almost any
-      country as long as your time zone is no further west than Los Angeles (GMT-8) and no further east than New York
-      (GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
-      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
-      willing to work hours different from your current time zone.
+      country as long as your time zone is no further west than Los Angeles (GMT-8/GMT-7) and no further east than New
+      York (GMT-5/GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to
+      collaborate and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if
+      you're willing to work hours different from your current time zone.
     </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
@@ -246,10 +246,10 @@
     <h4>Compatible time zones</h4>
     <p>
       You'll be working with a team in the <strong>US time zones</strong>, so you can be located in almost any
-      country as long as your time zone is no further west than Los Angeles (GMT-8) and no further east than New York
-      (GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
-      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
-      willing to work hours different from your current time zone.
+      country as long as your time zone is no further west than Los Angeles (GMT-8/GMT-7) and no further east than New
+      York (GMT-5/GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to
+      collaborate and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if
+      you're willing to work hours different from your current time zone.
     </p>
     <p>
       If the above describes you:<br />
@@ -313,10 +313,10 @@
     <h4>Compatible time zones</h4>
     <p>
       You'll be working with a team in the <strong>US time zones</strong>, so you can be located in almost any
-      country as long as your time zone is no further west than Los Angeles (GMT-8) and no further east than New York
-      (GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
-      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
-      willing to work hours different from your current time zone.
+      country as long as your time zone is no further west than Los Angeles (GMT-8/GMT-7) and no further east than New
+      York (GMT-5/GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to
+      collaborate and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if
+      you're willing to work hours different from your current time zone.
     </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
@@ -411,10 +411,10 @@
     <h4>Compatible time zones</h4>
     <p>
       You'll be working with a team in the <strong>US time zones</strong>, so you can be located in almost any
-      country as long as your time zone is no further west than Los Angeles (GMT-8) and no further east than New York
-      (GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to collaborate
-      and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if you're
-      willing to work hours different from your current time zone.
+      country as long as your time zone is no further west than Los Angeles (GMT-8/GMT-7) and no further east than New
+      York (GMT-5/GMT-4). We've found that when everyone on the team is located in similar time zones, it's easier to
+      collaborate and there's much less pressure to stay up late or get up early, so this is a hard constraint, even if
+      you're willing to work hours different from your current time zone.
     </p>
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -148,9 +148,9 @@
     <h4>Your Ideal Background</h4>
     <ul>
       <li>You know how to write code across the stack and have experience in Golang.</li>
+      <li>You have a strong background in software engineering.</li>
       <li>Experience with Node/TypeScript is a plus.</li>
       <li>Experience running production software, ideally with Terraform and AWS, is a plus.</li>
-      <li>You have a strong background in software engineering.</li>
       <li>Your happy place is writing code, but you enjoy seeing it in action with real customers.</li>
       <li>You are inspired by <a href="/about/#our-values">our values</a>.</li>
       <li>Bonus points for a sense of humor, empathy, and curiosity.</li>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -19,7 +19,7 @@
 
     <h2>Software Engineering</h2>
 
-    <h3 style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer - Developer Experience Team</h3>
+    <h3 id="senior-software-engineer-developer-experience-team" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer - Developer Experience Team</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT-8 to GMT-4</div>
 
     <h4>What You'll Work On</h4>
@@ -89,7 +89,7 @@
 
     <hr />
 
-    <h3 style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer (Contract/Part-Time)</h3>
+    <h3 id="senior-software-engineer-contract-part-time" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer (Contract/Part-Time)</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT-8 to GMT-4</div>
 
     <h4>Now seeking senior and principal levels</h4>
@@ -176,7 +176,7 @@
 
     <h2>Engineering Management</h2>
 
-    <h3 style="margin-top: 5px; margin-bottom: 5px">Engineering Manager</h3>
+    <h3 id="engineering-manager" style="margin-top: 5px; margin-bottom: 5px">Engineering Manager</h3>
     <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT-8 to GMT-4</div>
 
     <h4>What You'll Work On</h4>

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -11,8 +11,12 @@
 
     <ul>
       <li><a href="#senior-software-engineer-developer-experience-team">Senior Software Engineer - Developer Experience Team</a></li>
+      <li><a href="#senior-software-engineer-brand-new-product">Senior Software Engineer - Brand New Product</a></li>
       <li><a href="#senior-software-engineer-contract-part-time">Senior Software Engineer (Contract/Part-Time)</a></li>
       <li><a href="#engineering-manager">Engineering Manager</a></li>
+      <li><a href="#product-manager-iac">Senior Product Manager - Infrastructure as Code</a></li>
+      <li><a href="#product-manager-brand-new-product">Senior Product Manager - Brand New Product</a></li>
+      <li><a href="#designer-brand-new-product">Senior Designer - Brand New Product</a></li>
     </ul>
 
     <hr />
@@ -28,7 +32,7 @@
         architectures for Terraform and Terragrunt in just a few hours using a collection of internal Golang tools. Help
         us take this process to the next level of scale and UX as we create the definitive way to go to prod in the cloud.</li>
       <li><strong>Gruntwork platform.</strong> Integrate your new product work with our platform, which consists
-        of a REST API (Next.js/Typescript), a web-based single-page app (Next.js/Typescript, Tailwind), and a first-class CLI tool (Go).</li>
+        of a REST API (Next.js/Typescript), a web-based single-page app (React/Typescript, Tailwind), and a first-class CLI tool (Go).</li>
       <li>
         <strong>Open source.</strong> Contribute to our open source projects as needed, including
         <a href="https://github.com/gruntwork-io/terragrunt" target="_blank"
@@ -80,6 +84,76 @@
       If you're excited by the above:<br />
       <a
         href="https://apply.workable.com/j/0C9EAD03A2/apply"
+        class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"
+        style="margin-top: 10px"
+        role="button"
+        >Apply Now</a
+      >
+    </p>
+
+    <hr />
+
+    <h3 id="senior-software-engineer-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Software Engineer - Brand New Product</h3>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT+0 to GMT+2</div>
+
+    <h4>What You'll Work On</h4>
+    <ul>
+      <li>
+        <strong>Build a brand new product.</strong>
+        We have a new, unannounced product in the works. Join a small team to help design, prototype, test, launch,
+        and develop this exciting new initiative that we believe will transform the software industry.
+      </li>
+      <li>
+        <strong>CLI platform.</strong>
+        Develop a part of this new product by building a beautiful, first-class CLI experience using Go.
+      </li>
+      <li>
+        <strong>Web platform.</strong>
+        Integrate your new product work with our platform, which consists of a REST API (Next.js/Typescript) and a
+        web-based single-page app (React/Typescript, Tailwind).
+      </li>
+      <li>
+        <strong>Infrastructure.</strong>
+        Deploy and manage the new product on AWS using tools such as Fargate, Lambda, API Gateway, EKS, and more.
+        Define and manage all of the infrastructure as code using tools such as Terraform, Docker, and Packer.
+      </li>
+      <li>
+        <strong>And a little bit of everything else.</strong>
+        Gruntwork is a
+        <a
+          href="https://blog.gruntwork.io/how-we-built-a-distributed-self-funded-family-friendly-profitable-startup-93635feb5ace"
+          target="_blank"
+          >small, distributed, self-funded, profitable startup</a
+        >, so we all wear a few hats. You should expect to write plenty of code,
+        but, depending on your interests, there will also be ample opportunity
+        to write blog posts, give talks, contribute to open source, go to conferences,
+        talk with customers, do sales calls, interview candidates, mentor new hires,
+        design products, come up with marketing ideas, discuss strategy,
+        and all the other tasks that are part of working at a small company.
+      </li>
+    </ul>
+    <h4>Your Ideal Background</h4>
+    <ul>
+      <li>You know how to write code across the stack and have experience in Golang.</li>
+      <li>Experience with Node/TypeScript is a plus.</li>
+      <li>Experience running production software, ideally with Terraform and AWS, is a plus.</li>
+      <li>You have a strong background in software engineering.</li>
+      <li>Your happy place is writing code, but you enjoy seeing it in action with real customers.</li>
+      <li>You are inspired by <a href="/about/#our-values">our values</a>.</li>
+      <li>Bonus points for a sense of humor, empathy, and curiosity.</li>
+    </ul>
+    <h4>Compatible time zones</h4>
+    <p>
+      This role is specifically for the <strong>GMT+0 (e.g., London) to GMT+2 (e.g., Berlin) time zones</strong>,
+      though you can be located in almost any country within those time zones. We've found that when everyone on the team
+      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
+      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.
+    </p>
+    <h4>Help us a create a fundamentally better DevOps experience!</h4>
+    <p>
+      If you're excited by the above:<br />
+      <a
+        href="https://apply.workable.com/gruntwork/j/AD26F6ED87/apply/"
         class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"
         style="margin-top: 10px"
         role="button"
@@ -185,7 +259,7 @@
         the standard for Terraform, AWS, and DevOps best practices. We're looking for a hands-on manager who can empower
         our engineers to organize and ship their work, chart their careers at Gruntwork, and achieve both personal and company success.</li>
       <li><strong>Work alongside product and design.</strong> You'll serve as one member of
-        an executive "trio" that includes a product manager and product designer. You'll collaborate with your colleagues
+        an executive "trio" that includes a Product Manager and product designer. You'll collaborate with your colleagues
         on the vision, usability, and business viability of our product, and take primary responsibility for our ability
         to execute. Further, you'll work directly with one of our co-founders.</li>
       <li><strong>Mentor up and coming managers.</strong> Many of our engineers seek to become stronger individual contributors,
@@ -230,6 +304,265 @@
       If you're excited by the above:<br />
       <a
         href="https://apply.workable.com/j/592E04BB92/apply"
+        class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"
+        style="margin-top: 10px"
+        role="button"
+      >Apply Now</a
+      >
+    </p>
+
+    <hr/>
+
+    <h2>Product</h2>
+
+    <h3 id="product-manager-iac" style="margin-top: 5px; margin-bottom: 5px">Senior Product Manager - Infrastructure as Code</h3>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT-8 to GMT-4</div>
+
+    <h4>What You'll Work On</h4>
+    <ul>
+      <li>
+        <strong>Infrastructure as Code Library.</strong>
+        You will be the owner of the core of our business, the
+        <a href="/infrastructure-as-code-library" target="_blank">Infrastructure as Code (IaC) Library</a>,
+        a collection of over 350,000 lines of reusable, battle-tested, production-grade infrastructure code for AWS.
+        You'll be responsible for setting the direction for this library, which is written in Terraform, Go, Bash, and
+        Python and used in production by hundreds of companies.
+      </li>
+      <li>
+        <strong>Reference Architecture.</strong>
+        You'll also be the owner of the
+        <a href="/reference-architecture" target="_blank">Reference Architecture</a>, an opinionated, end-to-end tech
+        stack built on top of the Infrastructure as Code Library that we can deploy into a customer's AWS accounts in
+        about one day. You'll be responsible for defining the next generation of the Reference Architecture as part of
+        a major upcoming redesign.
+      </li>
+      <li>
+        <strong>Compliance.</strong>
+        Finally, you'll also be the owner of
+        <a href="achieve-compliance" target="_blank">Gruntwork Compliance</a>, which includes out-of-the-box compliance
+        with the CIS AWS Foundations Benchmark today, and soon, SOC 2. You'll set the direction for our compliance
+        business, including figuring out which standards we'll target in the future (e.g., ISO 27001, PCI, HIPAA, other
+        CIS benchmarks, etc.), how to package the product, how to help customers ensure ongoing compliance, and so on.
+      </li>
+      <li>
+        <strong>Work alongside engineering and design.</strong>
+        You'll serve as one member of an executive "trio" that includes an engineering manager and product designer.
+        You'll collaborate with your colleagues on the vision, usability, and business viability of this new product,
+        and take primary responsibility for our ability to execute. Further, you'll work directly with and report to
+        one of our co-founders.
+      </li>
+      <li>
+        <strong>Work alongside customers.</strong>
+        You'll work directly with our customers to understand what problems they are facing, figure out solutions to
+        those problems, guide the team in building those solutions, share those solutions with customers, gather
+        feedback, and iterate.
+      </li>
+      <li>
+        <strong>Drive our product management practices.</strong>
+        Help improve how we build products as a company by streamlining all of our product management processes,
+        including product planning, user testing, user story mapping, task tracking, backlog grooming, sprint planning
+        and execution, market research, pricing strategy, customer communication, and more.
+      </li>
+    </ul>
+    <h4>Your Ideal Background</h4>
+    <ul>
+      <li>
+        <strong>Product sensibility.</strong>
+        As the future owner of several major new products at Gruntwork, we'll look to you for leadership, insights, and
+        methodologies that will help us translate our shared vision into a fantastic experience for customers.
+      </li>
+      <li>
+        <strong>Leadership.</strong>
+        We're looking for someone with a proven track record of delivering products that move the needle. You must
+        have the ability to lead a team through ideation, prototyping, user testing, development, launch, and iteration.
+      </li>
+      <li>
+        <strong>Domain expertise.</strong>
+        We don't expect you to know everything coming in, but to create products in our space, you must be able to
+        quickly build a deep understanding of our domain: DevOps, cloud software, software delivery, CI / CD, and
+        infrastructure as code. If you happen to have prior experience in software engineering, working on dev tools, o
+        other technical domains, that is a big plus.
+      </li>
+      <li>
+        <strong>Values.</strong>
+        You are inspired by <a href="/about/#our-values">our values</a>. Bonus points for a sense of humor, empathy,
+        and curiosity.
+      </li>
+    </ul>
+    <h4>Compatible time zones</h4>
+    <p>
+      This role is specifically for the <strong>GMT-8 (Los Angeles standard time) to GMT-4 (New York daylight time) time zones</strong>,
+      though you can be located in almost any country within those time zones. We've found that when everyone on the team
+      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
+      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.
+    </p>
+    <h4>Help us a create a fundamentally better DevOps experience!</h4>
+    <p>
+      If you're excited by the above:<br />
+      <!-- TODO: Fill in the proper link!!! -->
+      <a
+        href="#TODO:fill-me-in!"
+        class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"
+        style="margin-top: 10px"
+        role="button"
+      >Apply Now</a
+      >
+    </p>
+
+    <hr />
+
+    <h3 id="product-manager-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Product Manager - Brand New Product</h3>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT+0 to GMT+2</div>
+
+    <h4>What You'll Work On</h4>
+    <ul>
+      <li>
+        <strong>Create a brand new product.</strong>
+        Take ownership of a new, unannounced product that we have in the works, which includes both a beautiful,
+        first-class CLI experience and a powerful web UI. Join a small team to help design, prototype, test, launch,
+        and develop this exciting new initiative that we believe will transform the software industry.
+      </li>
+      <li>
+        <strong>Work alongside engineering and design.</strong>
+        You'll serve as one member of an executive "trio" that includes an engineering manager and product designer.
+        You'll collaborate with your colleagues on the vision, usability, and business viability of this new product,
+        and take primary responsibility for our ability to execute. Further, you'll work directly with and report to
+        one of our co-founders.
+      </li>
+      <li>
+        <strong>Work alongside customers.</strong>
+        You'll work directly with our customers to understand what problems they are facing, figure out solutions to
+        those problems, guide the team in building those solutions, share those solutions with customers, gather
+        feedback, and iterate.
+      </li>
+      <li>
+        <strong>Drive our product management practices.</strong>
+        Help improve how we build products as a company by streamlining all of our product management processes,
+        including product planning, user testing, user story mapping, task tracking, backlog grooming, sprint planning
+        and execution, market research, pricing strategy, customer communication, and more.
+      </li>
+    </ul>
+    <h4>Your Ideal Background</h4>
+    <ul>
+      <li>
+        <strong>Product sensibility.</strong>
+        As the future owner of a major new product at Gruntwork, we'll look to you for leadership, insights, and
+        methodologies that will help us translate our shared vision into a fantastic product. Experience with launching
+        products from 0 to 1 is a plus.
+      </li>
+      <li>
+        <strong>Leadership.</strong>
+        We're looking for someone with a proven track record of delivering products that move the needle. You must
+        have the ability to lead a team through ideation, prototyping, user testing, development, launch, and iteration.
+      </li>
+      <li>
+        <strong>Domain expertise.</strong>
+        We don't expect you to know everything coming in, but to create products in our space, you must be able to
+        quickly build a deep understanding of our domain: DevOps, CLI tools, SaaS software, CI / CD, and infrastructure
+        as code. If you happen to have prior experience in software engineering, working on dev tools, or other
+        technical domains, that is a big plus.
+      </li>
+      <li>
+        <strong>Values.</strong>
+        You are inspired by <a href="/about/#our-values">our values</a>. Bonus points for a sense of humor, empathy,
+        and curiosity.
+      </li>
+    </ul>
+    <h4>Compatible time zones</h4>
+    <p>
+      This role is specifically for the <strong>GMT+0 (e.g., London) to GMT+2 (e.g., Berlin) time zones</strong>,
+      though you can be located in almost any country within those time zones. We've found that when everyone on the team
+      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
+      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.
+    </p>
+    <h4>Help us a create a fundamentally better DevOps experience!</h4>
+    <p>
+      If you're excited by the above:<br />
+      <!-- TODO: Fill in the proper link!!! -->
+      <a
+        href="#TODO:fill-me-in!"
+        class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"
+        style="margin-top: 10px"
+        role="button"
+      >Apply Now</a
+      >
+    </p>
+
+    <hr />
+
+    <h3 id="designer-brand-new-product" style="margin-top: 5px; margin-bottom: 5px">Senior Designer - Brand New Product</h3>
+    <div style="background-color:#2e3b4a; padding:4px 6px; border-radius: 10px; display:inline-block; font-size:14px;"><strong>Time Zone:</strong> GMT+0 to GMT+2</div>
+
+    <h4>What You'll Work On</h4>
+    <ul>
+      <li>
+        <strong>Design a brand new product.</strong>
+        Design a new, unannounced product that we have in the works, which includes both a beautiful,
+        first-class CLI experience and a powerful web UI. Join a small team to help design, prototype, test, launch,
+        and develop this exciting new initiative that we believe will transform the software industry.
+      </li>
+      <li>
+        <strong>Work alongside engineering and product.</strong>
+        You'll serve as one member of an executive "trio" that includes an engineering manager and product manager.
+        You'll collaborate with your colleagues on the vision, usability, and business viability of this new product,
+        and take primary responsibility for our ability to execute. Further, you'll work directly with and report to
+        one of our co-founders.
+      </li>
+      <li>
+        <strong>Work alongside customers.</strong>
+        You'll work directly with our customers to understand what problems they are facing, design solutions to
+        those problems, guide the team in user testing those solutions, gather feedback, and iterate.
+      </li>
+      <li>
+        <strong>Drive our design practices.</strong>
+        Help improve how we design products as a company by streamlining all of our design processes, including
+        designs prints, user testing, user story mapping, wireframing, prototyping, customer communication, and more.
+      </li>
+    </ul>
+    <h4>Your Ideal Background</h4>
+    <ul>
+      <li>
+        <strong>Product sensibility.</strong>
+        We're looking for a product designer—someone who can be an equal partner in helping us design and develop our
+        products. We'll look to you for leadership, insights, and methodologies that will help us translate our shared
+        vision into a fantastic product. Experience with launching products from 0 to 1 is a plus.
+      </li>
+      <li>
+        <strong>Design skill.</strong>
+        At the end of the day, the designs you create should look great and be easy to use. Help us make Gruntwork
+        customers smile. :)
+      </li>
+      <li>
+        <strong>Domain expertise.</strong>
+        We don't expect you to know everything coming in, but to design products in our space, you must be able to
+        quickly build a deep understanding of our domain: DevOps, CLI tools, SaaS software, CI / CD, and infrastructure
+        as code. If you happen to have prior experience in software engineering, working on dev tools, or other
+        technical domains, that is a big plus.
+      </li>
+      <li>
+        <strong>Bonus: HTML/CSS.</strong>
+        If you can occasionally roll up your sleeves and work directly in HTML/CSS, you can help us make sure the final
+        product is true to your vision.
+      </li>
+      <li>
+        <strong>Values.</strong>
+        You are inspired by <a href="/about/#our-values">our values</a>. Bonus points for a sense of humor, empathy,
+        and curiosity.
+      </li>
+    </ul>
+    <h4>Compatible time zones</h4>
+    <p>
+      This role is specifically for the <strong>GMT+0 (e.g., London) to GMT+2 (e.g., Berlin) time zones</strong>,
+      though you can be located in almost any country within those time zones. We've found that when everyone on the team
+      is located in a similar time zone, it's easier to collaborate and there's much less pressure to stay up late or get
+      up early, so this is a hard constraint, even if you're willing to work hours different from your current time zone.
+    </p>
+    <h4>Help us a create a fundamentally better DevOps experience!</h4>
+    <p>
+      If you're excited by the above:<br />
+      <!-- TODO: Fill in the proper link!!! -->
+      <a
+        href="#TODO:fill-me-in!"
         class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"
         style="margin-top: 10px"
         role="button"

--- a/pages/careers/_open-positions.html
+++ b/pages/careers/_open-positions.html
@@ -420,9 +420,8 @@
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
       If you're excited by the above:<br />
-      <!-- TODO: Fill in the proper link!!! -->
       <a
-        href="#TODO:fill-me-in!"
+        href="https://apply.workable.com/gruntwork/j/ABDEA396D4/apply/"
         class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"
         style="margin-top: 10px"
         role="button"
@@ -499,9 +498,8 @@
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
       If you're excited by the above:<br />
-      <!-- TODO: Fill in the proper link!!! -->
       <a
-        href="#TODO:fill-me-in!"
+        href="https://apply.workable.com/gruntwork/j/C011F0F8EC/apply/"
         class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"
         style="margin-top: 10px"
         role="button"
@@ -582,9 +580,8 @@
     <h4>Help us a create a fundamentally better DevOps experience!</h4>
     <p>
       If you're excited by the above:<br />
-      <!-- TODO: Fill in the proper link!!! -->
       <a
-        href="#TODO:fill-me-in!"
+        href="https://apply.workable.com/gruntwork/j/22AF2FDBC4/apply/"
         class="btn btn-primary-hollow btn-sm d-inline-block btn-dpa"
         style="margin-top: 10px"
         role="button"


### PR DESCRIPTION
I've added draft write-ups for the following job openings:

- Senior Software Engineer in the EU time zones
- Senior Product Manager in the US time zones
- Senior Product Manager in the EU time zones
- Senior Designer in the EU time zones

Note that the Software Engineer job is already posted on Workable, as we've hired plenty of people for that role before, and have a reasonable idea of how to approach it. On the other hand, I have _not_ yet posted any of the other jobs on Workable, as I wanted to get the job description, requirements, etc reviewed by others first. @josh-padnick I'd be especially grateful for your input here.

[Direct link to careers page in the Netlify preview build for easier reviewing](https://deploy-preview-710--keen-clarke-470db9.netlify.app/careers/#open-positions).