### PR TITLE
Fix invalid certificate error during package downloads in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ references:
       name: install jdk
       command: |
         sudo apt-get update
-        sudo apt-get install -y default-jre
+        sudo apt-get install openjdk-11-jre-headless # version 11.0.14+9-0ubuntu2
         sudo rm -rf /var/lib/apt/lists/*
 
   deploy_to_staging: &deploy-to-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,11 @@ references:
     run:
       name: install jdk 8
       command: |
-        sudo apt-get update
+        sudo apt-get update -y
         sudo apt-get install --reinstall -y ca-certificates
         sudo apt-get install -y wget apt-transport-https gnupg
         wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
         echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
-        sudo apt update -y
         sudo apt install -y temurin-8-jdk
 
   deploy_to_staging: &deploy-to-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,13 +44,11 @@ references:
   # https://adoptium.net/blog/2021/12/eclipse-temurin-linux-installers-available/
   install_jdk: &install-jdk
     run:
-      name: install jdk 8
+      name: install jdk
       command: |
-        sudo apt-get install -y wget apt-transport-https gnupg
-        wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
-        echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
-        sudo apt update -y
-        sudo apt install -y temurin-8-jdk
+        sudo apt-get update
+        sudo apt-get install -y default-jre
+        rm -rf /var/lib/apt/lists/*
 
   deploy_to_staging: &deploy-to-staging
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 # Define the ORBS we'll use in the rest of the workflow
 ######################################################################################################################
 orbs:
-  docker: circleci/docker@0.5.13
+  docker: circleci/docker@2.4.0
   awscli: circleci/aws-cli@0.1.13
   slack: circleci/slack@3.4.1
   python: circleci/python@0.3.0
@@ -44,11 +44,13 @@ references:
   # https://adoptium.net/blog/2021/12/eclipse-temurin-linux-installers-available/
   install_jdk: &install-jdk
     run:
-      name: install jdk
+      name: install jdk 8
       command: |
-        sudo apt-get update
-        sudo apt-get install openjdk-11-jre-headless # version 11.0.14+9-0ubuntu2
-        sudo rm -rf /var/lib/apt/lists/*
+        sudo apt-get install -y wget apt-transport-https gnupg
+        wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
+        echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+        sudo apt update -y
+        sudo apt install -y temurin-8-jdk
 
   deploy_to_staging: &deploy-to-staging
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ references:
       command: |
         sudo apt-get update
         sudo apt-get install -y default-jre
-        rm -rf /var/lib/apt/lists/*
+        sudo rm -rf /var/lib/apt/lists/*
 
   deploy_to_staging: &deploy-to-staging
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,8 @@ references:
     run:
       name: install jdk 8
       command: |
+        sudo apt-get update
+        sudo apt-get install --reinstall -y ca-certificates
         sudo apt-get install -y wget apt-transport-https gnupg
         wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -
         echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list


### PR DESCRIPTION
Fixes [this certificate error](https://app.circleci.com/pipelines/github/gruntwork-io/gruntwork-io.github.io/2144/workflows/2393ad16-ba47-4eb5-8f1a-c230e6a9480b/jobs/752?invite=true#step-105-5102_195) observed during Java download.

This change was tested with [a test-release](https://github.com/gruntwork-io/gruntwork-io.github.io/releases/tag/v0.0.255-testing) pointed at this branch. [See the successful CI log](https://app.circleci.com/pipelines/github/gruntwork-io/gruntwork-io.github.io/2154/workflows/e3787894-2c54-41fe-abec-830f46eae833/jobs/751?invite=true#step-105-17504_131)