### PR TITLE
Update terms of service to remove security vulnerability services

### DIFF
--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -182,3 +182,10 @@
   category: vulnerability-disclosure-policy
   link: https://github.com/gruntwork-io/gruntwork-io.github.io/commit/2d765b5
   date: 2022-05-02
+
+- guid: 10022
+  title:  Removed our security alerts service
+  description: Prior to this change, we emailed customers about critical security vulnerabilities. But since we began offering this service, many third parties have emerged that provide a better version of this functionality (in many cases at no cost), and customers have told us they do not receive much value from our notifications. For these reasons, we are removing this from our offering.
+  category: terms-of-service
+  link: https://github.com/gruntwork-io/gruntwork-io.github.io/commit/4fb50cd
+  date: 2022-05-05

--- a/_data/terms-of-service.yml
+++ b/_data/terms-of-service.yml
@@ -419,7 +419,6 @@
         <p><strong>2.3.1 Community Chat Room.</strong> Gruntwork provides a community chat room where Gruntwork customers may ask questions, discuss design decisions, and work together as a community. This communication will be done over a medium determined by Gruntwork, such as a Gitter or Slack channel.</p>
         <p><strong>2.3.2 Community Forum.</strong> Gruntwork provides a community forum where Gruntwork customers may ask questions, discuss design decisions, and work together as a community. This communication will be done over a medium determined by Gruntwork, such as a Discourse Forum, mailing list or Google Group. Gruntwork may discontinue this community forum if it determines that it is duplicative with the community chat room.</p>
         <p><strong>2.3.3 No Service Level Agreement.</strong> Gruntwork employees may, but are not obligated to, monitor the community chat room and community forum and provide help when appropriate. Gruntwork employees may be delayed in responding or may not respond at all to messages submitted via the community chat room or community forum.</p>
-        <p><strong>2.3.4 Security Alerts.</strong> Authorized Users may sign up for the Gruntwork security vulnerabilities list. Gruntwork will use this list to notify Authorized Users of urgent security vulnerabilities.</p>
       plain: |
         We’ll provide community support via our customer-only Slack workspace. We do not commit to any Service Level Agreement (SLA) at this tier.
 


### PR DESCRIPTION
I propose our email announcement to customers read as follows:

> Effective as of May 5, 2022, we are making changes to our Terms of Service. No action is needed from you today. We updated the following:
> - **Discontinued Security Vulnerability Notifications.** Historically, we emailed customers about critical security vulnerabilities, often just 2 or 3 per year. But since we began offering this service, many third parties have emerged that provide a better version of this functionality, in many cases at no cost. As one example, see [Vulmon Alerts](https://alerts.vulmon.com/). In addition, customers have told us they do not receive much value from these notifications, so we are discontinuing this courtesy service.
>
> [View Terms](https://gruntwork.io/legal/terms)
> Thank you for being a Gruntwork user!

@brikis98 Let me know what you think of the above.