### PR TITLE
Remove Jenkins (and some GitLab) references

### DIFF
--- a/_data/devops-checklist.yml
+++ b/_data/devops-checklist.yml
@@ -6,7 +6,7 @@
         <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html" target="_blank">Amazon Machine Images (AMIs)</a>
         using a tool such as <a href="https://www.packer.io/" target="_blank">Packer</a>. Although we recommend Docker
         for all stateless apps (see below), we recommend directly using AMIs and EC2 Instances for all stateful apps,
-        such as any data store (MySQL, MongoDB, Kafka), and app that writes to its local disk (e.g., WordPress, Jenkins).
+        such as any data store (MySQL, MongoDB, Kafka), and app that writes to its local disk (e.g., WordPress).
 
     - title: Deploy AMIs using Auto Scaling Groups
       description: |
@@ -360,8 +360,7 @@
       description: |
         Set up a server to automatically run builds, static analysis, automated tests, etc. after every commit. You can
         use a hosted system such as <a href="https://circleci.com/" target="_blank">CircleCI</a> or
-        <a href="https://travis-ci.org/" target="_blank">Travis CI</a>, or run your a build server yourself with a tool
-        such as <a href="https://jenkins.io/" target="_blank">Jenkins</a>.
+        <a href="https://travis-ci.org/" target="_blank">Travis CI</a>.
 
 - category: Continuous Delivery
   items:

--- a/_data/initial-setup-how-it-works.yml
+++ b/_data/initial-setup-how-it-works.yml
@@ -8,7 +8,6 @@
       <li>Run services on Docker using EKS (Kubernetes) or ECS, or directly on EC2 Instances using ASGs</li>
       <li>PostgreSQL, MySQL, SQL Server, Aurora, or other relational database</li>
       <li>Redis or Memcached</li>
-      <li>CircleCI, GitLab, or Jenkins</li>
       <li>Bastion Host or OpenVPN</li>
       <li>Static content storage and serving</li>
       <li>Serverless functions</li>

--- a/_data/library.yml
+++ b/_data/library.yml
@@ -14,7 +14,7 @@
       description: Launch a VPC meant to house applications and production code. This module creates the VPC, 3 "tiers" of subnets (public, private app, private persistence) across all Availability Zones, route tables, routing rules, Internet gateways, and NAT gateways.
     - name: vpc-mgmt
       blurb: launch a mgmt VPC
-      description: Launch a VPC meant to house internal tools (e.g. Jenkins, VPN server). This module creates the VPC, 2 "tiers" of subnets (public, private), route tables, routing rules, Internet gateways, and NAT gateways.
+      description: Launch a VPC meant to house internal tools (e.g. VPN server). This module creates the VPC, 2 "tiers" of subnets (public, private), route tables, routing rules, Internet gateways, and NAT gateways.
     - name: vpc-app-network-acls
       blurb: add NACLs to the app VPC
       description: Add a default set of Network ACLs to a VPC created using the vpc-app module that strictly control what inbound and outbound network traffic is allowed in each subnet of that VPC.
@@ -326,8 +326,7 @@
   subscriber_url: "https://github.com/gruntwork-io/module-ci"
   type: Subscriber-Only
   description: |
-    A collection of scripts and Terraform code that implement common CI and build pipeline tasks including running
-    Jenkins, configuring CircleCi, building a Docker image, building a Packer image, updating Terraform code, pushing
+    A collection of scripts and Terraform code that implement common CI and build pipeline tasks including configuring CircleCi, building a Docker image, building a Packer image, updating Terraform code, pushing
     to git, sharing or making AMIs public, and configuring the build environment.
   submodules:
     - name: aws-helpers
@@ -348,12 +347,6 @@
     - name: ec2-backup
       blurb: backup an EC2 instance on a schedule
       description: Run a Lambda function to make scheduled backups of EC2 Instances.
