### PR TITLE
Restore 'in about a day' messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the code for the [Gruntwork website](https://www.gruntwork.io).
 
-Gruntwork can help you get your entire infrastructure, defined as code, in a few days. You focus on your product.
+Gruntwork can help you get your entire infrastructure, defined as code, in about a day. You focus on your product.
 We'll take care of the Gruntwork.
 
 ## Docker quick start

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 baseurl: ""
 url: "https://www.gruntwork.io"
 name: "Gruntwork | DevOps as a Service"
-description: "Your entire infrastructure. Defined as code. In a few days. At Gruntwork, we get you running on AWS with Terraform and you get 100% of the code."
+description: "Your entire infrastructure. Defined as code. In about a day. At Gruntwork, we get you running on AWS with Terraform and you get 100% of the code."
 full_company_name: "Gruntwork, Inc"
 thumbnail_path: "/assets/img/logos-gruntwork/gruntwork-overview.png"
 repository: "gruntwork-io/gruntwork-io.github.io"

--- a/_data/cis-how-it-works.yml
+++ b/_data/cis-how-it-works.yml
@@ -24,7 +24,7 @@
     <p class="alert" style="border: 1px solid #194c5f; background-color: #242e3b;">
       <strong>Get an End-to-End CIS Compliant Production-Grade Architecture</strong><br>
       Request a <a href="/reference-architecture">Gruntwork Reference Architecture</a> to get an end to end
-      production-grade environment, certified by CIS for the AWS Foundations Benchmark, deployed into your AWS accounts, and fully managed as code—all in a few days!
+      production-grade environment, certified by CIS for the AWS Foundations Benchmark, deployed into your AWS accounts, and fully managed as code—all in about a day!
     </p>
 
 - title: Pass an audit

--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -169,7 +169,7 @@
                 The modules in the Infrastructure as Code Library are all designed to be highly configurable, composable, and to
                 work together. In fact, we even offer the <a href="/reference-architecture/">Reference Architecture</a>,
                 which is a battle-tested, end-to-end tech stack for AWS that we can customize to your needs and deploy
-                into your AWS accounts in a few days. With open source code, all the integration work is up to you,
+                into your AWS accounts in about a day. With open source code, all the integration work is up to you,
                 and you'll find many of the modules are too inflexible to fit your needs or incompatible with other modules.
               </td>
             </tr>

--- a/_data/initial-setup-how-it-works.yml
+++ b/_data/initial-setup-how-it-works.yml
@@ -20,7 +20,7 @@
     <p>
       We generate the architecture using Terragrunt, Terraform, Bash, Python and Go. We deploy the resources to your
       AWS accounts. We validate the configuration, then we push the code to your git repository. For AWS, this
-      takes a few days.
+      takes about a day.
     </p>
 
 - title: Learn how to use it

--- a/_data/reference-architecture-features.yml
+++ b/_data/reference-architecture-features.yml
@@ -5,7 +5,7 @@
   description: The architecture has been proven with hundreds of Gruntwork customers.
 
 - title: Fast
-  description: We'll deploy a fully-working, best-practices tech stack in AWS in a few days!
+  description: We'll deploy a fully-working, best-practices tech stack in AWS in about a day!
 
 - title: Reliable
   description: Designed for high availability, scalability, and durability

--- a/_data/steps.yml
+++ b/_data/steps.yml
@@ -25,7 +25,7 @@
     <a href="/reference-architecture/">Reference Architecture</a> for you. The Reference Architecture is an opinionated,
     battle-tested, end-to-end tech stack that includes just about everything you need, including: server cluster, load
     balancer, database, cache, network topology, monitoring, alerting, CI/CD, secrets management, VPN, and more. We
-    customize the Reference Architecture to your needs, give you 100% of the code, and deploy it into your AWS account in a few days.
+    customize the Reference Architecture to your needs, give you 100% of the code, and deploy it into your AWS account in about a day.
 
 - title: Learn Terraform, Docker, Packer, AWS, and DevOps
   description: |

--- a/pages/checkout/_add-ons.html
+++ b/pages/checkout/_add-ons.html
@@ -86,7 +86,7 @@
               Benchmark. Our code is certified compliant by the Center for
               Internet Security. Add the Reference Architecture to get an
               end-to-end, production-grade architecture in your own AWS
-              environment, fully managed as code - all in a few days!
+              environment, fully managed as code - all in about a day!
             </p>
             <p id="cis-button-default" hidden>
               <a

--- a/pages/checkout/_checkout.html
+++ b/pages/checkout/_checkout.html
@@ -117,7 +117,7 @@
               <li class="check-list-disabled" id="subscription-addon-2">
                 <span
                   class="help-text light"
-                  title="An opinionated, best-practices, end-to-end tech stack that we customize to your needs, deploy into your AWS accounts, and give you 100% of the code—all in a few days."
+                  title="An opinionated, best-practices, end-to-end tech stack that we customize to your needs, deploy into your AWS accounts, and give you 100% of the code—all in about a day."
                   data-toggle="tooltip"
                   id="subscription-addon-3-text"
                   >Reference Architecture</span

--- a/pages/how-it-works/index.html
+++ b/pages/how-it-works/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Gruntwork: How it Works"
-excerpt: Gruntwork can help you get your entire infrastructure defined as code in a few days. Here's how it works.
+excerpt: Gruntwork can help you get your entire infrastructure defined as code in about a day. Here's how it works.
 permalink: /how-it-works/
 slug: how-it-works
 footer_heading: Ready to hand off the gruntwork?

--- a/pages/index/_hero.html
+++ b/pages/index/_hero.html
@@ -9,7 +9,7 @@
   <h1 style="margin-bottom: 15px">
     Your entire infrastructure.
     <br />
-    Defined as code. In a few days.
+    Defined as code. In about a day.
   </h1>
   <div class="clearfix hidden-print">
     <div class="pull-left lead up-and-running-text">We get you running on AWS with</div>

--- a/pages/reference-architecture/_sub-hero.html
+++ b/pages/reference-architecture/_sub-hero.html
@@ -15,7 +15,7 @@
       We generate the Reference Architecture based on your needs, deploy into your
       AWS accounts, and give you 100% of the code. Since you have all the code, you
       can extend, enhance, and customize the environment exactly according to your
-      needs. The deploy process takes a few days. <a href="/contact">Contact Us</a>
+      needs. The deploy process takes about a day. <a href="/contact">Contact Us</a>
       to set up a demo!
     </p>
     <p>

--- a/pages/reference-architecture/index.html
+++ b/pages/reference-architecture/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Reference Architecture
-excerpt: An opinionated, end-to-end tech stack built on top of the Infrastructure as Code Library that we deploy into your AWS accounts in a few days.
+excerpt: An opinionated, end-to-end tech stack built on top of the Infrastructure as Code Library that we deploy into your AWS accounts in about a day.
 permalink: /reference-architecture/
 slug: reference-architecture
 footer_heading: Talk with our team of DevOps experts now!

--- a/pages/why-prod-is-down/index.html
+++ b/pages/why-prod-is-down/index.html
@@ -211,7 +211,7 @@ permalink: /why-prod-is-down/
               <a
                 href="https://www.gruntwork.io/?ref=why-prod-is-down"
                 class="white"
-                >Your entire infrastructure. Defined as code. In a few days.</a
+                >Your entire infrastructure. Defined as code. In about a day.</a
               >
             </div>
             <strong


### PR DESCRIPTION
We've been delivering the Ref Arch in about a day on average, and we're not certain that the "in a few days" messaging isn't eroding our marketing message, so we're restoring the "in about a day" wording throughout the site.