### PR TITLE
Update Gruntwork Address

### DIFF
--- a/_data/terms-of-service.yml
+++ b/_data/terms-of-service.yml
@@ -332,7 +332,7 @@
 
     - title: 17. Notices
       legalese: |
-        <p>Subject to <a href="#1-updates" title="Updates">Section 1</a>, any notice or other communication pursuant to these Terms will be in writing and use one of the following types of delivery, each of which is a writing for purposes of these Terms: personal delivery, mail (registered or certified mail, postage prepaid, return-receipt requested), nationally recognized overnight courier (fees prepaid), or email. Gruntwork shall address notices to you to the mailing address and email address you list in your GSA. You shall address notices to Gruntwork to: 221 E Indianola Ave, Phoenix, AZ 85012, and via email to legal@gruntwork.io.</p>
+        <p>Subject to <a href="#1-updates" title="Updates">Section 1</a>, any notice or other communication pursuant to these Terms will be in writing and use one of the following types of delivery, each of which is a writing for purposes of these Terms: personal delivery, mail (registered or certified mail, postage prepaid, return-receipt requested), nationally recognized overnight courier (fees prepaid), or email. Gruntwork shall address notices to you to the mailing address and email address you list in your GSA. You shall address notices to Gruntwork to: 2307 Fenton Pkwy #107-623, San Diego CA 92108, and via email to legal@gruntwork.io.</p>
       plain: |
         An official notice under this agreement can be sent by personal delivery, registered or certified mail, overnight courier, or email.
 

--- a/_data/website-terms.yml
+++ b/_data/website-terms.yml
@@ -115,7 +115,7 @@
         <div class='address-element'>
           <p>Gruntwork, Inc.</p>
           <p>Attn: Copyright Agent</p>
-          <p>221 E. Indianola Ave., Phoenix, AZ 85012</p>
+          <p>2307 Fenton Pkwy #107- 623, San Diego CA 92108</p>
           <p>Email: abuse@gruntwork.io</p>
         </div>
         <p>If you fail to comply with all of the requirements of Section 512(c)(3) of the DMCA, your DMCA Notice may not be effective.</p>

--- a/_data/website-terms.yml
+++ b/_data/website-terms.yml
@@ -115,7 +115,7 @@
         <div class='address-element'>
           <p>Gruntwork, Inc.</p>
           <p>Attn: Copyright Agent</p>
-          <p>2307 Fenton Pkwy #107- 623, San Diego CA 92108</p>
+          <p>2307 Fenton Pkwy #107-623, San Diego CA 92108</p>
           <p>Email: abuse@gruntwork.io</p>
         </div>
         <p>If you fail to comply with all of the requirements of Section 512(c)(3) of the DMCA, your DMCA Notice may not be effective.</p>


### PR DESCRIPTION
The official Gruntwork address changed to `2307 Fenton Pkwy #107-623, San Diego CA 92108` and this PR reflects those changes. 