### PR TITLE
Make the Ref Arch enterprise only

### DIFF
--- a/pages/pricing/_pricing-add-ons.html
+++ b/pages/pricing/_pricing-add-ons.html
@@ -10,11 +10,8 @@
         100% defined as code, deployed into your AWS accounts—all in about a day!</div>Reference Architecture
     </span>
     <div class="text-center grid-item-center">
-      <div class="pricing-checkbox-wrapper">
-        <input type="checkbox" id="add-on-reference-architecture-standard" {% unless include.already_included
-          %}name="{{site.products.RefArch.key}}" {% endunless %} class="addon-checkbox"
-          data-product-id="{{site.products.RefArch.stripeProductId}}">
-        <span class="light">+$<strong>4,950</strong> one-time</span>
+      <div class="text-center grid-item-center">
+        <img src="/assets/img/pricing-not-include.svg" alt="not_including" />
       </div>
     </div>
     <div class="text-center grid-item-center">

--- a/pages/reference-architecture/_sub-hero.html
+++ b/pages/reference-architecture/_sub-hero.html
@@ -1,6 +1,10 @@
 <div class="row row-page-header">
   <div class="col-xs-12">
     <h2>A new standard for architecture</h2>
+    <p class="alert" style="border: 1px solid #194c5f; background-color: #242e3b;">
+      <strong>Enterprise Only</strong><br>
+      The Reference Architecture is only available with Enterprise Subscriptions.
+    </p> 
     <p>
       The Reference Architecture is an opinionated, battle-tested, best-practices way of setting up all the foundational
       pieces you need to get started with AWS and Terraform, including:


### PR DESCRIPTION
See [this Slack thread](https://gruntwork-io.slack.com/archives/C0521Q6RNSY/p1699460090820559?thread_ts=1698883314.483969&cid=C0521Q6RNSY) for context.

Direct links to key changes:

- https://deploy-preview-830--keen-clarke-470db9.netlify.app/reference-architecture/
- https://deploy-preview-830--keen-clarke-470db9.netlify.app/pricing/