### PR TITLE
faq: clarify messaging

### DIFF
--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -104,8 +104,8 @@
           updates for our work over the long term.
         </p>
         <p>
-        To further enhance our products, we offer <a href="/consulting"> limited consulting services </a>. We directly collaborate with your team to create exceptional infrastructure, 
-        and we then provide continuous support and maintenance for that infrastructure. In fact, Gruntwork is a 100% bootstrapped company 
+        To further enhance our products, we offer <a href="/consulting"> limited consulting services </a>. We directly collaborate with your team to create exceptional infrastructure,
+        and we then provide continuous support and maintenance for that infrastructure. In fact, Gruntwork is a 100% bootstrapped company
         where we developed the majority of our products through consulting engagements.
         </p>
 
@@ -206,9 +206,8 @@
         <p>
           There are three ways you can try out Gruntwork Services with no commitment:
           <ol>
-            <li>You can try out parts of the IaC Library for free by checking out our <a href="/infrastructure-as-code-library?search=open" title="Free Open Source modules by Gruntwork">open source modules</a>.</li>
-            <li>Before any contracts are signed, we'd be happy to do a walkthrough of our code, training, and process.</li>
             <li>We offer a 30-day money-back guarantee, so if for any reason you're not happy after signing up, we'll refund 100% of your money in the first 30 days. Check out "<a href="/faq/#what-if-i-want-to-cancel-my-gruntwork-subscription" title="What if I want to cancel my Gruntwork Subscription?">What if I want to cancel my Gruntwork Subscription?</a>" for more info.</li>
+            <li>Before any contracts are signed, we'd be happy to do a walkthrough of our code, training, and process.</li>
           </ol>
         </p>
 
@@ -233,12 +232,6 @@
       answer: |
         <p>
           For monthly billing, we require automated payments via credit card or ACH transfer. If you wish to use invoices and pay by wire transfer or check instead, you must do annual billing. We also accept AWS Marketplace for annual contracts.
-        </p>
-
-    - question: Can I pay with AWS credits?
-      answer: |
-        <p>
-          Yes, please reach out to sales@gruntwork.io.
         </p>
 
     - question: What's a user?
@@ -278,6 +271,6 @@
     - question: If I require product customization or consulting support, what options are provided?
       answer: |
         <p>
-          The best way to personalize and customize products is through our <a href="/consulting">limited consulting services</a>. We are ready to collaborate closely with you to tailor our solutions according to your specific objectives. Please reach out to our team for a detailed discussion of your requirements and to explore the available options for the consulting support.        
+          The best way to personalize and customize products is through our <a href="/consulting">limited consulting services</a>. We are ready to collaborate closely with you to tailor our solutions according to your specific objectives. Please reach out to our team for a detailed discussion of your requirements and to explore the available options for the consulting support.
         </p>
-        
+


### PR DESCRIPTION
Remove old or ambiguous language on our pricing FAQs. 