### PR TITLE
pricing: clarify standard user licenses

### DIFF
--- a/pages/pricing/_standard-pricing.html
+++ b/pages/pricing/_standard-pricing.html
@@ -15,7 +15,7 @@
                   data-toggle="tooltip">250+ Subscriber-Only Modules</span></li>
         <li><span class="help-text light"
                   title="A user is a human or machine that accesses the Gruntwork code repos, training materials, or support services. For more than 20 users, see Gruntwork Enterprise."
-                  data-toggle="tooltip">Up to 20 Users</span></li>
+                  data-toggle="tooltip">20 Users Included, Upgradable up to 50 Users</span></li>
         <li><span class="help-text light"
                   title="Learn DevOps fundamentals with our online video courses designed specially for aspiring DevOps Engineers."
                   data-toggle="tooltip">DevOps Training Library &amp; Docs</span></li>

--- a/pages/pricing/_standard-pricing.html
+++ b/pages/pricing/_standard-pricing.html
@@ -15,7 +15,7 @@
                   data-toggle="tooltip">250+ Subscriber-Only Modules</span></li>
         <li><span class="help-text light"
                   title="A user is a human or machine that accesses the Gruntwork code repos, training materials, or support services. For more than 20 users, see Gruntwork Enterprise."
-                  data-toggle="tooltip">20 Users Included, Upgradable up to 50 Users</span></li>
+                  data-toggle="tooltip">20 Users Included, add up to 50 Users</span></li>
         <li><span class="help-text light"
                   title="Learn DevOps fundamentals with our online video courses designed specially for aspiring DevOps Engineers."
                   data-toggle="tooltip">DevOps Training Library &amp; Docs</span></li>


### PR DESCRIPTION
Clarify that 20 user licenses are included with Standard, and that you can add up to 30 additional users for a total of 50 before Enterprise pricing makes more sense. 