### PR TITLE
Remove manual 'last updated' date from the terms.

### DIFF
--- a/pages/cookie-policy/index.html
+++ b/pages/cookie-policy/index.html
@@ -13,7 +13,7 @@ slug: cookie-policy
       <div class="row">
         <div class="col-xs-12">
           <h1>{{ page.title }}</h1>
-          <p><em>Last Updated: {{ page.modified_date }}</em></p>
+          <p><a href="/legal/feed">View CHANGELOG</a></p>
         </div>
       </div>
       <div class="row">

--- a/pages/legal/website-terms/index.html
+++ b/pages/legal/website-terms/index.html
@@ -13,6 +13,7 @@ slug: website-terms
             <div class="row">
             <div class="col-xs-12">
                 <h1>{{ page.title }}</h1>
+                <p><a href="/legal/feed">View CHANGELOG</a></p>
             </div>
             </div>
             <div class="row">

--- a/pages/legal/website-terms/index.html
+++ b/pages/legal/website-terms/index.html
@@ -13,7 +13,6 @@ slug: website-terms
             <div class="row">
             <div class="col-xs-12">
                 <h1>{{ page.title }}</h1>
-                <p><em>Last Updated: {{ page.modified_date }}</em></p>
             </div>
             </div>
             <div class="row">

--- a/pages/privacy-policy/index.html
+++ b/pages/privacy-policy/index.html
@@ -13,7 +13,7 @@ slug: privacy-policy
       <div class="row">
         <div class="col-xs-12">
           <h1>{{ page.title }}</h1>
-          <p><em>Last Updated: {{ page.modified_date }}</em></p>
+          <p><a href="/legal/feed">View CHANGELOG</a></p>
         </div>
       </div>
       <div class="row">

--- a/pages/subprocessors/index.html
+++ b/pages/subprocessors/index.html
@@ -13,7 +13,7 @@ slug: subprocessors
       <div class="row">
         <div class="col-xs-12">
           <h1>{{ page.title }}</h1>
-          <p><em>Last Updated: {{ page.modified_date }}</em></p>
+          <p><a href="/legal/feed">View CHANGELOG</a></p>
         </div>
       </div>
       <div class="row">

--- a/pages/terms/index.html
+++ b/pages/terms/index.html
@@ -30,7 +30,6 @@ slug: terms
             right under "Legalese" and will apply if we ever need to work
             through any issues.
           </p>
-          <p><em>Last Modified: {{ page.modified_date }}</em></p>
           <p><a href="/legal/feed">View CHANGELOG</a></p>
           <h2 class="h3 hidden-print">Need to modify these terms?</h2>
           <p class="hidden-print">


### PR DESCRIPTION
Update all legal terms to refer to the CHANGELOG instead of reporting a static "last updated" date.

@iangrunt Could you review and approve this when you get a chance?