### PR TITLE
Update JDK install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,17 @@ references:
         sudo python3.7 -m pip install --upgrade pip setuptools wheel
         sudo python3.7 -m pip install pipenv
 
+  # We're installing the JDK from Adoptium
+  # https://adoptium.net/blog/2021/12/eclipse-temurin-linux-installers-available/
   install_jdk: &install-jdk
     run:
       name: install jdk 8
       command: |
-        sudo apt-get install -y temurin-8-jdk
+        sudo apt-get install -y wget apt-transport-https gnupg
+        wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
+        echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+        sudo apt update -y
+        sudo apt install -y temurin-8-jdk
 
   deploy_to_staging: &deploy-to-staging
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,7 @@ references:
     run:
       name: install jdk 8
       command: |
-        sudo apt-get install -y wget
-        wget https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/pool/main/a/adoptopenjdk-8-hotspot/adoptopenjdk-8-hotspot_8u222-b10-2_amd64.deb
-        sudo apt install ./adoptopenjdk-8-hotspot_8u222-b10-2_amd64.deb
+        sudo apt-get install temurin-8-jdk
 
   deploy_to_staging: &deploy-to-staging
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ references:
     run:
       name: install jdk 8
       command: |
-        sudo apt-get install temurin-8-jdk
+        sudo apt-get install -y temurin-8-jdk
 
   deploy_to_staging: &deploy-to-staging
     run:


### PR DESCRIPTION
Our CI build was installing the JDK from AdoptOpenJDK, but it looks like [AdoptOpenJDK has been deprecated](https://adoptium.net/blog/2023/07/adoptopenjdk-jfrog-io-has-been-deprecated/), and replaced by Adoptium. So this PR is an attempt to switch over to using Adoptium.