### PR TITLE
contact: Migrate to HubSpot forms as a temporary fix from broken FormBucket

### DIFF
--- a/pages/contact/_form.html
+++ b/pages/contact/_form.html
@@ -1,58 +1,8 @@
-<div id="error-message"></div>
-<form
-  id="contact-form"
-  method="post"
-  target="_blank"
-  action="https://api.formbucket.com/f/buk_7iB8j7vEJPW9ad2ClJwFfm5M"
->
-  <input
-    type="hidden"
-    name="_subject"
-    id="_subject"
-    value="New inquiry from {{ site.url }}"
-  />
-  <input type="hidden" name="_viewing" id="_viewing" value="v1-static" />
-  <input type="hidden" name="_next" id="_next" value="{{ site.url }}/thanks/" />
-  <input type="hidden" name="hello_gruntwork" value=""/>
-  <input type="text" name="_gotcha" style="display:none" />
-  {% include_relative _input-text.html id="contact-name" label="Name"
-  required=true placeholder="Jon Doe" %} {% include_relative _input-text.html
-  id="contact-email" label="Email" required=true placeholder="jon@acme.com"
-  type="email" %}
-  <div class="form-group">
-    <div class="row">
-      <div class="col-xs-12 col-md-4">
-        <label for="contact-message">How can we help?</label>
-      </div>
-      <div class="col-xs-12 col-md-8">
-        <textarea
-          id="contact-message"
-          name="contact-message"
-          class="form-control"
-          rows="3"
-          required="required"
-          placeholder="Enter a message"
-        ></textarea>
-      </div>
-    </div>
-  </div>
-<div class="form-group">
-    <div class="row">
-      <div class="col-xs-12 col-md-4">
-        <label for="contact-message"></label>
-      </div>
-      <div class="col-xs-12 col-md-8">
-        <div class="text-center" style="text-align:right;display: block;">
-    <br>
-    <button type="submit" id="submit-button" class="col-xs-8 btn btn-primary" ga-on="click" ga-event-category="contact" ga-event-action="submit" style="
-">
-      Book a Demo
-    </button>
-  </div>
-      </div>
-    </div>
-  </div>
-</form>
-
-
-
+<script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
+<script>
+  hbspt.forms.create({
+    region: "na1",
+    portalId: "8376079",
+    formId: "72a05b4d-bc84-4a5b-9bbc-dff4467406fa"
+  });
+</script>

--- a/pages/contact/_hero.html
+++ b/pages/contact/_hero.html
@@ -1,8 +1,8 @@
 <div class="container">
   <div class="row">
     <div class="col-xs-12 text-center">
-      <h1>Book a Gruntwork Demo</h1>
-      <p class="lead">Speak with a real human about your DevOps Foundations!</p>
+      <h1>Contact Us</h1>
+      <p class="lead">Speak with a real human about DevOps</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
FormBucket appears to be broken; we can migrate off it for now and use HubSpot and add automation later. Right now, contacts are not being created when using FormBucket. FormBucket's origin SSL cert appears to be busted, as it is not invoking webhooks nor sending emails when a submission is made. 

![Screenshot 2023-11-15 at 1 54 44 PM](https://github.com/gruntwork-io/gruntwork-io.github.io/assets/101607944/347172ed-5782-457c-a067-c1db68482b7e)
![Screenshot 2023-11-15 at 1 55 05 PM](https://github.com/gruntwork-io/gruntwork-io.github.io/assets/101607944/b6992e0c-bdb9-49f8-a59a-425f7da95b47)
![Screenshot 2023-11-15 at 1 55 20 PM](https://github.com/gruntwork-io/gruntwork-io.github.io/assets/101607944/7a3698f8-9a1f-417d-803b-b4da796824c1)
