### PR TITLE
Remove bug bounty

### DIFF
--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -84,7 +84,8 @@
 
 - guid: 10011
   title: Update Terms of Service to clean up and professionalize terms
-  description: We removed DevOps Bootcamps and Gruntwork Professional Services since we are no longer offering these services. While we have always required that you agree to an annual subscription, we’ve cleaned up a few legal provisions around billing practices and termination rights to make this crystal clear. We also clarified that the authorized users of your affiliated companies can use the services. In addition, we’ve put into writing our current policies and cleaned up a few legal positions around; <ul class="small">
+  description:
+    We removed DevOps Bootcamps and Gruntwork Professional Services since we are no longer offering these services. While we have always required that you agree to an annual subscription, we’ve cleaned up a few legal provisions around billing practices and termination rights to make this crystal clear. We also clarified that the authorized users of your affiliated companies can use the services. In addition, we’ve put into writing our current policies and cleaned up a few legal positions around; <ul class="small">
     <li>how we expect both you and us to behave when you use our website (see our <a href="/website-terms/" title="Website Terms">Site Terms</a>);</li>
     <li>how we use your data to help provide the services to you (see our updated <a href="/legal/privacy-policy/" title="Privacy Policy">Privacy Policy</a>);</li>
     <li>how we use your anonymized data to improve the services;</li>
@@ -184,8 +185,15 @@
   date: 2022-05-02
 
 - guid: 10022
-  title:  Removed our security alerts service
+  title: Removed our security alerts service
   description: Prior to this change, we emailed customers about critical security vulnerabilities. But since we began offering this service, many third parties have emerged that provide a better version of this functionality (in many cases at no cost), and customers have told us they do not receive much value from our notifications. For these reasons, we are removing this from our offering.
   category: terms-of-service
   link: https://github.com/gruntwork-io/gruntwork-io.github.io/commit/4fb50cd
   date: 2022-05-05
+
+- guid: 10023
+  title: Removed bug bounty
+  description: Unfortunately, our informal bug bounty greatly decreased the signal-to-noise ratio in our vulnerability reports. We remain fully committed to security and highly appreciative of any vulnerability reports made in good faith, which we continue to encourage and strive to address in a timely manner according to their urgency.
+  category: vulnerability-disclosure-policy
+  link: https://github.com/gruntwork-io/gruntwork-io.github.io/commit/f248314
+  date: 2022-06-06

--- a/pages/vulnerability-disclosure-policy/index.md
+++ b/pages/vulnerability-disclosure-policy/index.md
@@ -58,8 +58,6 @@ Though we develop and maintain other internet-accessible systems or services, we
 
 We do not support PGP-encrypted emails. For particularly sensitive information, please reach out to [support@gruntwork.io](mailto:support@gruntwork.io) to discuss before sending over.
 
-NOTE: *Currently, Gruntwork does not have an official bug bounty program, however we are grateful for efforts to help make our products more secure. Therefore, if you make a security disclosure, we may pay up to $500 cash, depending on the impact of the vulnerability. Please note that by submitting a vulnerability, you acknowledge that payment is completely at the discretion of Gruntwork.*
-
 ## What we would like to see from you
 
 In order to help us triage and prioritize submissions, we recommend that your report include the following:


### PR DESCRIPTION
We've removed the bug bounty from our Vulnerability Disclosure Policy due to the greatly decreased signal-to-noise ratio in the reports we received.