### PR TITLE
Remove deprecated search from IaC Library

### DIFF
--- a/pages/infrastructure-as-code-library/_library.html
+++ b/pages/infrastructure-as-code-library/_library.html
@@ -3,7 +3,7 @@
   The Infrastructure as Code Library consists of 300+ reusable, battle-tested
   production-grade Terraform modules for AWS.
 </p>
-<ul>
-  <li><a href="https://docs.gruntwork.io/library/overview/">Read the Library Docs</a></li>
-  <li><a href="https://docs.gruntwork.io/library/reference/">Search the Library</a></li>
-</ul>
+<p>
+  <a href="https://docs.gruntwork.io/library/reference/" class="btn btn-primary" role="button" ga-on="click" ga-event-category="CTA Clicks" ga-event-action="Search Library" ga-event-label="User clicked Search Library from marketing website" target="_blank">Search the library</a>
+  <a href="https://docs.gruntwork.io/library/overview/" class="btn" role="button" ga-on="click" ga-event-category="CTA Clicks" ga-event-action="Read Library Docs" ga-event-label="User clicked Read the Library Docs from marketing website" target="_blank">Read the library docs</a>
+</p>

--- a/pages/infrastructure-as-code-library/_library.html
+++ b/pages/infrastructure-as-code-library/_library.html
@@ -1,15 +1,9 @@
 <h2>What's in the Library?</h2>
 <p>
-  The Infrastructure as Code Library consists of 40+ GitHub repos, some open
-  source, some private, each of which contains reusable, battle-tested
-  infrastructure code for AWS, written in Terraform, Go, Bash,
-  and Python. Check out
-  <a
-    href="https://docs.gruntwork.io/library/overview/"
-    target="_blank"
-    >How to use the Gruntwork Infrastructure as Code Library</a
-  >
-  to see how it all works.
+  The Infrastructure as Code Library consists of 300+ reusable, battle-tested
+  production-grade Terraform modules for AWS.
 </p>
-{% include_relative _search.html %} {% include_relative _library-table.html %}
-{% include_relative _no-results.html %} {% include_relative _modals.html %}
+<ul>
+  <li><a href="https://docs.gruntwork.io/library/overview/">Read the Library Docs</a></li>
+  <li><a href="https://docs.gruntwork.io/library/reference/">Search the Library</a></li>
+</ul>


### PR DESCRIPTION
Now that we have a [Library Reference](https://docs.gruntwork.io/library/reference/), we should remove the current Library search from the marketing site, which is now outdated.