-    - name: install-jenkins
-      blurb: install Jenkins
-      description: Install Jenkins on a Linux server.
-    - name: jenkins-server
-      blurb: deploy Jenkins
-      description: Deploy a Jenkins server with an ASG, EBS Volume, ALB, and Route 53 settings.
 
 - name: "Relational Database"
   icons:
@@ -418,7 +411,7 @@
   subscriber_url: "https://github.com/gruntwork-io/module-server"
   type: Subscriber-Only
   description: |
-    Set up a best-practices deployment of a single, stateful server on top of AWS, such as Jenkins or WordPress. Supports
+    Set up a best-practices deployment of a single, stateful server on top of AWS, such as WordPress. Supports
     EBS volume re-attachment, and a scheduled Lambda job to backup the Instance on a cron schedule. Includes alarm if
     backup jobs fail.
   submodules:

--- a/_data/reference-architecture.yml
+++ b/_data/reference-architecture.yml
@@ -33,7 +33,7 @@ infrastructure:
 
   - title: CI server
     description: |
-      Choose from GitHub Actions, CircleCI, GitLab, or Jenkins.
+      Choose from GitHub Actions or CircleCI.
 
   - title: Sample frontend app
     description: |

--- a/_data/steps.yml
+++ b/_data/steps.yml
@@ -11,7 +11,7 @@
     Fortunately, there's a solution: the Gruntwork <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a>
     (IaC Library) is a collection of reusable infrastructure code written in Terraform, Go, Bash, and Python that
     solves these 1,001 problems. Instead of reinventing the wheel, you can leverage 5+ years and 350,000+ lines of
-    battle-tested code, including pre-built solutions for Kubernetes, MySQL, Postgres, Redis, OpenVPN, Jenkins, Lambda,
+    battle-tested code, including pre-built solutions for Kubernetes, MySQL, Postgres, Redis, OpenVPN, Lambda,
     CloudWatch, Kafka, ELK, and more, all of which have been proven in production at
     <a href="/customers/">hundreds of companies</a>. To get an idea of how the library works before signing up, try out
     our <a href="/infrastructure-as-code-library/#open-source">open source modules</a> and check out

--- a/_data/technologies.yml
+++ b/_data/technologies.yml
@@ -16,9 +16,6 @@
 - name: PostgreSQL
   logo: /assets/img/logos-technologies/logo-postgres.png
 
-- name: Jenkins
-  logo: /assets/img/logos-technologies/logo-jenkins.png
-
 - name: Redis
   logo: /assets/img/logos-technologies/logo-redis.png
 

--- a/pages/index/_learn-more.html
+++ b/pages/index/_learn-more.html
@@ -57,7 +57,7 @@
       deploy a <a href="/reference-architecture">Reference Architecture</a> for
       you, giving you an end-to-end tech stack, 100% backed by code, in about 1
       day. You get to customize the tech stack to your needs, choosing from
-      Kubernetes or ECS, MySQL or Postgres, Jenkins or CircleCI, and so on.
+      Kubernetes or ECS, MySQL or Postgres, and so on.
     </p>
     <p>
       <a

--- a/pages/infrastructure-as-code-library/_search.html
+++ b/pages/infrastructure-as-code-library/_search.html
@@ -4,7 +4,7 @@
       Search:
     </label>
     <div class="col-sm-11">
-      <input type="text" id="js-search-library" class="form-control" placeholder="E.g., Try searching for Kubernetes, Jenkins, Kafka, Lambda, etc..." data-hj-whitelist />
+      <input type="text" id="js-search-library" class="form-control" placeholder="E.g., Try searching for Kubernetes, Kafka, Lambda, etc..." data-hj-whitelist />
       <script>
         window.libraryEntries = [
           {% for package in site.data.library %}


### PR DESCRIPTION
Please check this work! This is my first PR against the website and I've made a number of changes that might have unintended consequences.

This is supporting https://gruntwork.atlassian.net/browse/CORE-62 in Jira, to remove references to Jenkins from the public website.