### PR TITLE
Update Enterprise Support description

### DIFF
--- a/pages/support/_enterprise-support.html
+++ b/pages/support/_enterprise-support.html
@@ -4,11 +4,9 @@
     <p>
       Gruntwork also offers an enterprise support plan that includes:
       <ul>
-        <li>Live chat in phone/video calls</li>
-        <li>Design reviews</li>
-        <li>Code reviews</li>
-        <li>Prioritized bug fixes</li>
-        <li>Guaranteed same-day response times</li>
+        <li>SLA on response times</li>
+        <li>Private shared Slack channel</li>
+        <li>Phone/video calls if we can’t resolve a problem async</li>
       </ul>
       For more information, please <a href="/contact">contact us</a>.
     </p>


### PR DESCRIPTION
Change the description of Enterprise Support to accurately reflect what we promise customers, per [this Slack conversation](https://gruntwork-io.slack.com/archives/C79R0C0SC/p1666379088111599).