### PR TITLE
Revert "Add new ecs-task-scheduler module to ECS IaC library page"

### DIFF
--- a/_data/library.yml
+++ b/_data/library.yml
@@ -83,9 +83,6 @@
     - name: ecs-deploy
       blurb: deploy a short-running task in your ECS cluster
       description: Deploy a Docker container as a short-running ECS Task, wait for it to exit, and exit with the same exit code as the ECS Task.
-    - name: ecs-task-scheduler
-      blurb: schedule ECS tasks
-      description: Schedule ECS tasks to be run on time or event-based schedules.
 
 - name: "EC2 Kubernetes Service (EKS)"
   icons:


### PR DESCRIPTION
Reverts gruntwork-io/gruntwork-io.github.io#760