### PR TITLE
Reflect new Ref Arch emergency measures

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the code for the [Gruntwork website](https://www.gruntwork.io).
 
-Gruntwork can help you get your entire infrastructure, defined as code, in about one day. You focus on your product.
+Gruntwork can help you get your entire infrastructure, defined as code, in a few days. You focus on your product.
 We'll take care of the Gruntwork.
 
 ## Docker quick start

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 baseurl: ""
 url: "https://www.gruntwork.io"
 name: "Gruntwork | DevOps as a Service"
-description: "Your entire infrastructure. Defined as code. In about one day. At Gruntwork, we get you running on AWS with Terraform and you get 100% of the code."
+description: "Your entire infrastructure. Defined as code. In a few days. At Gruntwork, we get you running on AWS with Terraform and you get 100% of the code."
 full_company_name: "Gruntwork, Inc"
 thumbnail_path: "/assets/img/logos-gruntwork/gruntwork-overview.png"
 repository: "gruntwork-io/gruntwork-io.github.io"

--- a/_data/cis-how-it-works.yml
+++ b/_data/cis-how-it-works.yml
@@ -24,7 +24,7 @@
     <p class="alert" style="border: 1px solid #194c5f; background-color: #242e3b;">
       <strong>Get an End-to-End CIS Compliant Production-Grade Architecture</strong><br>
       Request a <a href="/reference-architecture">Gruntwork Reference Architecture</a> to get an end to end
-      production-grade environment, certified by CIS for the AWS Foundations Benchmark, deployed into your AWS accounts, and fully managed as code—all in about 1 day!
+      production-grade environment, certified by CIS for the AWS Foundations Benchmark, deployed into your AWS accounts, and fully managed as code—all in a few days!
     </p>
 
 - title: Pass an audit

--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -169,7 +169,7 @@
                 The modules in the Infrastructure as Code Library are all designed to be highly configurable, composable, and to
                 work together. In fact, we even offer the <a href="/reference-architecture/">Reference Architecture</a>,
                 which is a battle-tested, end-to-end tech stack for AWS that we can customize to your needs and deploy
-                into your AWS accounts in about one day. With open source code, all the integration work is up to you,
+                into your AWS accounts in a few days. With open source code, all the integration work is up to you,
                 and you'll find many of the modules are too inflexible to fit your needs or incompatible with other modules.
               </td>
             </tr>

--- a/_data/initial-setup-how-it-works.yml
+++ b/_data/initial-setup-how-it-works.yml
@@ -20,7 +20,7 @@
     <p>
       We generate the architecture using Terragrunt, Terraform, Bash, Python and Go. We deploy the resources to your
       AWS accounts. We validate the configuration, then we push the code to your git repository. For AWS, this
-      takes about one day.
+      takes a few days.
     </p>
 
 - title: Learn how to use it

--- a/_data/initial-setup-how-it-works.yml
+++ b/_data/initial-setup-how-it-works.yml
@@ -2,10 +2,10 @@
   description: |
     <p>Customize your architecture and complete a few setup steps:</p>
     <ul>
-      <li>Create several AWS accounts (logs, security, shared, dev, stage, and prod)</li>
+      <li>Create six AWS accounts (logs, security, shared, dev, stage, and prod)</li>
       <li>Choose a region</li>
-      <li>Set up domains in DNS</li>
-      <li>Run services on Docker using EKS (Kubernetes) or ECS, or directly on EC2 Instances using ASGs</li>
+      <li>Set up domains (TLDs) in DNS</li>
+      <li>Run services on Docker using EKS (Kubernetes) or ECS</li>
       <li>PostgreSQL, MySQL, SQL Server, Aurora, or other relational database</li>
       <li>Redis or Memcached</li>
       <li>Bastion Host or OpenVPN</li>

--- a/_data/initial-setup-how-it-works.yml
+++ b/_data/initial-setup-how-it-works.yml
@@ -8,7 +8,6 @@
       <li>Run services on Docker using EKS (Kubernetes) or ECS, or directly on EC2 Instances using ASGs</li>
       <li>PostgreSQL, MySQL, SQL Server, Aurora, or other relational database</li>
       <li>Redis or Memcached</li>
-      <li>CircleCI, GitLab, or Jenkins</li>
       <li>Bastion Host or OpenVPN</li>
       <li>Static content storage and serving</li>
       <li>Serverless functions</li>

--- a/_data/reference-architecture-features.yml
+++ b/_data/reference-architecture-features.yml
@@ -5,7 +5,7 @@
   description: The architecture has been proven with hundreds of Gruntwork customers.
 
 - title: Fast
-  description: We'll deploy a fully-working, best-practices tech stack in AWS in about one day!
+  description: We'll deploy a fully-working, best-practices tech stack in AWS in a few days!
 
 - title: Reliable
   description: Designed for high availability, scalability, and durability

--- a/_data/steps.yml
+++ b/_data/steps.yml
@@ -25,7 +25,7 @@
     <a href="/reference-architecture/">Reference Architecture</a> for you. The Reference Architecture is an opinionated,
     battle-tested, end-to-end tech stack that includes just about everything you need, including: server cluster, load
     balancer, database, cache, network topology, monitoring, alerting, CI/CD, secrets management, VPN, and more. We
-    customize the Reference Architecture to your needs, give you 100% of the code, and deploy it into your AWS account in about one day.
+    customize the Reference Architecture to your needs, give you 100% of the code, and deploy it into your AWS account in a few days.
 
 - title: Learn Terraform, Docker, Packer, AWS, and DevOps
   description: |

--- a/_data/steps.yml
+++ b/_data/steps.yml
@@ -11,7 +11,7 @@
     Fortunately, there's a solution: the Gruntwork <a href="/infrastructure-as-code-library/">Infrastructure as Code Library</a>
     (IaC Library) is a collection of reusable infrastructure code written in Terraform, Go, Bash, and Python that
     solves these 1,001 problems. Instead of reinventing the wheel, you can leverage 5+ years and 350,000+ lines of
-    battle-tested code, including pre-built solutions for Kubernetes, MySQL, Postgres, Redis, OpenVPN, Jenkins, Lambda,
+    battle-tested code, including pre-built solutions for Kubernetes, MySQL, Postgres, Redis, OpenVPN, Lambda,
     CloudWatch, Kafka, ELK, and more, all of which have been proven in production at
     <a href="/customers/">hundreds of companies</a>. To get an idea of how the library works before signing up, try out
     our <a href="/infrastructure-as-code-library/#open-source">open source modules</a> and check out

--- a/pages/checkout/_add-ons.html
+++ b/pages/checkout/_add-ons.html
@@ -86,7 +86,7 @@
               Benchmark. Our code is certified compliant by the Center for
               Internet Security. Add the Reference Architecture to get an
               end-to-end, production-grade architecture in your own AWS
-              environment, fully managed as code - all in about 1 day!
+              environment, fully managed as code - all in a few days!
             </p>
             <p id="cis-button-default" hidden>
               <a

--- a/pages/checkout/_checkout.html
+++ b/pages/checkout/_checkout.html
@@ -117,7 +117,7 @@
               <li class="check-list-disabled" id="subscription-addon-2">
                 <span
                   class="help-text light"
-                  title="An opinionated, best-practices, end-to-end tech stack that we customize to your needs, deploy into your AWS accounts, and give you 100% of the code—all in about one day."
+                  title="An opinionated, best-practices, end-to-end tech stack that we customize to your needs, deploy into your AWS accounts, and give you 100% of the code—all in a few days."
                   data-toggle="tooltip"
                   id="subscription-addon-3-text"
                   >Reference Architecture</span

--- a/pages/how-it-works/index.html
+++ b/pages/how-it-works/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Gruntwork: How it Works"
-excerpt: Gruntwork can help you get your entire infrastructure defined as code in about one day. Here's how it works.
+excerpt: Gruntwork can help you get your entire infrastructure defined as code in a few days. Here's how it works.
 permalink: /how-it-works/
 slug: how-it-works
 footer_heading: Ready to hand off the gruntwork?

--- a/pages/index/_hero.html
+++ b/pages/index/_hero.html
@@ -9,7 +9,7 @@
   <h1 style="margin-bottom: 15px">
     Your entire infrastructure.
     <br />
-    Defined as code. In about a day.
+    Defined as code. In a few days.
   </h1>
   <div class="clearfix hidden-print">
     <div class="pull-left lead up-and-running-text">We get you running on AWS with</div>

--- a/pages/index/_learn-more.html
+++ b/pages/index/_learn-more.html
@@ -55,9 +55,9 @@
       Deploy your own tech stack by following our
       <a href="https://docs.gruntwork.io/docs/guides/build-it-yourself/overview/">deployment guides</a>, or have Gruntwork
       deploy a <a href="/reference-architecture">Reference Architecture</a> for
-      you, giving you an end-to-end tech stack, 100% backed by code, in about 1
-      day. You get to customize the tech stack to your needs, choosing from
-      Kubernetes or ECS, MySQL or Postgres, Jenkins or CircleCI, and so on.
+      you, giving you an end-to-end tech stack, 100% backed by code, in a few
+      days. You get to customize the tech stack to your needs, choosing from
+      Kubernetes or ECS, MySQL or Postgres, and so on.
     </p>
     <p>
       <a

--- a/pages/infrastructure-as-code-library/_search.html
+++ b/pages/infrastructure-as-code-library/_search.html
@@ -4,7 +4,7 @@
       Search:
     </label>
     <div class="col-sm-11">
-      <input type="text" id="js-search-library" class="form-control" placeholder="E.g., Try searching for Kubernetes, Jenkins, Kafka, Lambda, etc..." data-hj-whitelist />
+      <input type="text" id="js-search-library" class="form-control" placeholder="E.g., Try searching for Kubernetes, Kafka, Lambda, etc..." data-hj-whitelist />
       <script>
         window.libraryEntries = [
           {% for package in site.data.library %}

--- a/pages/reference-architecture/_sub-hero.html
+++ b/pages/reference-architecture/_sub-hero.html
@@ -15,7 +15,7 @@
       We generate the Reference Architecture based on your needs, deploy into your
       AWS accounts, and give you 100% of the code. Since you have all the code, you
       can extend, enhance, and customize the environment exactly according to your
-      needs. The deploy process takes about one day. <a href="/contact">Contact Us</a>
+      needs. The deploy process takes a few days. <a href="/contact">Contact Us</a>
       to set up a demo!
     </p>
     <p>

--- a/pages/reference-architecture/index.html
+++ b/pages/reference-architecture/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Reference Architecture
-excerpt: An opinionated, end-to-end tech stack built on top of the Infrastructure as Code Library that we deploy into your AWS accounts in about one day.
+excerpt: An opinionated, end-to-end tech stack built on top of the Infrastructure as Code Library that we deploy into your AWS accounts in a few days.
 permalink: /reference-architecture/
 slug: reference-architecture
 footer_heading: Talk with our team of DevOps experts now!

--- a/pages/why-prod-is-down/index.html
+++ b/pages/why-prod-is-down/index.html
@@ -211,7 +211,7 @@ permalink: /why-prod-is-down/
               <a
                 href="https://www.gruntwork.io/?ref=why-prod-is-down"
                 class="white"
-                >Your entire infrastructure. Defined as code. In one day.</a
+                >Your entire infrastructure. Defined as code. In a few days.</a
               >
             </div>
             <strong


### PR DESCRIPTION
This is a more surgical set of changes than my previous (closed) PR to update the website to reflect emergency Ref Arch deploy option limitations, per: https://gruntwork.atlassian.net/browse/CORE-25

To recap, the changes we're advertising are: 
* Set a hard limit of 6 AWS accounts per customer.
* (Temporarily) suspend the option for customer to choose their own CIDRs.
* (Temporarily) suspend ASG offering.
* Support only standard AWS regions.
* Only allow TLDs in each account.
* Loosen SLA to deploy within 2 weeks (aiming for 1 week) -- that is, change "in about a day" to "in a few days"

In particular, check the content of [_data/initial-setup-how-it-works.yml](https://github.com/gruntwork-io/gruntwork-io.github.io/compare/ref-arch-emergency-measures?expand=1#diff-bd0c87de715c1958a896a2df2ff8a934e97705bfc44294f48e04756538fc5229).