### PR TITLE
Add HubSpot back to gruntwork.io pages

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -9,6 +9,9 @@
 <script src="/assets/js/{{ js_file }}.js" type="text/javascript"></script>
 {% endfor %} {% endif %} {% if site.gtm_id %}
 
+<!-- HubSpot Embed Code per https://knowledge.hubspot.com/reports/install-the-hubspot-tracking-code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/8376079.js"></script>
+
 <!-- Google Tag Manager (noscript) -->
 <noscript>
   <iframe


### PR DESCRIPTION
Restore HubSpot functionality to the Gruntwork website. Additionally, now that this is back, we can add a chatbot that I currently have configured on all marketing pages except for `/contact/`:

<img width="1654" alt="Screenshot 2023-07-11 at 9 34 32 PM" src="https://github.com/gruntwork-io/gruntwork-io.github.io/assets/101607944/a0782597-40ea-49ba-a462-53d877ed69cc">
<img width="1654" alt="Screenshot 2023-07-11 at 9 34 36 PM" src="https://github.com/gruntwork-io/gruntwork-io.github.io/assets/101607944/0134d450-04a8-493f-9edf-ad2217e88399">
<img width="1654" alt="Screenshot 2023-07-11 at 9 34 52 PM" src="https://github.com/gruntwork-io/gruntwork-io.github.io/assets/101607944/eebdddab-6d74-489e-bd14-0ca43dd6ec37">
<img width="1654" alt="Screenshot 2023-07-11 at 10 02 49 PM" src="https://github.com/gruntwork-io/gruntwork-io.github.io/assets/101607944/e5cc7380-d93b-4182-b0a8-00afca3db8c0">

